### PR TITLE
fix: restore runtime env fallback, env.js path, and UTC date parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,8 @@
         <meta name="theme-color" content="#ffffff" />
 
         <title>Online-Beratung Admin</title>
-	<script src="%BASE_URL%/env.js"></script>
+        <!-- Vite prefixes the base path (dev: devHtml transform, build: public asset rewrite) -->
+        <script src="/env.js"></script>
         <script>
             const global = globalThis;
         </script>

--- a/public/env.js
+++ b/public/env.js
@@ -1,11 +1,3 @@
-window.__APP_CONFIG__ = {
-    "API_URL": "localhost:8088",
-    "KEYCLOAK_URL": "https://auth.oriso.org",
-    "KEYCLOAK_REALM": "online-beratung",
-    "KEYCLOAK_CLIENT_ID": "app",
-    "USE_API_URL": "true",
-    "USE_HTTPS": "false",
-    "COOKIE_DOMAIN": "localhost",
-    "COOKIE_SECURE": "false",
-    "CSRF_WHITELIST_HEADER": "X-CSRF-Token"
-};
+// Runtime config injected at container start (see scripts/generate-runtime-env.js).
+// Local development falls back to VITE_* values from .env when this file is empty.
+window.__APP_CONFIG__ = window.__APP_CONFIG__ || {};

--- a/src/pages/users/management/formatLastUpdated.ts
+++ b/src/pages/users/management/formatLastUpdated.ts
@@ -4,7 +4,8 @@ const parseApiDate = (value?: string | null): moment.Moment | null => {
     if (!value || value === 'null' || value === 'undefined') {
         return null;
     }
-    const parsed = moment(value);
+    // API timestamps are UTC LocalDateTime strings without offset (e.g. 2026-06-10T07:54:06)
+    const parsed = moment.utc(value).local();
     return parsed.isValid() ? parsed : null;
 };
 


### PR DESCRIPTION
## Summary

Three bugs that broke the local admin against the dev server:

1. **`public/env.js`**: commit 9fd581b checked in a personal local config (`API_URL: localhost:8088`). This runtime file overrides `.env`, so every other dev machine sent all `/service/*` calls to a port where nothing listens ("No Data" everywhere + endless spinners). Reverted to the neutral fallback; the container entrypoint regenerates this file in production anyway. Consider gitignoring it as a follow-up.
2. **`index.html`**: `%BASE_URL%/env.js` resolved to `/admin/admin/env.js` (404) because the Vite dev server prefixes the base on absolute URLs itself. Runtime config was therefore never loaded, in production too. Now referenced as `/env.js`, which Vite rewrites correctly in both dev and build.
3. **`formatLastUpdated.ts`**: backend services serialize `LocalDateTime` in UTC *without* offset (`String.valueOf`), but `moment(value)` parses that as local time — recently edited records showed "2 hours ago" instead of "a few seconds ago" (CEST). Now parsed with `moment.utc(value).local()`.

## Test plan

- Verified locally against the dev server: tenants list, tenant admin list and search load again at `localhost:9000/admin`
- `curl localhost:9000/admin/env.js` returns 200 and the served HTML references the correct path
- "Last updated" column shows correct relative times

🤖 Generated with [Claude Code](https://claude.com/claude-code)