### PR TITLE
Scope statistics access by admin role

### DIFF
--- a/src/constants/userRolesToPermissions.ts
+++ b/src/constants/userRolesToPermissions.ts
@@ -27,10 +27,8 @@ export const useUserRolesToPermission = () => {
         !settings.multitenancyWithSingleDomainEnabled || settings.legalContentChangesBySingleTenantAdminsAllowed;
     const isMultiTenancyWithSingleDomain = settings.multitenancyWithSingleDomainEnabled;
     const isTopicsEnabled = data?.settings?.featureTopicsEnabled;
-    const isStatisticsEnabled = Boolean(data?.settings?.featureStatisticsEnabled);
 
     // console.log('🔍 useUserRolesToPermission: isTopicsEnabled:', isTopicsEnabled);
-    // console.log('🔍 useUserRolesToPermission: isStatisticsEnabled:', isStatisticsEnabled);
 
     const permissions: Partial<Record<UserRole, UserPermissions>> = {
         [UserRole.RestrictedAgencyAdmin]: {
@@ -40,14 +38,14 @@ export const useUserRolesToPermission = () => {
         },
         [UserRole.AgencyAdmin]: {
             Agency: { read: true, create: true, update: true, delete: true },
-            Statistic: { read: isStatisticsEnabled },
+            Statistic: { read: true },
         },
         [UserRole.TenantAdmin]: {
             // Tenant-scoped admins can manage tenant settings, but only super-admins may create/delete tenants.
             Tenant: { read: true, update: true, create: isSuperAdmin, delete: isSuperAdmin },
             Language: { update: true },
             LegalText: { read: true, update: true },
-            Statistic: { read: isSuperAdmin || isStatisticsEnabled },
+            Statistic: { read: true },
             TenantAdminUser: {
                 read: true,
                 create: isSuperAdmin,
@@ -67,7 +65,7 @@ export const useUserRolesToPermission = () => {
                 read: isMultiTenancyWithSingleDomain || singleCanEditLegalText,
                 update: singleCanEditLegalText,
             },
-            Statistic: { read: isStatisticsEnabled },
+            Statistic: { read: true },
         },
         [UserRole.UserAdmin]: {
             Consultant: { read: true, create: true, update: true, delete: true },

--- a/src/constants/userRolesToPermissions.ts
+++ b/src/constants/userRolesToPermissions.ts
@@ -27,7 +27,7 @@ export const useUserRolesToPermission = () => {
         !settings.multitenancyWithSingleDomainEnabled || settings.legalContentChangesBySingleTenantAdminsAllowed;
     const isMultiTenancyWithSingleDomain = settings.multitenancyWithSingleDomainEnabled;
     const isTopicsEnabled = data?.settings?.featureTopicsEnabled;
-    const isStatisticsEnabled = data?.settings?.featureStatisticsEnabled;
+    const isStatisticsEnabled = Boolean(data?.settings?.featureStatisticsEnabled);
 
     // console.log('🔍 useUserRolesToPermission: isTopicsEnabled:', isTopicsEnabled);
     // console.log('🔍 useUserRolesToPermission: isStatisticsEnabled:', isStatisticsEnabled);
@@ -40,6 +40,7 @@ export const useUserRolesToPermission = () => {
         },
         [UserRole.AgencyAdmin]: {
             Agency: { read: true, create: true, update: true, delete: true },
+            Statistic: { read: isStatisticsEnabled },
         },
         [UserRole.TenantAdmin]: {
             // Tenant-scoped admins can manage tenant settings, but only super-admins may create/delete tenants.

--- a/src/pages/Statistic.tsx
+++ b/src/pages/Statistic.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { AdminSegmentedTabs } from '../components/AdminSegmentedTabs/AdminSegmentedTabs';
 import { Page } from '../components/Page';
 import SearchInput from '../components/SearchInput/SearchInput';
+import { UserRole } from '../enums/UserRole';
+import { useUserRoles } from '../hooks/useUserRoles.hook';
 import { ReactComponent as ActiveAgenciesIcon } from '../resources/img/svg/statistics-dashboard/active-agencies.svg';
 import { ReactComponent as CalendarIcon } from '../resources/img/svg/statistics-dashboard/calendar.svg';
 import { ReactComponent as ChevronDownIcon } from '../resources/img/svg/statistics-dashboard/chevron-down.svg';
@@ -313,6 +315,25 @@ const getConversationSegmentPercentage = (segment: ConversationSegment, segments
     }
 
     return Math.round((segment.value / total) * 100);
+};
+
+const getAllowedStatisticScopes = (
+    isSuperAdmin: boolean,
+    hasRole: (role: UserRole | UserRole[]) => boolean,
+): ScopeKey[] => {
+    if (isSuperAdmin) {
+        return scopeOrder;
+    }
+
+    if (hasRole([UserRole.TenantAdmin, UserRole.SingleTenantAdmin])) {
+        return ['tenant', 'agency'];
+    }
+
+    if (hasRole([UserRole.AgencyAdmin, UserRole.RestrictedAgencyAdmin])) {
+        return ['agency'];
+    }
+
+    return ['agency'];
 };
 
 const scopeDefinitions: Record<ScopeKey, ScopeDefinition> = {
@@ -3113,7 +3134,11 @@ export const Statistic = () => {
     const translate: DashboardTranslate = (key, options) =>
         translateSource?.(key, options) || String(options?.defaultValue || key);
     const locale = getDashboardLocale(i18nInstance?.resolvedLanguage || i18nInstance?.language);
-    const [activeScope, setActiveScope] = useState<ScopeKey>('platform');
+    const { hasRole, isSuperAdmin } = useUserRoles();
+    const allowedScopeKeys = useMemo(() => getAllowedStatisticScopes(isSuperAdmin, hasRole), [hasRole, isSuperAdmin]);
+    const allowedScopeKey = allowedScopeKeys.join('|');
+    const defaultScope = allowedScopeKeys[0] || 'agency';
+    const [activeScope, setActiveScope] = useState<ScopeKey>(defaultScope);
     const [selectedCardMenuByScope, setSelectedCardMenuByScope] =
         useState<SelectedCardMenuByScope>(readStoredCardMenuSelection);
     const [selectedFilterTargetIdsByScope, setSelectedFilterTargetIdsByScope] =
@@ -3218,7 +3243,7 @@ export const Statistic = () => {
             )
             .slice(0, 6);
     }, [availableFilterTargets, filterSearch, locale, translate, visibleFilterTargetIds]);
-    const scopeTabItems: AdminSegmentedTabItem[] = scopeOrder.map((scopeKey) => {
+    const scopeTabItems: AdminSegmentedTabItem[] = allowedScopeKeys.map((scopeKey) => {
         const scope = scopeDefinitions[scopeKey];
         const ScopeIcon = scope.icon;
 
@@ -3301,6 +3326,12 @@ export const Statistic = () => {
     useEffect(() => {
         storeFilterTargetSelection(selectedFilterTargetIdsByScope);
     }, [selectedFilterTargetIdsByScope]);
+
+    useEffect(() => {
+        if (!allowedScopeKeys.includes(activeScope)) {
+            setActiveScope(defaultScope);
+        }
+    }, [activeScope, allowedScopeKey, defaultScope]);
 
     return (
         <Page>

--- a/src/pages/Statistic.tsx
+++ b/src/pages/Statistic.tsx
@@ -3362,224 +3362,228 @@ export const Statistic = () => {
                         />
                     )}
 
-                    <div className="statisticDashboard__summaryGrid">
-                        {dashboard.topCards.map((card) => (
-                            <StatisticCard
-                                key={card.key}
-                                card={localizeStatisticCard(
-                                    getPersonalizedMetricCard(card, activeScope, metricOverrides),
-                                    translate,
-                                    locale,
-                                )}
-                                locale={locale}
-                                menuValue={selectedCardMenuByScope[activeScope][card.key]}
-                                onMenuChange={updateCardMenuSelection}
-                                translate={translate}
-                            />
-                        ))}
-                    </div>
-
-                    <div className="statisticDashboard__communicationGrid">
-                        {dashboard.communicationCards.map((card) => (
-                            <StatisticCard
-                                key={card.key}
-                                card={localizeStatisticCard(
-                                    getDisplayMetricCard(card, activeScope, metricOverrides),
-                                    translate,
-                                    locale,
-                                )}
-                                locale={locale}
-                                translate={translate}
-                            />
-                        ))}
-                    </div>
-
-                    <div className="statisticDashboard__chartGrid">
-                        <section className="statisticDashboard__chartCard statisticDashboard__caseChartCard">
-                            <div className="statisticDashboard__chartHeader">
-                                <h2>{translateDashboardText(translate, 'Beratungsfälle', locale)}</h2>
-                                <PeriodSelect<CasePeriodKey>
-                                    ariaLabel={translateDashboardKey(
+                    <div key={activeScope} className="statisticDashboard__animatedContent">
+                        <div className="statisticDashboard__summaryGrid">
+                            {dashboard.topCards.map((card) => (
+                                <StatisticCard
+                                    key={card.key}
+                                    card={localizeStatisticCard(
+                                        getPersonalizedMetricCard(card, activeScope, metricOverrides),
                                         translate,
-                                        'statistic.dashboard.chart.casePeriodAria',
-                                        'Zeitraum für Beratungsfälle',
+                                        locale,
                                     )}
-                                    onSelect={(periodKey) =>
-                                        setSelectedCasePeriodByScope((currentPeriods) => ({
-                                            ...currentPeriods,
-                                            [activeScope]: periodKey,
-                                        }))
-                                    }
-                                    options={localizedCasePeriodOptions}
-                                    value={selectedCasePeriod}
+                                    locale={locale}
+                                    menuValue={selectedCardMenuByScope[activeScope][card.key]}
+                                    onMenuChange={updateCardMenuSelection}
+                                    translate={translate}
                                 />
-                            </div>
+                            ))}
+                        </div>
 
-                            <div className="statisticDashboard__barChart">
-                                <div className="statisticDashboard__axisLabels" aria-hidden="true">
-                                    {yAxisLabels.map((label) => (
-                                        <span key={label}>{label}</span>
-                                    ))}
+                        <div className="statisticDashboard__communicationGrid">
+                            {dashboard.communicationCards.map((card) => (
+                                <StatisticCard
+                                    key={card.key}
+                                    card={localizeStatisticCard(
+                                        getDisplayMetricCard(card, activeScope, metricOverrides),
+                                        translate,
+                                        locale,
+                                    )}
+                                    locale={locale}
+                                    translate={translate}
+                                />
+                            ))}
+                        </div>
+
+                        <div className="statisticDashboard__chartGrid">
+                            <section className="statisticDashboard__chartCard statisticDashboard__caseChartCard">
+                                <div className="statisticDashboard__chartHeader">
+                                    <h2>{translateDashboardText(translate, 'Beratungsfälle', locale)}</h2>
+                                    <PeriodSelect<CasePeriodKey>
+                                        ariaLabel={translateDashboardKey(
+                                            translate,
+                                            'statistic.dashboard.chart.casePeriodAria',
+                                            'Zeitraum für Beratungsfälle',
+                                        )}
+                                        onSelect={(periodKey) =>
+                                            setSelectedCasePeriodByScope((currentPeriods) => ({
+                                                ...currentPeriods,
+                                                [activeScope]: periodKey,
+                                            }))
+                                        }
+                                        options={localizedCasePeriodOptions}
+                                        value={selectedCasePeriod}
+                                    />
                                 </div>
-                                <div className="statisticDashboard__barStage">
-                                    {gridLinePositions.map((position) => (
-                                        <span
-                                            key={position}
-                                            className="statisticDashboard__gridLine"
-                                            style={{ top: `${position}%` }}
-                                        />
-                                    ))}
-                                    <div className="statisticDashboard__bars">
-                                        {caseChart.map((bar, index) => {
-                                            const height = Math.round((bar.value / caseAxisMax) * 100);
-                                            const isSelected = bar.day === selectedCaseBar.day;
-                                            const barStyle = {
-                                                '--bar-index': index,
-                                                height: `${height}%`,
-                                            } as CSSProperties;
-                                            const tooltipLift = height <= 35 ? 48 : 18;
-                                            const tooltipStyle = {
-                                                '--statistic-dashboard-tooltip-bottom': `calc(${height}% + ${tooltipLift}px)`,
-                                            } as CSSProperties;
-                                            const barValue = bar.value.toLocaleString(locale);
-                                            const dateLabel = translateDashboardDateLabel(translate, bar.dateLabel);
-                                            const dayLabel = translateDashboardWeekday(translate, bar.day);
+
+                                <div className="statisticDashboard__barChart">
+                                    <div className="statisticDashboard__axisLabels" aria-hidden="true">
+                                        {yAxisLabels.map((label) => (
+                                            <span key={label}>{label}</span>
+                                        ))}
+                                    </div>
+                                    <div className="statisticDashboard__barStage">
+                                        {gridLinePositions.map((position) => (
+                                            <span
+                                                key={position}
+                                                className="statisticDashboard__gridLine"
+                                                style={{ top: `${position}%` }}
+                                            />
+                                        ))}
+                                        <div className="statisticDashboard__bars">
+                                            {caseChart.map((bar, index) => {
+                                                const height = Math.round((bar.value / caseAxisMax) * 100);
+                                                const isSelected = bar.day === selectedCaseBar.day;
+                                                const barStyle = {
+                                                    '--bar-index': index,
+                                                    height: `${height}%`,
+                                                } as CSSProperties;
+                                                const tooltipLift = height <= 35 ? 48 : 18;
+                                                const tooltipStyle = {
+                                                    '--statistic-dashboard-tooltip-bottom': `calc(${height}% + ${tooltipLift}px)`,
+                                                } as CSSProperties;
+                                                const barValue = bar.value.toLocaleString(locale);
+                                                const dateLabel = translateDashboardDateLabel(translate, bar.dateLabel);
+                                                const dayLabel = translateDashboardWeekday(translate, bar.day);
+
+                                                return (
+                                                    <button
+                                                        key={bar.day}
+                                                        type="button"
+                                                        className={`statisticDashboard__barSlot ${
+                                                            isSelected ? 'statisticDashboard__barSlot--selected' : ''
+                                                        }`}
+                                                        aria-label={translateDashboardKey(
+                                                            translate,
+                                                            'statistic.dashboard.chart.caseBarAria',
+                                                            `${bar.value} Beratungsfälle am ${bar.dateLabel}`,
+                                                            { date: dateLabel, value: barValue },
+                                                        )}
+                                                        aria-current={isSelected ? 'true' : undefined}
+                                                        aria-pressed={isSelected}
+                                                        data-day={bar.day}
+                                                        onClick={() => selectCaseDay(bar.day)}
+                                                        onFocus={() => selectCaseDay(bar.day)}
+                                                        onPointerDown={() => selectCaseDay(bar.day)}
+                                                    >
+                                                        {isSelected && (
+                                                            <div
+                                                                className="statisticDashboard__barTooltip"
+                                                                style={tooltipStyle}
+                                                            >
+                                                                <strong>
+                                                                    <span />
+                                                                    {barValue}
+                                                                </strong>
+                                                                <small>{dateLabel}</small>
+                                                            </div>
+                                                        )}
+                                                        <span
+                                                            key={`${chartAnimationKey}-${bar.day}`}
+                                                            className={`statisticDashboard__bar ${
+                                                                isSelected ? 'statisticDashboard__bar--highlight' : ''
+                                                            } ${
+                                                                bar.value === 0 ? 'statisticDashboard__bar--empty' : ''
+                                                            }`}
+                                                            style={barStyle}
+                                                        />
+                                                        <small className="statisticDashboard__barDayLabel">
+                                                            {dayLabel}
+                                                        </small>
+                                                    </button>
+                                                );
+                                            })}
+                                        </div>
+                                    </div>
+                                </div>
+                            </section>
+
+                            <section className="statisticDashboard__chartCard statisticDashboard__donutCard">
+                                <div className="statisticDashboard__chartHeader">
+                                    <h2>{translateDashboardText(translate, 'Gesprächstyp', locale)}</h2>
+                                    <PeriodSelect<ConversationPeriodKey>
+                                        ariaLabel={translateDashboardKey(
+                                            translate,
+                                            'statistic.dashboard.chart.conversationPeriodAria',
+                                            'Zeitraum für Gesprächstyp',
+                                        )}
+                                        onSelect={(periodKey) =>
+                                            setSelectedConversationPeriodByScope((currentPeriods) => ({
+                                                ...currentPeriods,
+                                                [activeScope]: periodKey,
+                                            }))
+                                        }
+                                        options={localizedConversationPeriodOptions}
+                                        value={selectedConversationPeriod}
+                                    />
+                                </div>
+
+                                <div className="statisticDashboard__donutContent">
+                                    <DonutChart
+                                        animationKey={donutAnimationKey}
+                                        data={conversationData}
+                                        locale={locale}
+                                        onSegmentSelect={selectConversationSegment}
+                                        selectedSegmentLabel={selectedConversationSegmentLabel}
+                                        translate={translate}
+                                    />
+
+                                    <div className="statisticDashboard__legend">
+                                        {conversationData.segments.map((segment) => {
+                                            const segmentPercentage = getConversationSegmentPercentage(
+                                                segment,
+                                                conversationData.segments,
+                                            );
+                                            const isSelected = segment.label === selectedConversationSegmentLabel;
+                                            const segmentLabel = translateDashboardText(
+                                                translate,
+                                                segment.displayLabel || segment.label,
+                                                locale,
+                                            );
+                                            const segmentAriaLabel = translateDashboardText(
+                                                translate,
+                                                segment.label,
+                                                locale,
+                                            );
+                                            const segmentValue = formatDashboardNumberText(`${segment.value}`, locale);
 
                                             return (
                                                 <button
-                                                    key={bar.day}
+                                                    key={segment.label}
                                                     type="button"
-                                                    className={`statisticDashboard__barSlot ${
-                                                        isSelected ? 'statisticDashboard__barSlot--selected' : ''
+                                                    className={`statisticDashboard__legendItem ${
+                                                        isSelected ? 'statisticDashboard__legendItem--active' : ''
                                                     }`}
-                                                    aria-label={translateDashboardKey(
-                                                        translate,
-                                                        'statistic.dashboard.chart.caseBarAria',
-                                                        `${bar.value} Beratungsfälle am ${bar.dateLabel}`,
-                                                        { date: dateLabel, value: barValue },
-                                                    )}
-                                                    aria-current={isSelected ? 'true' : undefined}
                                                     aria-pressed={isSelected}
-                                                    data-day={bar.day}
-                                                    onClick={() => selectCaseDay(bar.day)}
-                                                    onFocus={() => selectCaseDay(bar.day)}
-                                                    onPointerDown={() => selectCaseDay(bar.day)}
+                                                    onClick={() => selectConversationSegment(segment.label)}
                                                 >
-                                                    {isSelected && (
-                                                        <div
-                                                            className="statisticDashboard__barTooltip"
-                                                            style={tooltipStyle}
-                                                        >
-                                                            <strong>
-                                                                <span />
-                                                                {barValue}
-                                                            </strong>
-                                                            <small>{dateLabel}</small>
-                                                        </div>
-                                                    )}
                                                     <span
-                                                        key={`${chartAnimationKey}-${bar.day}`}
-                                                        className={`statisticDashboard__bar ${
-                                                            isSelected ? 'statisticDashboard__bar--highlight' : ''
-                                                        } ${bar.value === 0 ? 'statisticDashboard__bar--empty' : ''}`}
-                                                        style={barStyle}
+                                                        className="statisticDashboard__legendDot"
+                                                        style={{ backgroundColor: segment.color }}
                                                     />
-                                                    <small className="statisticDashboard__barDayLabel">
-                                                        {dayLabel}
-                                                    </small>
+                                                    <p aria-label={segmentAriaLabel}>{segmentLabel}</p>
+                                                    <span
+                                                        className="statisticDashboard__legendMeta"
+                                                        aria-label={translateDashboardKey(
+                                                            translate,
+                                                            'statistic.dashboard.chart.segmentMetaAria',
+                                                            `${segment.value} Gespräche, ${segmentPercentage}%`,
+                                                            {
+                                                                percentage: segmentPercentage,
+                                                                value: segmentValue,
+                                                            },
+                                                        )}
+                                                    >
+                                                        <strong>{segmentValue}</strong>
+                                                        <small>{segmentPercentage}%</small>
+                                                    </span>
                                                 </button>
                                             );
                                         })}
                                     </div>
                                 </div>
-                            </div>
-                        </section>
-
-                        <section className="statisticDashboard__chartCard statisticDashboard__donutCard">
-                            <div className="statisticDashboard__chartHeader">
-                                <h2>{translateDashboardText(translate, 'Gesprächstyp', locale)}</h2>
-                                <PeriodSelect<ConversationPeriodKey>
-                                    ariaLabel={translateDashboardKey(
-                                        translate,
-                                        'statistic.dashboard.chart.conversationPeriodAria',
-                                        'Zeitraum für Gesprächstyp',
-                                    )}
-                                    onSelect={(periodKey) =>
-                                        setSelectedConversationPeriodByScope((currentPeriods) => ({
-                                            ...currentPeriods,
-                                            [activeScope]: periodKey,
-                                        }))
-                                    }
-                                    options={localizedConversationPeriodOptions}
-                                    value={selectedConversationPeriod}
-                                />
-                            </div>
-
-                            <div className="statisticDashboard__donutContent">
-                                <DonutChart
-                                    animationKey={donutAnimationKey}
-                                    data={conversationData}
-                                    locale={locale}
-                                    onSegmentSelect={selectConversationSegment}
-                                    selectedSegmentLabel={selectedConversationSegmentLabel}
-                                    translate={translate}
-                                />
-
-                                <div className="statisticDashboard__legend">
-                                    {conversationData.segments.map((segment) => {
-                                        const segmentPercentage = getConversationSegmentPercentage(
-                                            segment,
-                                            conversationData.segments,
-                                        );
-                                        const isSelected = segment.label === selectedConversationSegmentLabel;
-                                        const segmentLabel = translateDashboardText(
-                                            translate,
-                                            segment.displayLabel || segment.label,
-                                            locale,
-                                        );
-                                        const segmentAriaLabel = translateDashboardText(
-                                            translate,
-                                            segment.label,
-                                            locale,
-                                        );
-                                        const segmentValue = formatDashboardNumberText(`${segment.value}`, locale);
-
-                                        return (
-                                            <button
-                                                key={segment.label}
-                                                type="button"
-                                                className={`statisticDashboard__legendItem ${
-                                                    isSelected ? 'statisticDashboard__legendItem--active' : ''
-                                                }`}
-                                                aria-pressed={isSelected}
-                                                onClick={() => selectConversationSegment(segment.label)}
-                                            >
-                                                <span
-                                                    className="statisticDashboard__legendDot"
-                                                    style={{ backgroundColor: segment.color }}
-                                                />
-                                                <p aria-label={segmentAriaLabel}>{segmentLabel}</p>
-                                                <span
-                                                    className="statisticDashboard__legendMeta"
-                                                    aria-label={translateDashboardKey(
-                                                        translate,
-                                                        'statistic.dashboard.chart.segmentMetaAria',
-                                                        `${segment.value} Gespräche, ${segmentPercentage}%`,
-                                                        {
-                                                            percentage: segmentPercentage,
-                                                            value: segmentValue,
-                                                        },
-                                                    )}
-                                                >
-                                                    <strong>{segmentValue}</strong>
-                                                    <small>{segmentPercentage}%</small>
-                                                </span>
-                                            </button>
-                                        );
-                                    })}
-                                </div>
-                            </div>
-                        </section>
+                            </section>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/styles/components/statistic.less
+++ b/src/styles/components/statistic.less
@@ -205,6 +205,23 @@
     max-width: 100%;
 }
 
+.statisticDashboard__animatedContent {
+    animation: statisticScopeIn 180ms ease-out both;
+    transform-origin: top center;
+}
+
+@keyframes statisticScopeIn {
+    from {
+        opacity: 0;
+        transform: translateY(8px) scale(0.985);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
 .statisticDashboard__summaryGrid,
 .statisticDashboard__communicationGrid,
 .statisticDashboard__chartGrid {
@@ -1080,6 +1097,12 @@
 
     .statisticDashboard__communicationGrid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .statisticDashboard__animatedContent {
+        animation: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- expose the statistics menu to tenant admins, single-tenant admins, and agency admins without relying on the tenant feature flag
- restrict visible statistics scopes by role: super admins see platform/tenant/agency, tenant admins see tenant/agency, agency admins see agency only
- keep restricted agency admins blocked from statistics access
- add a short zoom/slide transition when switching statistics scopes

## Verification
- npm run build
- Browser check on /admin/statistic as tenant: sidebar statistics link present, only tenant/agency scopes visible, agency scope hides the filter bar, no Vite overlay

## Notes
- This is split out from the merged UI polish PR so the role-scoping change can be reviewed independently.