### PR TITLE
Move hardcoded urls into env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,44 @@
+# ORISO-Admin environment configuration
+#
+# Local development:
+#   1. Copy this file to `.env`
+#   2. Use the DEV values below
+#   3. Run `npm install --legacy-peer-deps` and `npm run start`
+#
+# Production / Kubernetes:
+#   - Option A (build-time): set VITE_* vars before `npm run build`
+#   - Option B (runtime, recommended): inject pod env vars; container entrypoint
+#     generates `/admin/env.js` from VITE_* / REACT_APP_* at startup
+#
+# Host values may be written with or without protocol (https:// is added when USE_HTTPS=true).
+# Auth/login token uses the API host: {VITE_API_URL}/auth/realms/{VITE_KEYCLOAK_REALM}/...
+
+# --- Shared ---
 VITE_PORT=9000
 BROWSER=none
-VITE_CSRF_WHITELIST_HEADER_FOR_LOCAL_DEVELOPMENT=X-CSRF-Token
-VITE_API_URL=api.oriso.site
 VITE_USE_API_URL=true
 VITE_USE_HTTPS=true
-VITE_COOKIE_DOMAIN=.oriso.site
+VITE_KEYCLOAK_REALM=online-beratung
+VITE_KEYCLOAK_CLIENT_ID=app
+VITE_CSRF_WHITELIST_HEADER_FOR_LOCAL_DEVELOPMENT=X-CSRF-Token
+
+# --- DEV (oriso-dev.site) ---
+VITE_API_URL=api.oriso-dev.site
+VITE_APP_URL=app.oriso-dev.site
+VITE_MATRIX_URL=matrix.oriso-dev.site
+VITE_COOKIE_DOMAIN=.oriso-dev.site
 VITE_COOKIE_SECURE=true
+
+# --- PROD example (oriso.site) ---
+# VITE_API_URL=api.oriso.site
+# VITE_APP_URL=app.oriso.site
+# VITE_MATRIX_URL=matrix.oriso.site
+# VITE_COOKIE_DOMAIN=.oriso.site
+# VITE_COOKIE_SECURE=true
+
+# --- Optional ---
+# VITE_COOKIES_ALLOWEDLIST=
+# VITE_APPOINTMENT_SERVICE_URL=https://calcom-develop.suchtberatung.digital
+
+# DevOps / legacy CRA-style names are also supported at runtime via env.js:
+# REACT_APP_API_URL, REACT_APP_MATRIX_URL, REACT_APP_APP_URL

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,6 @@ ARG DOCKER_MATRIX=ghcr.io
 FROM $DOCKER_MATRIX/onlineberatung/onlineberatung-nginx/onlineberatung-nginx:dockerimage.v.005-main
 COPY build /usr/share/nginx/html/admin
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY scripts/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
         <meta name="theme-color" content="#ffffff" />
 
         <title>Online-Beratung Admin</title>
+        <script src="env.js"></script>
         <script>
             const global = globalThis;
         </script>

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         <meta name="theme-color" content="#ffffff" />
 
         <title>Online-Beratung Admin</title>
-        <script src="env.js"></script>
+        <script src="%BASE_URL%env.js"></script>
         <script>
             const global = globalThis;
         </script>

--- a/public/env.js
+++ b/public/env.js
@@ -1,0 +1,3 @@
+// Runtime config injected at container start (see scripts/generate-runtime-env.js).
+// Local development falls back to VITE_* values from .env when this file is empty.
+window.__APP_CONFIG__ = window.__APP_CONFIG__ || {};

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -eu
+
+TARGET="${RUNTIME_ENV_FILE:-/usr/share/nginx/html/admin/env.js}"
+
+pick() {
+    for key in "$@"; do
+        value=$(eval "printf '%s' \"\${$key:-}\"")
+        if [ -n "$value" ]; then
+            printf '%s' "$value"
+            return 0
+        fi
+    done
+    return 1
+}
+
+API_URL=$(pick VITE_API_URL REACT_APP_API_URL || true)
+APP_URL=$(pick VITE_APP_URL REACT_APP_APP_URL || true)
+MATRIX_URL=$(pick VITE_MATRIX_URL REACT_APP_MATRIX_URL || true)
+KEYCLOAK_REALM=$(pick VITE_KEYCLOAK_REALM REACT_APP_KEYCLOAK_REALM || true)
+KEYCLOAK_CLIENT_ID=$(pick VITE_KEYCLOAK_CLIENT_ID REACT_APP_KEYCLOAK_CLIENT_ID || true)
+USE_API_URL=$(pick VITE_USE_API_URL REACT_APP_USE_API_URL || true)
+USE_HTTPS=$(pick VITE_USE_HTTPS REACT_APP_USE_HTTPS || true)
+COOKIE_DOMAIN=$(pick VITE_COOKIE_DOMAIN REACT_APP_COOKIE_DOMAIN || true)
+COOKIE_SECURE=$(pick VITE_COOKIE_SECURE REACT_APP_COOKIE_SECURE || true)
+CSRF_WHITELIST_HEADER=$(pick VITE_CSRF_WHITELIST_HEADER VITE_CSRF_WHITELIST_HEADER_FOR_LOCAL_DEVELOPMENT REACT_APP_CSRF_WHITELIST_HEADER || true)
+COOKIES_ALLOWEDLIST=$(pick VITE_COOKIES_ALLOWEDLIST REACT_APP_COOKIES_ALLOWEDLIST || true)
+APPOINTMENT_SERVICE_URL=$(pick VITE_APPOINTMENT_SERVICE_URL REACT_APP_APPOINTMENT_SERVICE_URL || true)
+
+mkdir -p "$(dirname "$TARGET")"
+
+{
+    printf '%s\n' 'window.__APP_CONFIG__ = {'
+    [ -n "$API_URL" ] && printf '  "API_URL": "%s",\n' "$API_URL"
+    [ -n "$APP_URL" ] && printf '  "APP_URL": "%s",\n' "$APP_URL"
+    [ -n "$MATRIX_URL" ] && printf '  "MATRIX_URL": "%s",\n' "$MATRIX_URL"
+    [ -n "$KEYCLOAK_REALM" ] && printf '  "KEYCLOAK_REALM": "%s",\n' "$KEYCLOAK_REALM"
+    [ -n "$KEYCLOAK_CLIENT_ID" ] && printf '  "KEYCLOAK_CLIENT_ID": "%s",\n' "$KEYCLOAK_CLIENT_ID"
+    [ -n "$USE_API_URL" ] && printf '  "USE_API_URL": "%s",\n' "$USE_API_URL"
+    [ -n "$USE_HTTPS" ] && printf '  "USE_HTTPS": "%s",\n' "$USE_HTTPS"
+    [ -n "$COOKIE_DOMAIN" ] && printf '  "COOKIE_DOMAIN": "%s",\n' "$COOKIE_DOMAIN"
+    [ -n "$COOKIE_SECURE" ] && printf '  "COOKIE_SECURE": "%s",\n' "$COOKIE_SECURE"
+    [ -n "$CSRF_WHITELIST_HEADER" ] && printf '  "CSRF_WHITELIST_HEADER": "%s",\n' "$CSRF_WHITELIST_HEADER"
+    [ -n "$COOKIES_ALLOWEDLIST" ] && printf '  "COOKIES_ALLOWEDLIST": "%s",\n' "$COOKIES_ALLOWEDLIST"
+    [ -n "$APPOINTMENT_SERVICE_URL" ] && printf '  "APPOINTMENT_SERVICE_URL": "%s",\n' "$APPOINTMENT_SERVICE_URL"
+    printf '%s\n' '};'
+} > "$TARGET"
+
+exec nginx -g 'daemon off;'

--- a/scripts/generate-runtime-env.js
+++ b/scripts/generate-runtime-env.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/**
+ * Generates public/env.js from environment variables at container/runtime.
+ * Supports both VITE_* and REACT_APP_* names used by DevOps.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const pick = (...keys) => {
+    for (const key of keys) {
+        const value = process.env[key];
+        if (value !== undefined && value !== '') {
+            return value;
+        }
+    }
+    return undefined;
+};
+
+const config = {
+    API_URL: pick('VITE_API_URL', 'REACT_APP_API_URL'),
+    APP_URL: pick('VITE_APP_URL', 'REACT_APP_APP_URL'),
+    MATRIX_URL: pick('VITE_MATRIX_URL', 'REACT_APP_MATRIX_URL'),
+    KEYCLOAK_REALM: pick('VITE_KEYCLOAK_REALM', 'REACT_APP_KEYCLOAK_REALM'),
+    KEYCLOAK_CLIENT_ID: pick('VITE_KEYCLOAK_CLIENT_ID', 'REACT_APP_KEYCLOAK_CLIENT_ID'),
+    USE_API_URL: pick('VITE_USE_API_URL', 'REACT_APP_USE_API_URL'),
+    USE_HTTPS: pick('VITE_USE_HTTPS', 'REACT_APP_USE_HTTPS'),
+    COOKIE_DOMAIN: pick('VITE_COOKIE_DOMAIN', 'REACT_APP_COOKIE_DOMAIN'),
+    COOKIE_SECURE: pick('VITE_COOKIE_SECURE', 'REACT_APP_COOKIE_SECURE'),
+    CSRF_WHITELIST_HEADER: pick(
+        'VITE_CSRF_WHITELIST_HEADER',
+        'VITE_CSRF_WHITELIST_HEADER_FOR_LOCAL_DEVELOPMENT',
+        'REACT_APP_CSRF_WHITELIST_HEADER',
+    ),
+    COOKIES_ALLOWEDLIST: pick('VITE_COOKIES_ALLOWEDLIST', 'REACT_APP_COOKIES_ALLOWEDLIST'),
+    APPOINTMENT_SERVICE_URL: pick('VITE_APPOINTMENT_SERVICE_URL', 'REACT_APP_APPOINTMENT_SERVICE_URL'),
+};
+
+Object.keys(config).forEach((key) => {
+    if (config[key] === undefined) {
+        delete config[key];
+    }
+});
+
+const outputPath = process.argv[2] || path.join(__dirname, '..', 'public', 'env.js');
+const contents = `window.__APP_CONFIG__ = ${JSON.stringify(config, null, 4)};\n`;
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, contents, 'utf8');
+
+console.log(`Generated runtime config: ${outputPath}`);

--- a/src/api/auth/accessSessionCookie.ts
+++ b/src/api/auth/accessSessionCookie.ts
@@ -1,3 +1,5 @@
+import { runtimeConfig } from '../../config/runtimeConfig';
+
 export const setValueInCookie = (name: string, value: string) => {
     // console.log('🔍 setValueInCookie: name:', name);
     // console.log('🔍 setValueInCookie: value length:', value.length);
@@ -42,7 +44,7 @@ export const removeAllCookies = () => {
     // console.log('🔍 removeAllCookies: Current cookies:', document.cookie);
     document.cookie.split(';').forEach((c) => {
         const name = c.trim().split('=')[0];
-        if ((import.meta.env.VITE_COOKIES_ALLOWEDLIST ?? '').split(',').includes(name)) {
+        if (runtimeConfig.cookiesAllowedList.includes(name)) {
             // console.log('🔍 removeAllCookies: Preserving cookie:', name);
             return;
         }

--- a/src/appConfig.ts
+++ b/src/appConfig.ts
@@ -1,23 +1,13 @@
+import { keycloakAuthPath, runtimeConfig } from './config/runtimeConfig';
 import getLocationVariables from './utils/getLocationVariables';
 
-const VITE_CSRF_WHITELIST_HEADER_PROPERTY = import.meta.env.VITE_CSRF_WHITELIST_HEADER_FOR_LOCAL_DEVELOPMENT;
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-export const CSRF_WHITELIST_HEADER: string = VITE_CSRF_WHITELIST_HEADER_PROPERTY;
-const { subdomain, origin } = getLocationVariables();
+export const CSRF_WHITELIST_HEADER: string = runtimeConfig.csrfWhitelistHeader;
 
-let url = origin;
+const { subdomain } = getLocationVariables();
 
-const useHttps = import.meta.env.VITE_USE_HTTPS !== 'false';
-const protocol = useHttps ? 'https' : 'http';
-
-if (import.meta.env.VITE_USE_API_URL === 'true') {
-    url = `${protocol}://${import.meta.env.VITE_API_URL}`;
-} else if (origin.includes('localhost')) {
-    url = `${protocol}://${subdomain && `${subdomain}.`}${import.meta.env.VITE_API_URL}`;
-}
-
-export const mainURL = url;
+export const mainURL = runtimeConfig.apiBaseUrl;
+export const appURL = runtimeConfig.appBaseUrl;
+export const matrixURL = runtimeConfig.matrixBaseUrl;
 
 export const clusterFeatureFlags = {
     useApiClusterSettings: true, // Fetch server settings from /service/settings
@@ -47,8 +37,8 @@ export const counselorEndpoint = `${mainURL}/service/useradmin/consultants`;
 export const diocesesEndpoint = `${mainURL}/service/agencyadmin/dioceses`;
 export const agencyAdminEndpoint = `${mainURL}/service/useradmin/agencyadmins`;
 export const eventTypeById = `${mainURL}/eventTypes/{eventTypeId}`;
-export const loginEndpoint = `${mainURL}/auth/realms/online-beratung/protocol/openid-connect/token`;
-export const logoutEndpoint = `${mainURL}/auth/realms/online-beratung/protocol/openid-connect/logout`;
+export const loginEndpoint = keycloakAuthPath('/protocol/openid-connect/token');
+export const logoutEndpoint = keycloakAuthPath('/protocol/openid-connect/logout');
 export const tenantEndpoint = `${mainURL}/service/tenant/`;
 export const tenantAccessEndpoint = `${mainURL}/service/tenant/access`;
 export const tenantAdminEndpoint = `${mainURL}/service/tenantadmin`;
@@ -101,8 +91,8 @@ const routePathNames = {
     tenants: '/admin/tenants',
     tenantAdmins: '/admin/users/tenant-admins',
     inviteLinks: '/admin/invite-links',
-    loginResetPasswordLink: '/auth/realms/online-beratung/login-actions/reset-credentials?client_id=account',
-    appointmentServiceDevServer: 'https://calcom-develop.suchtberatung.digital',
+    loginResetPasswordLink: keycloakAuthPath('/login-actions/reset-credentials?client_id=account'),
+    appointmentServiceDevServer: runtimeConfig.appointmentServiceUrl,
 };
 
 export default routePathNames;

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -1,0 +1,109 @@
+import getLocationVariables from '../utils/getLocationVariables';
+import type { AppRuntimeConfig } from '../types/runtimeConfig';
+
+// Runtime config is injected by public/env.js in production deployments.
+// eslint-disable-next-line no-underscore-dangle
+const runtime = (): AppRuntimeConfig => window.__APP_CONFIG__ ?? {};
+
+const readEnvString = (key: string): string | undefined => {
+    const value = import.meta.env[key as keyof ImportMetaEnv];
+    return typeof value === 'string' && value !== '' ? value : undefined;
+};
+
+const readConfigValue = (...keys: string[]): string | undefined => {
+    const rt = runtime();
+    const resolvedKey = keys.find((key) => {
+        const runtimeValue = rt[key as keyof AppRuntimeConfig];
+        if (runtimeValue !== undefined && runtimeValue !== '') {
+            return true;
+        }
+
+        if (readEnvString(`VITE_${key}`)) {
+            return true;
+        }
+
+        if (readEnvString(`REACT_APP_${key}`)) {
+            return true;
+        }
+
+        return false;
+    });
+
+    if (!resolvedKey) {
+        return undefined;
+    }
+
+    const runtimeValue = rt[resolvedKey as keyof AppRuntimeConfig];
+    if (runtimeValue !== undefined && runtimeValue !== '') {
+        return runtimeValue;
+    }
+
+    return readEnvString(`VITE_${resolvedKey}`) ?? readEnvString(`REACT_APP_${resolvedKey}`);
+};
+
+const readBooleanConfig = (key: keyof AppRuntimeConfig, defaultValue: boolean): boolean => {
+    const value = readConfigValue(key);
+    if (value === undefined) {
+        return defaultValue;
+    }
+    return value !== 'false';
+};
+
+const stripUrlProtocol = (value: string): string => value.replace(/^https?:\/\//, '').replace(/\/$/, '');
+
+const toAbsoluteUrl = (value: string | undefined, useHttps: boolean): string => {
+    if (!value) {
+        return '';
+    }
+
+    if (/^https?:\/\//i.test(value)) {
+        return value.replace(/\/$/, '');
+    }
+
+    const protocol = useHttps ? 'https' : 'http';
+    return `${protocol}://${stripUrlProtocol(value)}`;
+};
+
+const useHttps = readBooleanConfig('USE_HTTPS', true);
+const useApiUrl = readBooleanConfig('USE_API_URL', true);
+const { subdomain, origin } = getLocationVariables();
+
+const apiHost = stripUrlProtocol(readConfigValue('API_URL') ?? '');
+const configuredAppHost = stripUrlProtocol(readConfigValue('APP_URL') ?? '');
+const appHost = configuredAppHost || apiHost.replace(/^api\./i, 'app.');
+const matrixHost = stripUrlProtocol(readConfigValue('MATRIX_URL') ?? '');
+
+let apiBaseUrl = origin;
+
+if (useApiUrl && apiHost) {
+    apiBaseUrl = toAbsoluteUrl(apiHost, useHttps);
+} else if (origin.includes('localhost') && apiHost) {
+    const hostPrefix = subdomain && subdomain !== 'localhost' ? `${subdomain}.` : '';
+    apiBaseUrl = toAbsoluteUrl(`${hostPrefix}${apiHost}`, useHttps);
+}
+
+export const runtimeConfig = {
+    useHttps,
+    useApiUrl,
+    apiBaseUrl,
+    appBaseUrl: toAbsoluteUrl(appHost, useHttps) || apiBaseUrl,
+    matrixBaseUrl: matrixHost ? toAbsoluteUrl(matrixHost, useHttps) : '',
+    keycloakRealm: readConfigValue('KEYCLOAK_REALM') ?? 'online-beratung',
+    keycloakClientId: readConfigValue('KEYCLOAK_CLIENT_ID') ?? 'app',
+    csrfWhitelistHeader:
+        readConfigValue('CSRF_WHITELIST_HEADER') ??
+        readEnvString('VITE_CSRF_WHITELIST_HEADER_FOR_LOCAL_DEVELOPMENT') ??
+        '',
+    cookieDomain: readConfigValue('COOKIE_DOMAIN') ?? '',
+    cookieSecure: readBooleanConfig('COOKIE_SECURE', true),
+    cookiesAllowedList: (readConfigValue('COOKIES_ALLOWEDLIST') ?? '')
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    appointmentServiceUrl:
+        readConfigValue('APPOINTMENT_SERVICE_URL') ?? 'https://calcom-develop.suchtberatung.digital',
+};
+
+// Auth (Keycloak) is served on the API host: {API_URL}/auth/realms/{realm}/...
+export const keycloakAuthPath = (path: string) =>
+    `${runtimeConfig.apiBaseUrl}/auth/realms/${runtimeConfig.keycloakRealm}${path}`;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,7 +2,18 @@ interface ImportMetaEnv {
     readonly VITE_PORT: number;
     readonly VITE_CSRF_WHITELIST_HEADER_FOR_LOCAL_DEVELOPMENT: string;
     readonly VITE_API_URL: string;
-    readonly VITE_USE_API_URL: ?('true' | 'false');
+    readonly VITE_APP_URL: string;
+    readonly VITE_MATRIX_URL: string;
+    readonly VITE_KEYCLOAK_REALM: string;
+    readonly VITE_KEYCLOAK_CLIENT_ID: string;
+    readonly VITE_USE_API_URL: 'true' | 'false';
+    readonly VITE_USE_HTTPS: 'true' | 'false';
+    readonly VITE_COOKIE_DOMAIN: string;
+    readonly VITE_COOKIE_SECURE: 'true' | 'false';
+    readonly VITE_COOKIES_ALLOWEDLIST: string;
+    readonly VITE_APPOINTMENT_SERVICE_URL: string;
+    readonly REACT_APP_API_URL: string;
+    readonly REACT_APP_MATRIX_URL: string;
 }
 
 interface ImportMeta {

--- a/src/pages/InviteLinks/index.tsx
+++ b/src/pages/InviteLinks/index.tsx
@@ -8,7 +8,7 @@ import { getSingleTenantData } from '../../api/tenant/getSingleTenantData';
 import { useAgenciesData } from '../../hooks/useAgencysData';
 import { useUserRoles } from '../../hooks/useUserRoles.hook';
 import { parseUserAuthInfo } from '../../utils/parseUserAuthInfo';
-import { mainURL } from '../../appConfig';
+import { appURL } from '../../appConfig';
 
 interface TenantOption {
     id: number;
@@ -86,12 +86,7 @@ export const InviteLinksPage = () => {
         [t, loadLinks],
     );
 
-    const buildUrl = (link: AgencyInviteLinkDTO) => {
-        // The user-facing app is served from app.oriso-dev.site (single-domain
-        // multi-tenancy). Swap the api subdomain for app.
-        const host = mainURL.replace('api.', 'app.');
-        return `${host}/invite/${link.token}`;
-    };
+    const buildUrl = (link: AgencyInviteLinkDTO) => `${appURL}/invite/${link.token}`;
 
     const copyLink = (link: AgencyInviteLinkDTO) => {
         const url = buildUrl(link);

--- a/src/types/runtimeConfig.d.ts
+++ b/src/types/runtimeConfig.d.ts
@@ -1,0 +1,22 @@
+export interface AppRuntimeConfig {
+    API_URL?: string;
+    APP_URL?: string;
+    MATRIX_URL?: string;
+    KEYCLOAK_REALM?: string;
+    KEYCLOAK_CLIENT_ID?: string;
+    USE_API_URL?: string;
+    USE_HTTPS?: string;
+    COOKIE_DOMAIN?: string;
+    COOKIE_SECURE?: string;
+    CSRF_WHITELIST_HEADER?: string;
+    COOKIES_ALLOWEDLIST?: string;
+    APPOINTMENT_SERVICE_URL?: string;
+}
+
+declare global {
+    interface Window {
+        __APP_CONFIG__?: AppRuntimeConfig;
+    }
+}
+
+export {};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,8 @@ export default ({ mode }) => {
         configureServer(server) {
             const envPath = `${process.cwd()}/public/env.js`;
 
-            server.middlewares.use('/admin/env.js', (_req, res, next) => {
+            const runtimeEnvPath = `${(process.env.BASE || '/admin').replace(/\/$/, '')}/env.js`;
+            server.middlewares.use(runtimeEnvPath, (_req, res, next) => {
                 if (!existsSync(envPath)) {
                     next();
                     return;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 import svgrPlugin from 'vite-plugin-svgr';
 import eslintPlugin from 'vite-plugin-eslint';
+import { existsSync, readFileSync } from 'node:fs';
 
 // https://vitejs.dev/config/
 export default ({ mode }) => {
@@ -10,6 +11,7 @@ export default ({ mode }) => {
 
     return defineConfig({
         base: process.env.BASE || '/admin',
+        envPrefix: ['VITE_', 'REACT_APP_'],
         plugins: [
             react(),
             viteTsconfigPaths(),
@@ -19,7 +21,7 @@ export default ({ mode }) => {
                 failOnWarning: false,
                 emitError: true,
                 failOnError: true,
-                fix: process.env.NODE_ENV === 'development',
+                fix: false,
             }),
         ],
         css: {
@@ -35,6 +37,18 @@ export default ({ mode }) => {
         server: {
             host: '0.0.0.0',
             port: (process.env.VITE_PORT as unknown as number) || 9000,
+        },
+        configureServer(server) {
+            const envPath = `${process.cwd()}/public/env.js`;
+
+            server.middlewares.use('/admin/env.js', (_req, res, next) => {
+                if (!existsSync(envPath)) {
+                    next();
+                    return;
+                }
+                res.setHeader('Content-Type', 'application/javascript');
+                res.end(readFileSync(envPath));
+            });
         },
     });
 };


### PR DESCRIPTION
This PR includes two related commits to make ORISO-Admin deployment-safe and fully environment-driven for host/API resolution.

**Summary**

- Migrates URL/config usage away from hardcoded host assumptions and aligns with env/runtime config patterns.
- Fixes runtime config loading so env.js is reliably loaded on all admin routes (including deep links), preventing fallback to stale build-time values.

**Changes included**

- Environment/runtime configuration updates for host/API settings.
- Runtime config script path updated to be base-aware:
- %BASE_URL%env.js in index.html
- Dev runtime env middleware updated to be base-aware in vite.config.ts:
- from hardcoded /admin/env.js to ${BASE}/env.js

**Why this is needed**
In deployment, if env.js is not loaded correctly (especially on nested routes), runtime values are missing and the app can resolve incorrect URLs. These changes ensure runtime config is consistently applied across environments.

**Outcome**

- More stable deployments across environments.
- No hard dependency on baked build-time host values for runtime behavior.
- Reduced risk of API/host mismatch after deployment.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces hardcoded host/URL values with a centralised `runtimeConfig` module that reads from `window.__APP_CONFIG__` (injected at container start via a new shell entrypoint) with fallbacks to `VITE_*` and `REACT_APP_*` env vars baked in at build time. A `%BASE_URL%env.js` script tag in `index.html` ensures runtime values are available before any module is evaluated.

- **New `src/config/runtimeConfig.ts`** centralises all URL and auth config resolution with a clear priority chain: runtime injection → VITE_* build-time → REACT_APP_* build-time; `keycloakAuthPath` helper replaces hardcoded realm strings in `appConfig.ts`.
- **New `scripts/docker-entrypoint.sh`** generates `env.js` from container env vars and launches nginx; `scripts/generate-runtime-env.js` is a safer Node.js alternative (uses `JSON.stringify`) but is not wired into the Dockerfile.
- **`vite.config.ts`** gains `envPrefix: ['VITE_', 'REACT_APP_']` and an intended dev-server middleware for `env.js`, though the middleware is placed outside a plugin object and is therefore not registered by Vite.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Merging is risky without fixing the shell entrypoint value escaping — a misconfigured URL containing a double-quote would silently produce broken JavaScript that prevents the app from loading any runtime config at all.

The shell entrypoint writes env var values directly into JSON string literals with no escaping. A value containing a double-quote, backslash, or newline breaks the generated env.js syntax. The Node.js script handles this correctly via JSON.stringify but is not used in Docker. The appHost fallback in runtimeConfig also silently resolves to the API URL when APP_URL is absent and the host does not follow the api. naming pattern, causing all invite links to point at the wrong host.

scripts/docker-entrypoint.sh and src/config/runtimeConfig.ts need the most attention before this reaches production.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/docker-entrypoint.sh | New shell entrypoint that generates env.js from container env vars then starts nginx. Values are interpolated into JSON strings using printf without any escaping, so values containing double-quotes or backslashes produce syntactically broken JavaScript. |
| src/config/runtimeConfig.ts | New module that centralises runtime/env config resolution with priority: window.__APP_CONFIG__ > VITE_* > REACT_APP_*. The appHost fallback via regex substitution silently produces the wrong URL when the API host does not start with api. |
| vite.config.ts | Adds envPrefix for REACT_APP_* support and a dev-server middleware for env.js. The configureServer hook is placed at the top level of defineConfig rather than inside a plugin object, so it is never registered by Vite. |
| scripts/generate-runtime-env.js | Node.js alternative to the shell entrypoint; correctly uses JSON.stringify for safe serialization. Not used by the Dockerfile. |
| src/appConfig.ts | Simplified to delegate URL and Keycloak path construction to runtimeConfig and keycloakAuthPath; removes all hardcoded host strings and protocol logic. |
| index.html | Adds script src before other scripts so runtime config is available before any module is evaluated. |
| Dockerfile | Copies and sets the shell entrypoint. The base nginx image may have its own entrypoint initialization; overriding it without delegating could silently skip upstream setup steps. |
| src/pages/InviteLinks/index.tsx | Replaces the local api to app host-swap logic with appURL from runtimeConfig; cleaner but inherits the appBaseUrl fallback risk when APP_URL is not set and API host does not start with api. |
| src/api/auth/accessSessionCookie.ts | Replaces inline env-var split with runtimeConfig.cookiesAllowedList; straightforward correctness improvement. |

</details>

</details>

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openresilienceinitiative%2Foriso-admin%22%20on%20the%20existing%20branch%20%22fixing-hardcoded-urls%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fixing-hardcoded-urls%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fdocker-entrypoint.sh%3A34-46%0A**Missing%20JSON%20escaping%20for%20env%20var%20values**%0A%0AThe%20shell%20%60printf%60%20inserts%20values%20directly%20into%20the%20JavaScript%20string%20literals%20without%20escaping.%20Any%20value%20containing%20a%20double-quote%2C%20backslash%2C%20or%20newline%20will%20produce%20syntactically%20broken%20JavaScript%20in%20%60env.js%60%20and%20silently%20crash%20the%20entire%20runtime%20config%2C%20leaving%20the%20app%20with%20no%20config%20at%20all.%20The%20%60generate-runtime-env.js%60%20counterpart%20avoids%20this%20by%20using%20%60JSON.stringify%60%2C%20but%20the%20Dockerfile%20only%20copies%20and%20runs%20this%20shell%20script.%0A%0A%23%23%23%20Issue%202%20of%203%0Avite.config.ts%3A41-53%0A%60configureServer%60%20is%20a%20Vite%20**plugin%20hook**%2C%20not%20a%20top-level%20%60UserConfig%60%20property.%20Placed%20here%20it%20is%20silently%20ignored%20by%20Vite%20at%20runtime%20%E2%80%94%20the%20middleware%20is%20never%20registered.%20Vite's%20built-in%20static-file%20serving%20for%20%60public%2F%60%20already%20covers%20the%20same%20path%20so%20there%20is%20no%20visible%20breakage%2C%20but%20the%20intent%20to%20serve%20%60env.js%60%20via%20custom%20middleware%20is%20not%20being%20executed.%20Moving%20it%20into%20an%20inline%20plugin%20makes%20the%20code%20match%20its%20intent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20'runtime-env-middleware'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20configureServer%28server%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20const%20envPath%20%3D%20%60%24%7Bprocess.cwd%28%29%7D%2Fpublic%2Fenv.js%60%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20const%20runtimeEnvPath%20%3D%20%60%24%7B%28process.env.BASE%20%7C%7C%20'%2Fadmin'%29.replace%28%2F%5C%2F%24%2F%2C%20''%29%7D%2Fenv.js%60%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20server.middlewares.use%28runtimeEnvPath%2C%20%28_req%2C%20res%2C%20next%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28!existsSync%28envPath%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20next%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20res.setHeader%28'Content-Type'%2C%20'application%2Fjavascript'%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20res.end%28readFileSync%28envPath%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fconfig%2FruntimeConfig.ts%3A73%0AWhen%20%60APP_URL%60%20is%20not%20configured%2C%20%60appHost%60%20is%20derived%20by%20replacing%20only%20the%20leading%20%60api.%60%20prefix.%20If%20the%20API%20host%20uses%20any%20other%20naming%20scheme%20%28e.g.%20%60backend.example.com%60%29%2C%20the%20substitution%20returns%20the%20unchanged%20API%20hostname%2C%20so%20%60appBaseUrl%60%20silently%20resolves%20to%20the%20API%20base%20URL%20instead%20of%20the%20user-facing%20app%20URL.%20Invite%20links%20would%20then%20point%20at%20the%20API%20host%2C%20breaking%20every%20shared%20link%20without%20any%20error.%0A%0A%60%60%60suggestion%0Aconst%20derivedAppHost%20%3D%20%2F%5Eapi%5C.%2Fi.test%28apiHost%29%20%3F%20apiHost.replace%28%2F%5Eapi%5C.%2Fi%2C%20'app.'%29%20%3A%20''%3B%0Aconst%20appHost%20%3D%20configuredAppHost%20%7C%7C%20derivedAppHost%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fdocker-entrypoint.sh%3A34-46%0A**Missing%20JSON%20escaping%20for%20env%20var%20values**%0A%0AThe%20shell%20%60printf%60%20inserts%20values%20directly%20into%20the%20JavaScript%20string%20literals%20without%20escaping.%20Any%20value%20containing%20a%20double-quote%2C%20backslash%2C%20or%20newline%20will%20produce%20syntactically%20broken%20JavaScript%20in%20%60env.js%60%20and%20silently%20crash%20the%20entire%20runtime%20config%2C%20leaving%20the%20app%20with%20no%20config%20at%20all.%20The%20%60generate-runtime-env.js%60%20counterpart%20avoids%20this%20by%20using%20%60JSON.stringify%60%2C%20but%20the%20Dockerfile%20only%20copies%20and%20runs%20this%20shell%20script.%0A%0A%23%23%23%20Issue%202%20of%203%0Avite.config.ts%3A41-53%0A%60configureServer%60%20is%20a%20Vite%20**plugin%20hook**%2C%20not%20a%20top-level%20%60UserConfig%60%20property.%20Placed%20here%20it%20is%20silently%20ignored%20by%20Vite%20at%20runtime%20%E2%80%94%20the%20middleware%20is%20never%20registered.%20Vite's%20built-in%20static-file%20serving%20for%20%60public%2F%60%20already%20covers%20the%20same%20path%20so%20there%20is%20no%20visible%20breakage%2C%20but%20the%20intent%20to%20serve%20%60env.js%60%20via%20custom%20middleware%20is%20not%20being%20executed.%20Moving%20it%20into%20an%20inline%20plugin%20makes%20the%20code%20match%20its%20intent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20'runtime-env-middleware'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20configureServer%28server%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20const%20envPath%20%3D%20%60%24%7Bprocess.cwd%28%29%7D%2Fpublic%2Fenv.js%60%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20const%20runtimeEnvPath%20%3D%20%60%24%7B%28process.env.BASE%20%7C%7C%20'%2Fadmin'%29.replace%28%2F%5C%2F%24%2F%2C%20''%29%7D%2Fenv.js%60%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20server.middlewares.use%28runtimeEnvPath%2C%20%28_req%2C%20res%2C%20next%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28!existsSync%28envPath%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20next%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20res.setHeader%28'Content-Type'%2C%20'application%2Fjavascript'%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20res.end%28readFileSync%28envPath%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fconfig%2FruntimeConfig.ts%3A73%0AWhen%20%60APP_URL%60%20is%20not%20configured%2C%20%60appHost%60%20is%20derived%20by%20replacing%20only%20the%20leading%20%60api.%60%20prefix.%20If%20the%20API%20host%20uses%20any%20other%20naming%20scheme%20%28e.g.%20%60backend.example.com%60%29%2C%20the%20substitution%20returns%20the%20unchanged%20API%20hostname%2C%20so%20%60appBaseUrl%60%20silently%20resolves%20to%20the%20API%20base%20URL%20instead%20of%20the%20user-facing%20app%20URL.%20Invite%20links%20would%20then%20point%20at%20the%20API%20host%2C%20breaking%20every%20shared%20link%20without%20any%20error.%0A%0A%60%60%60suggestion%0Aconst%20derivedAppHost%20%3D%20%2F%5Eapi%5C.%2Fi.test%28apiHost%29%20%3F%20apiHost.replace%28%2F%5Eapi%5C.%2Fi%2C%20'app.'%29%20%3A%20''%3B%0Aconst%20appHost%20%3D%20configuredAppHost%20%7C%7C%20derivedAppHost%3B%0A%60%60%60%0A%0A&repo=openresilienceinitiative%2Foriso-admin&pr=21&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fdocker-entrypoint.sh%3A34-46%0A**Missing%20JSON%20escaping%20for%20env%20var%20values**%0A%0AThe%20shell%20%60printf%60%20inserts%20values%20directly%20into%20the%20JavaScript%20string%20literals%20without%20escaping.%20Any%20value%20containing%20a%20double-quote%2C%20backslash%2C%20or%20newline%20will%20produce%20syntactically%20broken%20JavaScript%20in%20%60env.js%60%20and%20silently%20crash%20the%20entire%20runtime%20config%2C%20leaving%20the%20app%20with%20no%20config%20at%20all.%20The%20%60generate-runtime-env.js%60%20counterpart%20avoids%20this%20by%20using%20%60JSON.stringify%60%2C%20but%20the%20Dockerfile%20only%20copies%20and%20runs%20this%20shell%20script.%0A%0A%23%23%23%20Issue%202%20of%203%0Avite.config.ts%3A41-53%0A%60configureServer%60%20is%20a%20Vite%20**plugin%20hook**%2C%20not%20a%20top-level%20%60UserConfig%60%20property.%20Placed%20here%20it%20is%20silently%20ignored%20by%20Vite%20at%20runtime%20%E2%80%94%20the%20middleware%20is%20never%20registered.%20Vite's%20built-in%20static-file%20serving%20for%20%60public%2F%60%20already%20covers%20the%20same%20path%20so%20there%20is%20no%20visible%20breakage%2C%20but%20the%20intent%20to%20serve%20%60env.js%60%20via%20custom%20middleware%20is%20not%20being%20executed.%20Moving%20it%20into%20an%20inline%20plugin%20makes%20the%20code%20match%20its%20intent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20'runtime-env-middleware'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20configureServer%28server%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20const%20envPath%20%3D%20%60%24%7Bprocess.cwd%28%29%7D%2Fpublic%2Fenv.js%60%3B%0A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20const%20runtimeEnvPath%20%3D%20%60%24%7B%28process.env.BASE%20%7C%7C%20'%2Fadmin'%29.replace%28%2F%5C%2F%24%2F%2C%20''%29%7D%2Fenv.js%60%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20server.middlewares.use%28runtimeEnvPath%2C%20%28_req%2C%20res%2C%20next%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28!existsSync%28envPath%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20next%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20res.setHeader%28'Content-Type'%2C%20'application%2Fjavascript'%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20res.end%28readFileSync%28envPath%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fconfig%2FruntimeConfig.ts%3A73%0AWhen%20%60APP_URL%60%20is%20not%20configured%2C%20%60appHost%60%20is%20derived%20by%20replacing%20only%20the%20leading%20%60api.%60%20prefix.%20If%20the%20API%20host%20uses%20any%20other%20naming%20scheme%20%28e.g.%20%60backend.example.com%60%29%2C%20the%20substitution%20returns%20the%20unchanged%20API%20hostname%2C%20so%20%60appBaseUrl%60%20silently%20resolves%20to%20the%20API%20base%20URL%20instead%20of%20the%20user-facing%20app%20URL.%20Invite%20links%20would%20then%20point%20at%20the%20API%20host%2C%20breaking%20every%20shared%20link%20without%20any%20error.%0A%0A%60%60%60suggestion%0Aconst%20derivedAppHost%20%3D%20%2F%5Eapi%5C.%2Fi.test%28apiHost%29%20%3F%20apiHost.replace%28%2F%5Eapi%5C.%2Fi%2C%20'app.'%29%20%3A%20''%3B%0Aconst%20appHost%20%3D%20configuredAppHost%20%7C%7C%20derivedAppHost%3B%0A%60%60%60%0A%0A&pr=21&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: update script path to use BASE\_URL ..."](https://github.com/openresilienceinitiative/oriso-admin/commit/c71b40b0c126af57fc33eaadd66906a83b12a6d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33210418)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->