### PR TITLE
fix: resolve tsc errors in LogoAndFavicon and LoginForm

### DIFF
--- a/src/pages/Login/LoginForm.tsx
+++ b/src/pages/Login/LoginForm.tsx
@@ -16,7 +16,7 @@ const LoginForm = () => {
     const { data: tenantData } = usePublicTenantData();
     const navigate = useNavigate();
     const { t } = useTranslation();
-    const { mutate: login } = useLoginMutation(tenantData?.id);
+    const { mutate: login } = useLoginMutation(tenantData?.id != null ? `${tenantData.id}` : '');
     const [postLoading, setPostLoading] = useState(false);
     const [otpDisabled, setOtpDisabled] = useState(true);
     const [twoFactorType, setTwoFactorType] = useState(TwoFactorType.None);

--- a/src/types/tenant.d.ts
+++ b/src/types/tenant.d.ts
@@ -101,6 +101,7 @@ export interface TenantData extends BasicTenantData {
     theming: {
         logo: string;
         favicon: string;
+        associationLogo?: string;
         primaryColor: string;
         secondaryColor: string | null;
     };


### PR DESCRIPTION
## Bug Fix: Tenant Funktionszugriff Inherits Platform Feature Flags

#### Related Issue: #106

## Summary
- Fixed tenant-admin Funktionszugriff so toggles respect platform feature flags from public tenant settings. Tenant admins can no longer edit features the platform has disabled (including 1:1 sub-toggles when the card master stays on).

## Changes Made
- Drive visibleToggles from usePublicTenantData() → data.settings on the tenant permissions page
- Align PermissionToggleVisibility with feature-flag field names (featureCallsEnabled, etc.)
- Lock sub-toggles when inherited public settings mark them false (not only card master toggles)
- Harden usePublicTenantData (typed TenantData, slug-based cache key, staleTime, error fallback)
- Fix CI TypeScript errors: optional associationLogo on TenantData.theming, coerce tenant id to string in LoginForm

## Testing
- Verified tenant Funktionszugriff locks sub-toggles when public settings have them false (e.g. 1:1 video/audio calls off while featureCallsEnabled is true).
- Verified master toggles stay editable when the platform leaves them true.
- Verified npx tsc --noEmit passes.