### PR TITLE
[codex] Fix runtime env script path

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         <meta name="theme-color" content="#ffffff" />
 
         <title>Online-Beratung Admin</title>
-	<script src="%BASE_URL%/env.js"></script>
+        <script src="/env.js"></script>
         <script>
             const global = globalThis;
         </script>


### PR DESCRIPTION
## What changed
- Changes the runtime env script tag from `%BASE_URL%/env.js` to `/env.js` in `index.html`.

## Why
In local dev with the admin app served under `/admin`, `%BASE_URL%/env.js` resolves to `/admin/admin/env.js`, so `window.__APP_CONFIG__` is not loaded. API calls then fall back to the frontend origin and can return the Vite HTML shell instead of JSON, which makes user tables appear empty.

With `/env.js`, Vite serves the script at `/admin/env.js` locally and the production build still emits `/admin/env.js`.

## Scope
This is intentionally isolated from the statistics PR and the UI polish PR.

## Validation
- `npm run build` passes.
- Existing baseline lint/prettier warnings remain unchanged.
