### PR TITLE
fix(users): default list sort to last updated descending

### DIFF
--- a/src/constants/userTableSort.ts
+++ b/src/constants/userTableSort.ts
@@ -3,17 +3,17 @@ export const USER_TABLE_API_SAFE_SORT = 'FIRSTNAME';
 export const USER_TABLE_API_SAFE_ORDER = 'ASC';
 
 /** Tenant admin search only supports these sort fields (see useradminservice.yaml). */
-export const TENANT_ADMIN_ALLOWED_SORT_FIELDS = ['FIRSTNAME', 'LASTNAME', 'EMAIL', 'TENANT_ID'] as const;
+export const TENANT_ADMIN_ALLOWED_SORT_FIELDS = ['FIRSTNAME', 'LASTNAME', 'EMAIL', 'TENANT_ID', 'UPDATE_DATE'] as const;
 
 /** Preferred default once `UPDATE_DATE` is deployed everywhere. */
 export const USER_TABLE_PREFERRED_SORT = 'UPDATE_DATE';
 export const USER_TABLE_PREFERRED_ORDER = 'DESC';
 
-export const USER_TABLE_DEFAULT_SORT = USER_TABLE_API_SAFE_SORT;
-export const USER_TABLE_DEFAULT_ORDER = USER_TABLE_API_SAFE_ORDER;
+export const USER_TABLE_DEFAULT_SORT = USER_TABLE_PREFERRED_SORT;
+export const USER_TABLE_DEFAULT_ORDER = USER_TABLE_PREFERRED_ORDER;
 
 export const normalizeTenantAdminSortField = (field?: string): string => {
-    const normalized = (field || USER_TABLE_API_SAFE_SORT).toUpperCase();
+    const normalized = (field || USER_TABLE_PREFERRED_SORT).toUpperCase();
     if ((TENANT_ADMIN_ALLOWED_SORT_FIELDS as readonly string[]).includes(normalized)) {
         return normalized;
     }

--- a/src/pages/users/management/UserManagementTable.tsx
+++ b/src/pages/users/management/UserManagementTable.tsx
@@ -190,6 +190,8 @@ export const UserManagementTable = ({ figmaTableHeader = false }: UserManagement
         mainTenantSubdomain: settings.mainTenantSubdomainForSingleDomainMultitenancy,
         figmaTableHeader: figmaTableHeader && !isOrganizations,
         fixActionsColumn: !isMobile,
+        sortBy: tableState.sortBy,
+        order: tableState.order,
     }).filter((column) => column.key !== 'status' || config.showStatus);
 
     const setSearchDebounced = useDebouncedCallback((value: string) => {

--- a/src/pages/users/management/useUserTableColumns.tsx
+++ b/src/pages/users/management/useUserTableColumns.tsx
@@ -29,6 +29,17 @@ const SORT_FIELD_BY_COLUMN: Partial<Record<UserTableColumnKey, string>> = {
     tenantOrgName: 'NAME',
 };
 
+const getColumnSortOrder = (
+    columnKey: UserTableColumnKey,
+    sortBy?: string,
+    order?: string,
+): 'ascend' | 'descend' | undefined => {
+    const apiField = SORT_FIELD_BY_COLUMN[columnKey];
+    if (!apiField || !sortBy || apiField !== sortBy) return undefined;
+    return order === 'DESC' ? 'descend' : 'ascend';
+};
+
+
 type TableRow = CounselorData | TenantData;
 
 interface UseUserTableColumnsParams {
@@ -45,6 +56,8 @@ interface UseUserTableColumnsParams {
     mainTenantSubdomain?: string;
     figmaTableHeader?: boolean;
     fixActionsColumn?: boolean;
+    sortBy?: string;
+    order?: string;
 }
 
 export const useUserTableColumns = ({
@@ -61,6 +74,8 @@ export const useUserTableColumns = ({
     mainTenantSubdomain,
     figmaTableHeader = false,
     fixActionsColumn = true,
+    sortBy,
+    order
 }: UseUserTableColumnsParams) => {
     const { t } = useTranslation();
     const config = USER_TABLE_CONFIGS[sectionId];
@@ -113,10 +128,10 @@ export const useUserTableColumns = ({
                 className: 'counselorList__column',
                 ...(sortable && apiSortField
                     ? {
-                          sorter: true,
-                          sortOrder: undefined,
-                          showSorterTooltip: false,
-                      }
+                        sorter: true,
+                        sortOrder: getColumnSortOrder(key, sortBy, order),
+                        showSorterTooltip: false,
+                    }
                     : {}),
             };
 
@@ -300,6 +315,8 @@ export const useUserTableColumns = ({
         t,
         showTenant,
         showSubdomain,
+        sortBy,
+        order
     ]);
 };
 

--- a/src/pages/users/management/userTableConfigs.ts
+++ b/src/pages/users/management/userTableConfigs.ts
@@ -61,7 +61,7 @@ const baseIdentityColumns = (): UserTableColumnConfig[] => [
 ];
 
 const tenantAdminIdentityColumns = (): UserTableColumnConfig[] => [
-    col('lastUpdated', true, false, 210),
+    col('lastUpdated', true, true, 210),
     col('status', true, false, 120),
     col('lastname', true, true, 130),
     col('firstname', true, true, 120),

--- a/src/utils/fetchUserSearchWithSortFallback.ts
+++ b/src/utils/fetchUserSearchWithSortFallback.ts
@@ -1,5 +1,5 @@
 import { fetchData, FETCH_METHODS } from '../api/fetchData';
-import { USER_TABLE_API_SAFE_ORDER, USER_TABLE_API_SAFE_SORT } from '../constants/userTableSort';
+import { USER_TABLE_API_SAFE_ORDER, USER_TABLE_API_SAFE_SORT, USER_TABLE_DEFAULT_ORDER } from '../constants/userTableSort';
 import { CounselorData } from '../types/counselor';
 import { HalResponseList, ResponseList } from '../types/ResponseList';
 import removeEmbedded from './removeEmbedded';
@@ -28,7 +28,7 @@ export const fetchUserSearchWithSortFallback = async ({
 }: FetchUserSearchParams): Promise<ResponseList<CounselorData>> => {
     const resolveField = normalizeSortField ?? ((field?: string) => field || USER_TABLE_API_SAFE_SORT);
     const field = resolveField(sortBy);
-    const sortOrder = order || USER_TABLE_API_SAFE_ORDER;
+    const sortOrder = order || USER_TABLE_DEFAULT_ORDER;
 
     const request = (sortField: string, sortDirection: string) =>
         fetchData({


### PR DESCRIPTION
## Bug Fix: Default user list to last updated, newest first

#### Related Issues: https://github.com/OpenResilienceInitiative/ORISO-Admin/issues/78

## Summary
- User/admin lists now default to Last updated ↓ so new and recently edited records appear at the top without search.

## Changes Made
- Default sort: UPDATE_DATE / DESC
- Allow UPDATE_DATE on tenant-admin search
- Wire sort state to column headers; enable “Last updated” sort on tenant-admin tables

## Tested 
- Consultants, Agency admins, Tenant admins, Platform admins — default UPDATE_DATE / DESC
- New record visible at top without search
- Sort toggle reverses order

## Screenshots
<img width="1896" height="862" alt="image" src="https://github.com/user-attachments/assets/576fde09-3bff-4964-99c9-2d98d1226bec" />
<img width="1895" height="854" alt="image" src="https://github.com/user-attachments/assets/80c48aae-0414-4e3e-9c1e-03e295831423" />
<img width="1902" height="855" alt="image" src="https://github.com/user-attachments/assets/761ef76d-d9e4-4f82-99fb-8717168a8b59" />
<img width="1898" height="851" alt="image" src="https://github.com/user-attachments/assets/0b82692d-def5-42a7-a86f-c40613cafccc" />
