### PR TITLE
Feature/wire tenant branding issue 49

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,16 @@ export const App = () => {
         multitenancyWithSingleDomainEnabled: settings.multitenancyWithSingleDomainEnabled,
     });
 
+    // Apply tenant favicon when appearance config is available
+    useEffect(() => {
+        const favicon = publicTenantData?.theming?.favicon;
+        if (!favicon) return;
+        const link = document.querySelector<HTMLLinkElement>("link[rel='icon']");
+        if (link) {
+            link.href = favicon;
+        }
+    }, [publicTenantData?.theming?.favicon]);
+
     useEffect(() => {
         if (location.pathname === routePathNames.root || location.pathname === `${routePathNames.root}/`) {
             if (can(PermissionAction.Create, Resource.Tenant)) {

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -82,7 +82,7 @@ export const Login = () => {
             <div className="loginLanguageSelector">
                 <LanguageSelector variant="login" ariaLabelKey="language.loginSelectAriaLabel" />
             </div>
-            <Stage />
+            <Stage logo={tenantData?.theming?.logo} claim={tenantData?.content?.claim} />
             <Row align="middle" style={{ flex: '1 0 auto' }}>
                 <Col xs={{ span: 10, offset: 1 }} md={{ span: 6, offset: 3 }} xl={{ span: 4, offset: 6 }}>
                     <LoginForm />

--- a/src/pages/Login/Stage.tsx
+++ b/src/pages/Login/Stage.tsx
@@ -2,21 +2,23 @@ import React from 'react';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import Title from 'antd/es/typography/Title';
-import Logo from '../../resources/img/Logo-Connecta.png';
+import DefaultLogo from '../../resources/img/Logo-Connecta.png';
 import Spinner from '../../components/Spinner/Spinner';
 
 export interface StageProps {
     className?: string;
     hasAnimation?: boolean;
     isReady?: boolean;
+    // Tenant branding — falls back to defaults when not configured
+    logo?: string | null;
+    claim?: string | null;
 }
 
 /**
- * login component
- * checks if the users token is still valid
- * @constructor
+ * Login stage panel — shows tenant logo and slogan.
+ * Uses tenant appearance config when available, falls back to defaults.
  */
-const Stage = ({ className, hasAnimation, isReady = true }: StageProps) => {
+const Stage = ({ className, hasAnimation, isReady = true, logo, claim }: StageProps) => {
     const { t } = useTranslation();
     return (
         <div
@@ -26,10 +28,10 @@ const Stage = ({ className, hasAnimation, isReady = true }: StageProps) => {
             })}
         >
             <div className="logo">
-                <img src={Logo} alt="Logo Connecta" />
+                <img src={logo || DefaultLogo} alt="Logo" />
             </div>
             <div className="stage__headline">
-                <Title level={1}>{t('slogan')}</Title>
+                <Title level={1}>{claim || t('slogan')}</Title>
                 <Title level={3}>{t('subSlogan')}</Title>
             </div>
             <Spinner className={clsx('stage__spinner', !hasAnimation && 'hidden')} />


### PR DESCRIPTION
## What
- `Stage.tsx` — uses `tenantData.theming.logo` instead of hardcoded PNG; falls back to default logo when not configured
- `Stage.tsx` — uses `tenantData.content.claim` as headline instead of hardcoded i18n key; falls back to `t('slogan')`  
- `App.tsx` — `useEffect` updates `<link rel="icon">` from `publicTenantData.theming.favicon` when available
## Why
Closes #49 — logo, slogan and favicon uploaded via Appearance settings were never wired to the login page or browser tab. The tenant data was already being fetched (`usePublicTenantData`) but the return value wasn't used for rendering.
## Notes
- Color injection (`primaryColor`) not included — LESS variables compile at build time and can't be overridden via CSS vars without a larger refactor
- All fields have safe fallbacks — login page shows defaults when tenant hasn't configured branding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit Keycloak URL runtime/config option
  * Topic selection when editing consultants
  * Tenant-specific login branding (logo & claim)

* **Improvements**
  * Rich-text editor: more formatting, placeholders, link handling
  * Redesigned users & tenant-admin management UI with unified table
  * Settings navigation rebuilt to show dynamic, permission-aware tabs
  * Expanded English/German translations and localization

* **Bug Fixes**
  * Cleanup for stuck modal overlays and improved modal close handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->