### PR TITLE
fix: sync tenantAdminControls and use live form state on instant permission-toggle saves

### DIFF
--- a/src/components/Tenants/AppSettings/PermissionsSettings/index.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/index.tsx
@@ -15,6 +15,12 @@ import styles from './styles.module.scss';
 let MASTER_TOGGLE_CHILDREN: Record<string, string[]> = {};
 let syncMasterChildTogglesInForm: (form: FormInstance, fieldPath: string | string[], value: boolean) => void;
 
+type ToggleAfterChangeHandler = (
+    fieldPath: string | string[],
+    value: boolean,
+    currentFormData?: { settings?: Record<string, unknown> },
+) => void;
+
 const buildTogglePayload = (fieldPath: string | string[], value: boolean): Record<string, unknown> => {
     const path = Array.isArray(fieldPath) ? fieldPath : [fieldPath];
     const fieldKey = path[path.length - 1] as string;
@@ -40,7 +46,7 @@ type CheckToggleInnerProps = {
     disabled?: boolean;
     label: string;
     fieldName: string | string[];
-    onAfterChange?: (fieldPath: string | string[], value: boolean) => void;
+    onAfterChange?: ToggleAfterChangeHandler;
 };
 
 const CheckToggleInner = ({ checked, onChange, disabled, label, fieldName, onAfterChange }: CheckToggleInnerProps) => {
@@ -51,7 +57,7 @@ const CheckToggleInner = ({ checked, onChange, disabled, label, fieldName, onAft
         const newValue = !checked;
         onChange?.(newValue);
         syncMasterChildTogglesInForm(form, fieldName, newValue);
-        onAfterChange?.(fieldName, newValue);
+        onAfterChange?.(fieldName, newValue, form.getFieldsValue(true));
     };
     return (
         <button
@@ -100,7 +106,7 @@ type CheckToggleProps = {
     name: string | string[];
     label: string;
     disabled?: boolean;
-    onAfterChange?: (fieldPath: string | string[], value: boolean) => void;
+    onAfterChange?: ToggleAfterChangeHandler;
 };
 
 const CheckToggle = ({ name, label, disabled, onAfterChange }: CheckToggleProps) => (
@@ -533,21 +539,33 @@ export const PermissionsSettings = ({
         [inheritedForcedOffFields],
     );
 
-    const handleToggleUpdate = useCallback(
-        (fieldPath: string | string[], value: boolean) => {
+    const handleToggleUpdate = useCallback<ToggleAfterChangeHandler>(
+        (fieldPath, value, currentFormData) => {
             if (!data) return;
             const toggleUpdate = buildTogglePayload(fieldPath, value) as { settings?: Record<string, boolean> };
+            // Base the payload on the live form state (not the react-query cache) so rapid
+            // consecutive toggles don't overwrite each other, then run it through the same
+            // restriction pipeline as the explicit save: tenantAdminControls must stay in
+            // sync on every persisted change, otherwise tenant admins keep access to
+            // features a super admin already disabled.
+            const formData = {
+                settings: {
+                    ...data.settings,
+                    ...(currentFormData?.settings ?? {}),
+                    ...toggleUpdate.settings,
+                },
+            };
+            const restrictedData = superAdminControlMode
+                ? syncMasterTogglesToTenantAdminControls(formData)
+                : enforceToggleRestrictions(formData, forcedOffToggles);
             updateTenant({
                 name: data.name,
                 subdomain: data.subdomain,
                 licensing: data.licensing,
-                settings: {
-                    ...data.settings,
-                    ...toggleUpdate.settings,
-                },
+                settings: applyForcedOffFields(restrictedData.settings, inheritedForcedOffFields),
             } as TenantAdminData);
         },
-        [data, updateTenant],
+        [data, updateTenant, superAdminControlMode, forcedOffToggles, inheritedForcedOffFields],
     );
 
     return (
@@ -649,7 +667,6 @@ export const PermissionsSettings = ({
                                                             masterEnabled,
                                                         )}
                                                         onAfterChange={handleToggleUpdate}
-
                                                     />
                                                 </div>
                                             ))}


### PR DESCRIPTION
## Summary

Fixes the broken Super-Admin → tenant-admin inheritance on the **Funktionszugriff** (feature access) cards. Closes #106.

The instant per-toggle save path (`handleToggleUpdate`) had two bugs:

1. **`tenantAdminControls.allowedPermissionToggles` was never synced.** `syncMasterTogglesToTenantAdminControls` only ran in the explicit Save-button path. A Super-Admin disabling a feature by clicking a toggle persisted the tenant's feature flag, but the restriction list for the tenant admin was never written — so the tenant admin could simply re-enable the feature on their own settings page.
2. **Payloads were built from the stale react-query cache.** Rapid consecutive toggle clicks overwrote each other's changes (lost intermediate state).

## Changes

- `CheckToggleInner` now passes the live form values (`form.getFieldsValue(true)`) to `onAfterChange`.
- `handleToggleUpdate` builds its payload from the live form state, merges the clicked change on top, and runs the **same restriction pipeline as the Save button**:
  - `syncMasterTogglesToTenantAdminControls` in `superAdminControlMode`
  - `enforceToggleRestrictions` otherwise
  - `applyForcedOffFields` for inherited force-offs on every save

## Verification

- `tsc --noEmit` passes
- `eslint` clean on the changed file
- No component tests exist for this file (repo has no working test runner)

## Out of scope

The structural follow-up — real three-level inheritance (platform → tenant → agency/Beratungsstelle) computed and enforced server-side — is tracked in #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)