### PR TITLE
[THB-06] Apply inverted admin shell theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,9 +58,13 @@ const AgencyInitialMeetingRedirect = () => {
 };
 
 export const App = () => {
-    const { data: publicTenantData } = usePublicTenantData();
+    const {
+        data: publicTenantData,
+        isLoading: isPublicTenantLoading,
+        isFetched: isPublicTenantFetched,
+    } = usePublicTenantData();
     const { isLoading, data } = useTenantData();
-    useAdminInvertedTheme(publicTenantData?.theming);
+    useAdminInvertedTheme(publicTenantData?.theming, isPublicTenantFetched || !isPublicTenantLoading);
     const { settings } = useAppConfigContext();
     const navigate = useNavigate();
     const location = useLocation();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { usePublicTenantData } from './hooks/usePublicTenantData.hook';
 import { useUserRoles } from './hooks/useUserRoles.hook';
 import { UserRole } from './enums/UserRole';
 import { useAppConfigContext } from './context/useAppConfig';
+import { useAdminInvertedTheme } from './hooks/useAdminInvertedTheme.hook';
 import {
     LazyAgencyList,
     LazyAgencyPageEdit,
@@ -59,6 +60,7 @@ const AgencyInitialMeetingRedirect = () => {
 export const App = () => {
     const { data: publicTenantData } = usePublicTenantData();
     const { isLoading, data } = useTenantData();
+    useAdminInvertedTheme(publicTenantData?.theming);
     const { settings } = useAppConfigContext();
     const navigate = useNavigate();
     const location = useLocation();

--- a/src/app.css
+++ b/src/app.css
@@ -35,11 +35,11 @@
     --input-border-radius: 4px;
     --input-border-color: var(--m3-outline);
     --input-active-border-color: var(--m3-on-surface);
-    --input-disabled-border-color: rgb(68 71 72 / 38%);
+    --input-disabled-border-color: color-mix(in srgb, var(--m3-outline) 38%, transparent);
     --input-bg: transparent;
     --input-disabled-bg: transparent;
-    --input-disabled-color: rgb(27 27 28 / 38%);
-    --input-placeholder-color: rgb(68 71 72 / 64%);
+    --input-disabled-color: color-mix(in srgb, var(--m3-on-surface) 38%, transparent);
+    --input-placeholder-color: color-mix(in srgb, var(--m3-on-surface-variant) 64%, transparent);
     --input-label-bg: var(--m3-surface);
     --label-color: var(--m3-on-surface-variant);
     --form-item-label-font-size: var(--fontSize-s);

--- a/src/app.css
+++ b/src/app.css
@@ -131,7 +131,7 @@
 }
 
 body {
-    background: #f2efea;
+    background: var(--m3-background, #f2efea);
 }
 
 .ant-layout {

--- a/src/components/Layout/styles.module.scss
+++ b/src/components/Layout/styles.module.scss
@@ -1,17 +1,17 @@
 .content {
     height: 100vh;
     overflow: auto;
-    background: #f0edee;
+    background: var(--m3-surface-container, #f0edee);
 
     :global(.ant-layout-content) {
-        background: #f0edee;
+        background: var(--m3-surface-container, #f0edee);
     }
 }
 
 .mainContent {
-    background: #f0edee;
+    background: var(--m3-surface-container, #f0edee);
 
     :global(.ant-layout) {
-        background: #f0edee;
+        background: var(--m3-surface-container, #f0edee);
     }
 }

--- a/src/components/Page/styles.module.scss
+++ b/src/components/Page/styles.module.scss
@@ -186,6 +186,13 @@
     flex: 0 0 auto;
     gap: 16px;
     min-width: 0;
+    color: var(--m3-on-surface, #1b1b1c);
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+        color: var(--m3-on-surface, #1b1b1c);
+    }
 
     > svg {
         box-sizing: border-box;

--- a/src/hooks/useAdminInvertedTheme.hook.ts
+++ b/src/hooks/useAdminInvertedTheme.hook.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { applyAdminInvertedTheme } from '../utils/applyAdminTheme';
+import { applyAdminInvertedTheme, clearAdminInvertedThemeTokens } from '../utils/applyAdminTheme';
 import { ThemingSeedFields } from '../utils/themeSeeds';
 
 export const useAdminInvertedTheme = (theming: ThemingSeedFields | null | undefined, isReady = true) => {
@@ -9,5 +9,9 @@ export const useAdminInvertedTheme = (theming: ThemingSeedFields | null | undefi
         }
 
         applyAdminInvertedTheme(theming);
+
+        return () => {
+            clearAdminInvertedThemeTokens();
+        };
     }, [theming, isReady]);
 };

--- a/src/hooks/useAdminInvertedTheme.hook.ts
+++ b/src/hooks/useAdminInvertedTheme.hook.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+import { applyAdminInvertedTheme } from '../utils/applyAdminTheme';
+import { ThemingSeedFields } from '../utils/themeSeeds';
+
+export const useAdminInvertedTheme = (theming: ThemingSeedFields | null | undefined) => {
+    useEffect(() => {
+        applyAdminInvertedTheme(theming);
+    }, [theming]);
+};

--- a/src/hooks/useAdminInvertedTheme.hook.ts
+++ b/src/hooks/useAdminInvertedTheme.hook.ts
@@ -4,11 +4,9 @@ import { ThemingSeedFields } from '../utils/themeSeeds';
 
 export const useAdminInvertedTheme = (theming: ThemingSeedFields | null | undefined, isReady = true) => {
     useEffect(() => {
-        if (!isReady) {
-            return;
+        if (isReady) {
+            applyAdminInvertedTheme(theming);
         }
-
-        applyAdminInvertedTheme(theming);
 
         return () => {
             clearAdminInvertedThemeTokens();

--- a/src/hooks/useAdminInvertedTheme.hook.ts
+++ b/src/hooks/useAdminInvertedTheme.hook.ts
@@ -2,8 +2,12 @@ import { useEffect } from 'react';
 import { applyAdminInvertedTheme } from '../utils/applyAdminTheme';
 import { ThemingSeedFields } from '../utils/themeSeeds';
 
-export const useAdminInvertedTheme = (theming: ThemingSeedFields | null | undefined) => {
+export const useAdminInvertedTheme = (theming: ThemingSeedFields | null | undefined, isReady = true) => {
     useEffect(() => {
+        if (!isReady) {
+            return;
+        }
+
         applyAdminInvertedTheme(theming);
-    }, [theming]);
+    }, [theming, isReady]);
 };

--- a/src/utils/applyAdminTheme.test.ts
+++ b/src/utils/applyAdminTheme.test.ts
@@ -64,6 +64,21 @@ describe('applyAdminInvertedTheme', () => {
         warn.mockRestore();
     });
 
+    it('clears previously applied admin tokens when a later seed is invalid', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const root = document.createElement('div');
+
+        applyAdminInvertedTheme({ primaryColor: BENCHMARK_SEED }, root);
+        expect(root.style.getPropertyValue('--m3-surface')).not.toBe('');
+
+        const applied = applyAdminInvertedTheme({ primaryColor: 'not-a-hex' }, root);
+
+        expect(applied).toBe(false);
+        expect(root.style.getPropertyValue('--m3-surface')).toBe('');
+        expect(root.style.getPropertyValue('--m3-primary')).toBe('');
+        warn.mockRestore();
+    });
+
     it.each([
         ['--m3-on-surface', '--m3-surface'],
         ['--m3-on-surface', '--m3-surface-container-lowest'],

--- a/src/utils/applyAdminTheme.test.ts
+++ b/src/utils/applyAdminTheme.test.ts
@@ -53,6 +53,16 @@ describe('applyAdminInvertedTheme', () => {
         expect(root.style.getPropertyValue('--m3-surface')).toBe(tokens['--m3-surface']);
     });
 
+    it('ignores an invalid accent seed when the primary seed is valid', () => {
+        const root = document.createElement('div');
+        const applied = applyAdminInvertedTheme({ primaryColor: BENCHMARK_SEED, accent: 'not-a-hex' }, root);
+        const { tokens } = computeOrisoPalette({ accentDark: BENCHMARK_SEED }, 'inverted');
+
+        expect(applied).toBe(true);
+        expect(root.style.getPropertyValue('--m3-primary')).toBe(tokens['--m3-primary']);
+        expect(root.style.getPropertyValue('--m3-primary-container')).toBe(tokens['--m3-primary-container']);
+    });
+
     it('keeps the static palette on an invalid stored seed', () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const root = document.createElement('div');

--- a/src/utils/applyAdminTheme.test.ts
+++ b/src/utils/applyAdminTheme.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest';
-import { DEFAULT_ADMIN_SEED, applyAdminInvertedTheme } from './applyAdminTheme';
+import { DEFAULT_ADMIN_SEED, applyAdminInvertedTheme, clearAdminInvertedThemeTokens } from './applyAdminTheme';
 import { computeOrisoPalette } from './theme/orisoScheme';
 
 const BENCHMARK_SEED = '#a5000a';
@@ -72,6 +72,17 @@ describe('applyAdminInvertedTheme', () => {
         expect(root.style.length).toBe(0);
         expect(warn).toHaveBeenCalled();
         warn.mockRestore();
+    });
+
+    it('clears applied admin tokens from the root element', () => {
+        const root = document.createElement('div');
+        applyAdminInvertedTheme({ primaryColor: BENCHMARK_SEED }, root);
+        expect(root.style.getPropertyValue('--m3-surface')).not.toBe('');
+
+        clearAdminInvertedThemeTokens(root);
+
+        expect(root.style.getPropertyValue('--m3-surface')).toBe('');
+        expect(root.style.getPropertyValue('--m3-primary')).toBe('');
     });
 
     it('clears previously applied admin tokens when a later seed is invalid', () => {

--- a/src/utils/applyAdminTheme.test.ts
+++ b/src/utils/applyAdminTheme.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { DEFAULT_ADMIN_SEED, applyAdminInvertedTheme } from './applyAdminTheme';
+import { computeOrisoPalette } from './theme/orisoScheme';
+
+const BENCHMARK_SEED = '#a5000a';
+
+const wcagRatio = (hexA: string, hexB: string): number => {
+    const channel = (value: number) => {
+        const c = value / 255;
+        return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+    };
+    const luminance = (hex: string) => {
+        const n = parseInt(hex.slice(1), 16);
+        // eslint-disable-next-line no-bitwise
+        return 0.2126 * channel((n >> 16) & 255) + 0.7152 * channel((n >> 8) & 255) + 0.0722 * channel(n & 255);
+    };
+    const a = luminance(hexA);
+    const b = luminance(hexB);
+    return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+};
+
+describe('applyAdminInvertedTheme', () => {
+    it('overrides the --m3-* tokens with the inverted theme output', () => {
+        const root = document.createElement('div');
+        const applied = applyAdminInvertedTheme({ primaryColor: BENCHMARK_SEED }, root);
+        const { tokens } = computeOrisoPalette({ accentDark: BENCHMARK_SEED }, 'inverted');
+
+        expect(applied).toBe(true);
+        Object.entries(tokens)
+            .filter(([name]) => name.startsWith('--m3-'))
+            .forEach(([name, value]) => {
+                expect(root.style.getPropertyValue(name), name).toBe(value);
+            });
+        expect(root.style.getPropertyValue('--m3-surface')).not.toBe('#fcf9f9');
+    });
+
+    it('uses the same stored seeds without writing a separate admin palette', () => {
+        const root = document.createElement('div');
+        applyAdminInvertedTheme({ primaryColor: BENCHMARK_SEED, accent: '#646d78' }, root);
+        const { tokens } = computeOrisoPalette({ accentDark: BENCHMARK_SEED, accentLight: '#646d78' }, 'inverted');
+
+        expect(root.style.getPropertyValue('--m3-primary')).toBe(tokens['--m3-primary']);
+        expect(root.style.getPropertyValue('--m3-primary-container')).toBe(tokens['--m3-primary-container']);
+    });
+
+    it('uses the benchmark admin seed when the tenant has no stored seed', () => {
+        const root = document.createElement('div');
+        const applied = applyAdminInvertedTheme({}, root);
+        const { tokens } = computeOrisoPalette({ accentDark: DEFAULT_ADMIN_SEED }, 'inverted');
+
+        expect(applied).toBe(true);
+        expect(root.style.getPropertyValue('--m3-surface')).toBe(tokens['--m3-surface']);
+    });
+
+    it('keeps the static palette on an invalid stored seed', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const root = document.createElement('div');
+        const applied = applyAdminInvertedTheme({ primaryColor: 'not-a-hex' }, root);
+
+        expect(applied).toBe(false);
+        expect(root.style.length).toBe(0);
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it.each([
+        ['--m3-on-surface', '--m3-surface'],
+        ['--m3-on-surface', '--m3-surface-container-lowest'],
+        ['--m3-on-surface', '--m3-surface-container-low'],
+        ['--m3-on-surface', '--m3-surface-container'],
+        ['--m3-on-surface', '--m3-surface-container-high'],
+        ['--m3-on-surface', '--m3-surface-container-highest'],
+        ['--m3-on-surface-variant', '--m3-surface-variant'],
+        ['--m3-on-primary', '--m3-primary'],
+        ['--m3-on-primary-container', '--m3-primary-container'],
+        ['--m3-on-secondary', '--m3-secondary'],
+        ['--m3-on-secondary-container', '--m3-secondary-container'],
+        ['--m3-on-error', '--m3-error'],
+        ['--m3-on-error-container', '--m3-error-container'],
+    ])('%s on %s meets WCAG-AA body contrast', (onRole, surface) => {
+        const { tokens } = computeOrisoPalette({ accentDark: BENCHMARK_SEED }, 'inverted');
+        const ratio = wcagRatio(tokens[onRole], tokens[surface]);
+
+        expect(
+            ratio,
+            `${onRole} (${tokens[onRole]}) on ${surface} (${tokens[surface]}) = ${ratio.toFixed(2)}:1`,
+        ).toBeGreaterThanOrEqual(4.5);
+    });
+});

--- a/src/utils/applyAdminTheme.ts
+++ b/src/utils/applyAdminTheme.ts
@@ -2,6 +2,7 @@ import { computeOrisoPalette } from './theme/orisoScheme';
 import { readSeeds, ThemingSeedFields } from './themeSeeds';
 
 export const DEFAULT_ADMIN_SEED = '#A5000A';
+const ADMIN_THEME_TOKEN_PREFIX = '--m3-';
 
 const normalizeSeed = (value: string | null | undefined, label: string): string | undefined => {
     if (!value?.trim()) {
@@ -40,7 +41,7 @@ export const applyAdminInvertedTheme = (
         );
 
         Object.entries(tokens)
-            .filter(([name]) => name.startsWith('--m3-'))
+            .filter(([name]) => name.startsWith(ADMIN_THEME_TOKEN_PREFIX))
             .forEach(([name, value]) => {
                 root.style.setProperty(name, value);
             });
@@ -49,6 +50,9 @@ export const applyAdminInvertedTheme = (
     } catch (error) {
         // eslint-disable-next-line no-console
         console.warn('Admin theming: stored seed is invalid, keeping the static palette.', error);
+        Array.from(root.style)
+            .filter((name) => name.startsWith(ADMIN_THEME_TOKEN_PREFIX))
+            .forEach((name) => root.style.removeProperty(name));
         return false;
     }
 };

--- a/src/utils/applyAdminTheme.ts
+++ b/src/utils/applyAdminTheme.ts
@@ -4,7 +4,11 @@ import { readSeeds, ThemingSeedFields } from './themeSeeds';
 export const DEFAULT_ADMIN_SEED = '#A5000A';
 const ADMIN_THEME_TOKEN_PREFIX = '--m3-';
 
-const normalizeSeed = (value: string | null | undefined, label: string): string | undefined => {
+const normalizeSeed = (
+    value: string | null | undefined,
+    label: string,
+    { optional = false }: { optional?: boolean } = {},
+): string | undefined => {
     if (!value?.trim()) {
         return undefined;
     }
@@ -16,6 +20,10 @@ const normalizeSeed = (value: string | null | undefined, label: string): string 
             : withHash;
 
     if (!/^#[0-9a-f]{6}$/i.test(expanded)) {
+        if (optional) {
+            return undefined;
+        }
+
         throw new Error(`Admin theming: ${label} seed is not a valid hex colour.`);
     }
 
@@ -29,7 +37,7 @@ export const applyAdminInvertedTheme = (
     try {
         const seeds = readSeeds(theming);
         const primary = normalizeSeed(seeds.primary ?? seeds.accentDark, 'primary') ?? DEFAULT_ADMIN_SEED;
-        const accent = normalizeSeed(seeds.accent ?? seeds.accentLight, 'accent');
+        const accent = normalizeSeed(seeds.accent ?? seeds.accentLight, 'accent', { optional: true });
         const { tokens } = computeOrisoPalette(
             {
                 accentDark: primary,

--- a/src/utils/applyAdminTheme.ts
+++ b/src/utils/applyAdminTheme.ts
@@ -4,6 +4,12 @@ import { readSeeds, ThemingSeedFields } from './themeSeeds';
 export const DEFAULT_ADMIN_SEED = '#A5000A';
 const ADMIN_THEME_TOKEN_PREFIX = '--m3-';
 
+export const clearAdminInvertedThemeTokens = (root: HTMLElement = document.documentElement): void => {
+    Array.from(root.style)
+        .filter((name) => name.startsWith(ADMIN_THEME_TOKEN_PREFIX))
+        .forEach((name) => root.style.removeProperty(name));
+};
+
 const normalizeSeed = (
     value: string | null | undefined,
     label: string,
@@ -58,9 +64,7 @@ export const applyAdminInvertedTheme = (
     } catch (error) {
         // eslint-disable-next-line no-console
         console.warn('Admin theming: stored seed is invalid, keeping the static palette.', error);
-        Array.from(root.style)
-            .filter((name) => name.startsWith(ADMIN_THEME_TOKEN_PREFIX))
-            .forEach((name) => root.style.removeProperty(name));
+        clearAdminInvertedThemeTokens(root);
         return false;
     }
 };

--- a/src/utils/applyAdminTheme.ts
+++ b/src/utils/applyAdminTheme.ts
@@ -1,0 +1,54 @@
+import { computeOrisoPalette } from './theme/orisoScheme';
+import { readSeeds, ThemingSeedFields } from './themeSeeds';
+
+export const DEFAULT_ADMIN_SEED = '#A5000A';
+
+const normalizeSeed = (value: string | null | undefined, label: string): string | undefined => {
+    if (!value?.trim()) {
+        return undefined;
+    }
+
+    const withHash = value.trim().startsWith('#') ? value.trim() : `#${value.trim()}`;
+    const expanded =
+        withHash.length === 4
+            ? `#${withHash[1]}${withHash[1]}${withHash[2]}${withHash[2]}${withHash[3]}${withHash[3]}`
+            : withHash;
+
+    if (!/^#[0-9a-f]{6}$/i.test(expanded)) {
+        throw new Error(`Admin theming: ${label} seed is not a valid hex colour.`);
+    }
+
+    return expanded.toLowerCase();
+};
+
+export const applyAdminInvertedTheme = (
+    theming: ThemingSeedFields | null | undefined,
+    root: HTMLElement = document.documentElement,
+): boolean => {
+    try {
+        const seeds = readSeeds(theming);
+        const primary = normalizeSeed(seeds.primary ?? seeds.accentDark, 'primary') ?? DEFAULT_ADMIN_SEED;
+        const accent = normalizeSeed(seeds.accent ?? seeds.accentLight, 'accent');
+        const { tokens } = computeOrisoPalette(
+            {
+                accentDark: primary,
+                accentLight: accent,
+                primary,
+                accent,
+            },
+            'inverted',
+        );
+
+        Object.entries(tokens)
+            .filter(([name]) => name.startsWith('--m3-'))
+            .forEach(([name, value]) => {
+                root.style.setProperty(name, value);
+            });
+
+        return true;
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('Admin theming: stored seed is invalid, keeping the static palette.', error);
+        return false;
+    }
+};

--- a/src/utils/theme/orisoScheme.ts
+++ b/src/utils/theme/orisoScheme.ts
@@ -1,5 +1,7 @@
 import { getAccentDark, getAccentLight, TenantSeeds } from '../themeSeeds';
 
+export type OrisoSchemeName = 'light' | 'inverted';
+
 export interface OrisoPaletteResult {
     tokens: Record<string, string>;
     tooPale: boolean;
@@ -59,6 +61,7 @@ const DEFAULT_ACCENT_DIM = '#ffb4aa';
 const DEFAULT_ACCENT_ACTION = '#cc1e1c';
 const SYSTEM_ALERT = '#410001';
 const SYSTEM_ERROR = '#b1005e';
+const DARK_TEXT = '#141c25';
 
 const defaultAccentTokens = (accentDark: string, explicitAccentLight?: string) => {
     if (!explicitAccentLight && accentDark === DEFAULT_ACCENT_DARK) {
@@ -80,7 +83,58 @@ const defaultAccentTokens = (accentDark: string, explicitAccentLight?: string) =
     };
 };
 
-export const computeOrisoPalette = (seeds: TenantSeeds): OrisoPaletteResult => {
+const readableOn = (background: string) => (luminance(background) > 0.62 ? DARK_TEXT : '#ffffff');
+
+const invertedTokens = (accentDark: string, accentLight: string, accentDim: string, onAccentLightVariant: string) => {
+    const primary = accentLight;
+    const primaryContainer = accentDark;
+    const action = mix(accentLight, '#ffffff', 0.1);
+
+    return {
+        '--m3-primary': primary,
+        '--m3-on-primary': readableOn(primary),
+        '--m3-primary-container': primaryContainer,
+        '--m3-on-primary-container': readableOn(primaryContainer),
+        '--m3-primary-fixed': accentLight,
+        '--m3-primary-fixed-dim': accentDim,
+        '--m3-on-primary-fixed-variant': onAccentLightVariant,
+        '--m3-secondary': '#cbd6e2',
+        '--m3-on-secondary': DARK_TEXT,
+        '--m3-secondary-container': '#39414b',
+        '--m3-on-secondary-container': '#e7effc',
+        '--m3-error': '#ffb1c8',
+        '--m3-on-error': '#41001f',
+        '--m3-error-container': '#8a0049',
+        '--m3-on-error-container': '#ffd9e5',
+        '--m3-warning': '#ffb4ab',
+        '--m3-on-warning': SYSTEM_ALERT,
+        '--m3-surface': '#303030',
+        '--m3-on-surface': '#f4eff0',
+        '--m3-surface-container-lowest': '#252324',
+        '--m3-surface-container-low': '#383637',
+        '--m3-surface-container': '#3d3b3c',
+        '--m3-surface-container-high': '#474545',
+        '--m3-surface-container-highest': '#514f50',
+        '--m3-on-surface-variant': '#d0c4c7',
+        '--m3-surface-variant': '#494647',
+        '--m3-outline': '#9a9295',
+        '--m3-outline-variant': '#4d484a',
+        '--m3-background': '#303030',
+        '--m3-on-background': '#f4eff0',
+        '--m3-inverse-surface': '#fcf9f9',
+        '--m3-inverse-on-surface': '#1a1c1e',
+        '--oriso-app-accent': primary,
+        '--oriso-app-accent-dark': accentDark,
+        '--oriso-app-accent-light': accentLight,
+        '--oriso-app-on-accent': readableOn(primary),
+        '--oriso-app-accent-container': primaryContainer,
+        '--oriso-app-chat-surface': '#ffffff',
+        '--oriso-app-action': action,
+        '--oriso-app-on-action': readableOn(action),
+    };
+};
+
+export const computeOrisoPalette = (seeds: TenantSeeds, scheme: OrisoSchemeName = 'light'): OrisoPaletteResult => {
     const accentDark = normalizeHex(getAccentDark(seeds)) ?? DEFAULT_ACCENT_DARK;
     const explicitAccentLight = normalizeHex(getAccentLight(seeds));
     const { accentLight, accentDim, accentAction, onAccentLightVariant } = defaultAccentTokens(
@@ -90,9 +144,17 @@ export const computeOrisoPalette = (seeds: TenantSeeds): OrisoPaletteResult => {
     const onAccentDark = luminance(accentDark) > 0.62 ? '#141c25' : '#ffffff';
     const onAccentLight = luminance(accentLight) > 0.62 ? '#141c25' : '#ffffff';
     const onAccentAction = luminance(accentAction) > 0.62 ? '#141c25' : '#ffffff';
+    const tooPale = saturation(accentDark) < 0.12;
+
+    if (scheme === 'inverted') {
+        return {
+            tooPale,
+            tokens: invertedTokens(accentDark, accentLight, accentDim, onAccentLightVariant),
+        };
+    }
 
     return {
-        tooPale: saturation(accentDark) < 0.12,
+        tooPale,
         tokens: {
             '--m3-primary': accentDark,
             '--m3-on-primary': onAccentDark,


### PR DESCRIPTION
## Problem

This PR was previously stacked on the closed THB theme branches, so retargeting it directly to `dev` would have pulled an outdated 12k-line stack into review. The current `dev` branch already contains the ThemeBuilder and seed model pieces, so this PR now carries only the missing runtime behavior.

## Solution

- Keep `computeOrisoPalette(seeds)` backward-compatible for the existing light ThemeBuilder flow.
- Add `computeOrisoPalette(seeds, 'inverted')` for the admin shell chrome.
- Apply the inverted `--m3-*` tokens from the active tenant seeds in the App shell.
- Leave the static CSS palette in place when stored seed data is invalid.

## Validation

- `npm test -- applyAdminTheme`
- `npx eslint src/App.tsx src/hooks/useAdminInvertedTheme.hook.ts src/utils/applyAdminTheme.ts src/utils/theme/orisoScheme.ts`
- `npm run build`

Full `npm test` is currently blocked by an existing `dev` baseline failure in `src/pages/Agency/Edit/index.test.tsx` (`No QueryClient set`), unrelated to this PR.

## Reviewer note

The branch was intentionally rewritten onto `dev` to remove the obsolete closed THB stack. The final diff should now be small and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin areas now support an automatically applied inverted theme, with colors computed from tenant theming seeds.
  * Theme inversion is coordinated with tenant data readiness to prevent premature styling.
* **Bug Fixes**
  * Improved handling of missing/invalid theme seeds to avoid partially applied or stale theme tokens.
  * Enhanced admin UI color contrast for better readability.
* **Tests**
  * Added Vitest coverage for inverted token application, cleanup behavior, invalid-seed handling, and WCAG ≥ 4.5 contrast checks.
* **Chores**
  * Updated disabled input/placeholder styling to derive from M3 theme tokens via `color-mix`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->