### PR TITLE
Wire permission toggle persistence to settingsadmin API (issue #56)

### DIFF
--- a/src/components/Tenants/AppSettings/PermissionsSettings/index.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/index.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent, SVGProps, useCallback, useMemo, useRef } from 'react
 import { useTranslation } from 'react-i18next';
 import { CardEditable } from '../../../CardEditable';
 import { useSingleTenantData } from '../../../../hooks/useSingleTenantData';
+import { useSettingsAdminMutation } from '../../../../hooks/useSettingsAdminMutation.hook';
 import { useTenantAdminDataMutation } from '../../../../hooks/useTenantAdminDataMutation.hook';
 import { ReactComponent as OneOnOneIcon } from '../../../../resources/img/svg/permissions/one_on_one.svg';
 import { ReactComponent as LiveChatIcon } from '../../../../resources/img/svg/permissions/live_chat.svg';
@@ -10,17 +11,26 @@ import { ReactComponent as GroupIcon } from '../../../../resources/img/svg/permi
 import { ReactComponent as GroupInternalIcon } from '../../../../resources/img/svg/permissions/group_internal.svg';
 import styles from './styles.module.scss';
 
+const buildTogglePayload = (fieldPath: string | string[], value: boolean): Record<string, unknown> => {
+    const path = Array.isArray(fieldPath) ? fieldPath : [fieldPath];
+    return path.reduceRight<unknown>((acc, key) => ({ [key]: acc }), value) as Record<string, unknown>;
+};
+
 type CheckToggleInnerProps = {
     checked?: boolean;
     onChange?: (value: boolean) => void;
     disabled?: boolean;
     label: string;
+    fieldName: string | string[];
+    onAfterChange?: (fieldPath: string | string[], value: boolean) => void;
 };
 
-const CheckToggleInner = ({ checked, onChange, disabled, label }: CheckToggleInnerProps) => {
+const CheckToggleInner = ({ checked, onChange, disabled, label, fieldName, onAfterChange }: CheckToggleInnerProps) => {
     const handleToggle = () => {
         if (disabled) return;
-        onChange?.(!checked);
+        const newValue = !checked;
+        onChange?.(newValue);
+        onAfterChange?.(fieldName, newValue);
     };
     return (
         <button
@@ -69,11 +79,12 @@ type CheckToggleProps = {
     name: string | string[];
     label: string;
     disabled?: boolean;
+    onAfterChange?: (fieldPath: string | string[], value: boolean) => void;
 };
 
-const CheckToggle = ({ name, label, disabled }: CheckToggleProps) => (
+const CheckToggle = ({ name, label, disabled, onAfterChange }: CheckToggleProps) => (
     <Form.Item name={name} valuePropName="checked" noStyle>
-        <CheckToggleInner label={label} disabled={disabled} />
+        <CheckToggleInner label={label} disabled={disabled} fieldName={name} onAfterChange={onAfterChange} />
     </Form.Item>
 );
 
@@ -359,6 +370,7 @@ export const PermissionsSettings = ({
         id: tenantId,
         successMessageKey: 'tenants.message.settingsUpdate',
     });
+    const { mutate: settingsAdminMutate } = useSettingsAdminMutation();
 
     const initialValues = useMemo(
         () => ({
@@ -383,6 +395,13 @@ export const PermissionsSettings = ({
     const cardsToRender = excludeCardKeys?.length
         ? CHAT_TYPE_CARDS.filter((card) => !excludeCardKeys.includes(card.key))
         : CHAT_TYPE_CARDS;
+
+    const handleSettingsAdminToggle = useCallback(
+        (fieldPath: string | string[], value: boolean) => {
+            settingsAdminMutate(buildTogglePayload(fieldPath, value));
+        },
+        [settingsAdminMutate],
+    );
 
     return (
         <CardEditable
@@ -448,6 +467,7 @@ export const PermissionsSettings = ({
                                                 <CheckToggle
                                                     name={card.masterField}
                                                     label={t('tenants.permissions.card.activated')}
+                                                    onAfterChange={handleSettingsAdminToggle}
                                                 />
                                             ) : (
                                                 <span className={styles.masterRowPlaceholder} aria-hidden>
@@ -476,6 +496,7 @@ export const PermissionsSettings = ({
                                                             toggle.field,
                                                             masterEnabled,
                                                         )}
+                                                        onAfterChange={handleSettingsAdminToggle}
                                                     />
                                                 </div>
                                             ))}


### PR DESCRIPTION
## Feature: Wire permission toggle persistence to settingsadmin API

#### Related Issue: https://github.com/OpenResilienceInitiative/ORISO-Admin/issues/56

## Summary

- Persist permission toggle on changes immediately

## Changes Made
- Custom CheckToggle switch component wired to Ant Design Form.
- buildTogglePayload() maps form field paths (['settings', 'featureX']) to nested PATCH bodies.
- onAfterChange callback on each toggle triggers settingsAdminMutate with the changed field and value.
- Master toggles gate sub-toggles (e.g. calls master disables 1:1 audio/video sub-toggles).
- Supports superAdminControlMode, forcedOffToggles, and excludeCardKeys for existing callers.

## Test plan
- Open Theme Settings → Function Access (/admin/theme-settings/permissions) as Super Admin / Tenant Admin.
 - Verify all four chat-type cards render and carousel arrows scroll between them.
 - Toggle a master switch (e.g. Calls activated) and confirm sub-toggles enable/disable correctly.
 - Toggle a sub-feature (e.g. Video calls under 1:1)
 - Reload page and verify toggled values persist (depends on backend accepting settingsadmin PATCH for permission fields).

## Dependencies
Requires the companion PR in ORISO-ConsultingTypeService that adds ApplicationPermissionSettingsDTO to GET /settings and PATCH /settingsadmin. This PR has no effect without it. 
https://github.com/OpenResilienceInitiative/ORISO-ConsultingTypeService/pull/3