### PR TITLE
Align permissions UI with tenantAdminControls allowedPermissionToggles

### DIFF
--- a/src/api/auth/getAccessToken.ts
+++ b/src/api/auth/getAccessToken.ts
@@ -16,9 +16,8 @@ const getKeycloakAccessToken = (loginProps: {
         // console.log('🔍 getKeycloakAccessToken: username:', username);
         // console.log('🔍 getKeycloakAccessToken: tryUnencryptedForEmail:', tryUnencryptedForEmail);
 
-        const dataBody = `username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}${
-            otp ? `&otp=${otp}` : ``
-        }&client_id=app&grant_type=password`;
+        const dataBody = `username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}${otp ? `&otp=${otp}` : ``
+            }&client_id=app&grant_type=password`;
 
         const req = new Request(loginEndpoint, {
             method: 'POST',

--- a/src/components/Tenants/AppSettings/PermissionsSettings/index.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/index.tsx
@@ -131,32 +131,32 @@ interface PermissionsSettingsArgs {
 }
 
 type PermissionToggleVisibility = {
-    featureAnonymousChatEnabled?: boolean | null;
-    featureGroupChatV2Enabled?: boolean | null;
-    featureCallsEnabled?: boolean | null;
-    featureSupervisionEnabled?: boolean | null;
-    featureSupervisionAnonymousChatsEnabled?: boolean | null;
-    featureSupervisionOneOnOneChatsEnabled?: boolean | null;
-    featureAudioCallsEnabled?: boolean | null;
-    featureAudioCallsAnonymousChatsEnabled?: boolean | null;
-    featureAudioCallsOneOnOneChatsEnabled?: boolean | null;
-    featureAudioCallsGroupChatsEnabled?: boolean | null;
-    featureAudioCallsSupervisionChatsEnabled?: boolean | null;
-    featureVideoCallsEnabled?: boolean | null;
-    featureVideoCallsAnonymousChatsEnabled?: boolean | null;
-    featureVideoCallsOneOnOneChatsEnabled?: boolean | null;
-    featureVideoCallsGroupChatsEnabled?: boolean | null;
-    featureVideoCallsSupervisionChatsEnabled?: boolean | null;
-    featureThreadsEnabled?: boolean | null;
-    featureThreadsAnonymousChatsEnabled?: boolean | null;
-    featureThreadsGroupChatsEnabled?: boolean | null;
-    featureThreadsOneOnOneEnabled?: boolean | null;
-    featureThreadsSupervisionChatsEnabled?: boolean | null;
-    featureVoiceMessagesEnabled?: boolean | null;
-    featureVoiceMessagesAnonymousChatsEnabled?: boolean | null;
-    featureVoiceMessagesOneOnOneChatsEnabled?: boolean | null;
-    featureVoiceMessagesGroupChatsEnabled?: boolean | null;
-    featureVoiceMessagesSupervisionChatsEnabled?: boolean | null;
+    anonymousChat?: boolean;
+    groupChat?: boolean;
+    calls?: boolean;
+    supervision?: boolean;
+    supervisionAnonymousChats?: boolean;
+    supervisionOneOnOneChats?: boolean;
+    audioCalls?: boolean;
+    audioCallsAnonymousChats?: boolean;
+    audioCallsOneOnOneChats?: boolean;
+    audioCallsGroupChats?: boolean;
+    audioCallsSupervisionChats?: boolean;
+    videoCalls?: boolean;
+    videoCallsAnonymousChats?: boolean;
+    videoCallsOneOnOneChats?: boolean;
+    videoCallsGroupChats?: boolean;
+    videoCallsSupervisionChats?: boolean;
+    threads?: boolean;
+    threadsAnonymousChats?: boolean;
+    threadsOneOnOneChats?: boolean;
+    threadsGroupChats?: boolean;
+    threadsSupervisionChats?: boolean;
+    voiceMessages?: boolean;
+    voiceMessagesAnonymousChats?: boolean;
+    voiceMessagesOneOnOneChats?: boolean;
+    voiceMessagesGroupChats?: boolean;
+    voiceMessagesSupervisionChats?: boolean;
 };
 
 const DEFAULT_PERMISSION_SETTINGS = {
@@ -188,34 +188,7 @@ const DEFAULT_PERMISSION_SETTINGS = {
     featureVoiceMessagesSupervisionChatsEnabled: true,
 } as const;
 
-type AllowedPermissionToggleKey =
-    | 'anonymousChat'
-    | 'calls'
-    | 'supervision'
-    | 'supervisionAnonymousChats'
-    | 'supervisionOneOnOneChats'
-    | 'audioCalls'
-    | 'audioCallsAnonymousChats'
-    | 'audioCallsOneOnOneChats'
-    | 'audioCallsGroupChats'
-    | 'audioCallsSupervisionChats'
-    | 'videoCalls'
-    | 'videoCallsAnonymousChats'
-    | 'videoCallsOneOnOneChats'
-    | 'videoCallsGroupChats'
-    | 'videoCallsSupervisionChats'
-    | 'threads'
-    | 'threadsAnonymousChats'
-    | 'threadsOneOnOneChats'
-    | 'threadsGroupChats'
-    | 'threadsSupervisionChats'
-    | 'voiceMessages'
-    | 'voiceMessagesAnonymousChats'
-    | 'voiceMessagesOneOnOneChats'
-    | 'voiceMessagesGroupChats'
-    | 'voiceMessagesSupervisionChats';
-
-const PLATFORM_TOGGLE_FIELDS: Record<AllowedPermissionToggleKey, string[]> = {
+const PLATFORM_TOGGLE_FIELDS: Record<keyof PermissionToggleVisibility, string[]> = {
     anonymousChat: [
         'featureAnonymousChatEnabled',
         'featureVideoCallsAnonymousChatsEnabled',
@@ -224,11 +197,18 @@ const PLATFORM_TOGGLE_FIELDS: Record<AllowedPermissionToggleKey, string[]> = {
         'featureThreadsAnonymousChatsEnabled',
         'featureSupervisionAnonymousChatsEnabled',
     ],
+    groupChat: [
+        'featureGroupChatV2Enabled',
+        'featureVideoCallsGroupChatsEnabled',
+        'featureAudioCallsGroupChatsEnabled',
+        'featureVoiceMessagesGroupChatsEnabled',
+        'featureThreadsGroupChatsEnabled',
+    ],
     calls: ['featureCallsEnabled'],
     supervision: [
         'featureSupervisionEnabled',
-        'featureSupervisionAnonymousChatsEnabled',
-        'featureSupervisionOneOnOneChatsEnabled',
+        // 'featureSupervisionAnonymousChatsEnabled',
+        // 'featureSupervisionOneOnOneChatsEnabled',
         'featureVideoCallsSupervisionChatsEnabled',
         'featureAudioCallsSupervisionChatsEnabled',
         'featureVoiceMessagesSupervisionChatsEnabled',
@@ -282,26 +262,17 @@ const PLATFORM_TOGGLE_FIELDS: Record<AllowedPermissionToggleKey, string[]> = {
     voiceMessagesSupervisionChats: ['featureVoiceMessagesSupervisionChatsEnabled'],
 };
 
-const PERMISSION_SETTING_KEYS = new Set<string>(Object.keys(DEFAULT_PERMISSION_SETTINGS));
-
 const getForcedOffFields = (toggles?: PermissionToggleVisibility) => {
     if (!toggles) return new Set<string>();
 
     return Object.entries(toggles).reduce((fields, [toggleKey, enabled]) => {
-        if (enabled !== false) {
-            return fields;
+        if (enabled === false) {
+            const platformFields = PLATFORM_TOGGLE_FIELDS[toggleKey as keyof PermissionToggleVisibility];
+            if (platformFields) {
+                platformFields.forEach((field) => fields.add(field));
+                return fields;
+            }
         }
-
-        const platformFields = PLATFORM_TOGGLE_FIELDS[toggleKey as AllowedPermissionToggleKey];
-        if (platformFields) {
-            platformFields.forEach((field) => fields.add(field));
-            return fields;
-        }
-
-        if (PERMISSION_SETTING_KEYS.has(toggleKey)) {
-            fields.add(toggleKey);
-        }
-
         return fields;
     }, new Set<string>());
 };
@@ -332,35 +303,39 @@ const syncMasterTogglesToTenantAdminControls = (formData) => {
     const { settings } = next;
     const isEnabled = (key: string) => settings?.[key] !== false;
     const anonymousEnabled = isEnabled('featureAnonymousChatEnabled');
+    const groupEnabled = isEnabled('featureGroupChatV2Enabled');
+    const oneOnOneEnabled = isEnabled('featureCallsEnabled');
+    const supervisionEnabled = isEnabled('featureSupervisionEnabled');
 
     settings.tenantAdminControls = {
         ...(settings.tenantAdminControls ?? {}),
         allowedPermissionToggles: {
             anonymousChat: anonymousEnabled,
-            calls: isEnabled('featureCallsEnabled'),
-            supervision: isEnabled('featureSupervisionEnabled'),
+            groupChat: groupEnabled,
+            calls: oneOnOneEnabled,
+            supervision: supervisionEnabled,
             supervisionAnonymousChats: anonymousEnabled && isEnabled('featureSupervisionAnonymousChatsEnabled'),
-            supervisionOneOnOneChats: isEnabled('featureSupervisionOneOnOneChatsEnabled'),
+            supervisionOneOnOneChats: oneOnOneEnabled && isEnabled('featureSupervisionOneOnOneChatsEnabled'),
             audioCalls: isEnabled('featureAudioCallsEnabled'),
             audioCallsAnonymousChats: anonymousEnabled && isEnabled('featureAudioCallsAnonymousChatsEnabled'),
-            audioCallsOneOnOneChats: isEnabled('featureAudioCallsOneOnOneChatsEnabled'),
-            audioCallsGroupChats: isEnabled('featureAudioCallsGroupChatsEnabled'),
+            audioCallsOneOnOneChats: oneOnOneEnabled && isEnabled('featureAudioCallsOneOnOneChatsEnabled'),
+            audioCallsGroupChats: groupEnabled && isEnabled('featureAudioCallsGroupChatsEnabled'),
             audioCallsSupervisionChats: isEnabled('featureAudioCallsSupervisionChatsEnabled'),
             videoCalls: isEnabled('featureVideoCallsEnabled'),
             videoCallsAnonymousChats: anonymousEnabled && isEnabled('featureVideoCallsAnonymousChatsEnabled'),
-            videoCallsOneOnOneChats: isEnabled('featureVideoCallsOneOnOneChatsEnabled'),
-            videoCallsGroupChats: isEnabled('featureVideoCallsGroupChatsEnabled'),
-            videoCallsSupervisionChats: isEnabled('featureVideoCallsSupervisionChatsEnabled'),
+            videoCallsOneOnOneChats: oneOnOneEnabled && isEnabled('featureVideoCallsOneOnOneChatsEnabled'),
+            videoCallsGroupChats: groupEnabled && isEnabled('featureVideoCallsGroupChatsEnabled'),
+            videoCallsSupervisionChats: supervisionEnabled && isEnabled('featureVideoCallsSupervisionChatsEnabled'),
             threads: isEnabled('featureThreadsEnabled'),
             threadsAnonymousChats: anonymousEnabled && isEnabled('featureThreadsAnonymousChatsEnabled'),
-            threadsOneOnOneChats: isEnabled('featureThreadsOneOnOneEnabled'),
-            threadsGroupChats: isEnabled('featureThreadsGroupChatsEnabled'),
-            threadsSupervisionChats: isEnabled('featureThreadsSupervisionChatsEnabled'),
+            threadsOneOnOneChats: oneOnOneEnabled && isEnabled('featureThreadsOneOnOneEnabled'),
+            threadsGroupChats: groupEnabled && isEnabled('featureThreadsGroupChatsEnabled'),
+            threadsSupervisionChats: supervisionEnabled && isEnabled('featureThreadsSupervisionChatsEnabled'),
             voiceMessages: isEnabled('featureVoiceMessagesEnabled'),
             voiceMessagesAnonymousChats: anonymousEnabled && isEnabled('featureVoiceMessagesAnonymousChatsEnabled'),
-            voiceMessagesOneOnOneChats: isEnabled('featureVoiceMessagesOneOnOneChatsEnabled'),
-            voiceMessagesGroupChats: isEnabled('featureVoiceMessagesGroupChatsEnabled'),
-            voiceMessagesSupervisionChats: isEnabled('featureVoiceMessagesSupervisionChatsEnabled'),
+            voiceMessagesOneOnOneChats: oneOnOneEnabled && isEnabled('featureVoiceMessagesOneOnOneChatsEnabled'),
+            voiceMessagesGroupChats: groupEnabled && isEnabled('featureVoiceMessagesGroupChatsEnabled'),
+            voiceMessagesSupervisionChats: supervisionEnabled && isEnabled('featureVoiceMessagesSupervisionChatsEnabled'),
         },
     };
     return next;

--- a/src/pages/TenantSettings/PermissionsSettings/index.tsx
+++ b/src/pages/TenantSettings/PermissionsSettings/index.tsx
@@ -1,16 +1,16 @@
 import { PermissionsSettings } from '../../../components/Tenants/AppSettings/PermissionsSettings';
-import { usePublicTenantData } from '../../../hooks/usePublicTenantData.hook';
+import { useTenantData } from '../../../hooks/useTenantData.hook';
 import { useUserRoles } from '../../../hooks/useUserRoles.hook';
 
 export const PermissionsSettingsPage = () => {
-    const { data } = usePublicTenantData();
+    const { data } = useTenantData();
     const { tenantId, isSuperAdmin } = useUserRoles();
     const resolvedTenantId = tenantId && tenantId > 0 ? tenantId : data?.id;
 
     return (
         <PermissionsSettings
             tenantId={`${resolvedTenantId || ''}`}
-            visibleToggles={data?.settings}
+            visibleToggles={data?.settings?.tenantAdminControls?.allowedPermissionToggles}
             superAdminControlMode={isSuperAdmin}
         />
     );

--- a/src/pages/Tenants/Edit/GlobalSettings/index.tsx
+++ b/src/pages/Tenants/Edit/GlobalSettings/index.tsx
@@ -19,7 +19,7 @@ export const TenantGlobalSettings = () => {
                     <PermissionsSettings
                         tenantId={id || ''}
                         superAdminControlMode
-                        visibleToggles={{ featureAnonymousChatEnabled: false }}
+                        visibleToggles={{ anonymousChat: false }}
                     />
                 </div>
             </Col>

--- a/src/types/tenant.d.ts
+++ b/src/types/tenant.d.ts
@@ -47,6 +47,7 @@ export interface TenantSettings {
         permissionsPageEnabled?: boolean | null;
         allowedPermissionToggles?: {
             anonymousChat?: boolean | null;
+            groupChat?: boolean | null;
             appearance?: boolean | null;
             calls?: boolean | null;
             supervision?: boolean | null;


### PR DESCRIPTION
## Feature: Align permissions UI with tenantAdminControls allowedPermissionToggles

#### Related Issue: https://github.com/OpenResilienceInitiative/ORISO-Admin/issues/107

## Summary
- Migrated visibleToggles from legacy feature* setting keys to the tenantAdminControls.allowedPermissionToggles shape so tenant-admin permission restrictions match the backend model.
- Added groupChat as a platform-controlled permission toggle with correct field mapping and parent/child gating.
- Ensured super-admin saves keep tenantAdminControls.allowedPermissionToggles in sync with the permissions card UI.

## Changes Made
- Replaced PermissionToggleVisibility legacy feature* keys with allowedPermissionToggles keys (anonymousChat, groupChat, calls, supervision, etc.)
- Added PLATFORM_TOGGLE_FIELDS mapping from toggle keys to underlying feature* settings for forced-off enforcement
- Updated getForcedOffFields to resolve disabled toggles via PLATFORM_TOGGLE_FIELDS
- Extended syncMasterTogglesToTenantAdminControls to sync groupChat and gate group/one-on-one/supervision sub-toggles by their parent masters
- Wired tenant permissions page to pass data?.settings?.tenantAdminControls?.allowedPermissionToggles into PermissionsSettings
- Switched tenant permissions page data source to useTenantData so full tenant settings (including tenantAdminControls) are available
- Updated global settings to use visibleToggles={{ anonymousChat: false }} instead of the legacy featureAnonymousChatEnabled key
- Added groupChat to TenantSettings.tenantAdminControls.allowedPermissionToggles in tenant.d.ts

## Testing
- Verified tenant admin permissions page disables toggles when allowedPermissionToggles entries are false
- Verified super-admin global settings still hides live chat via anonymousChat: false
- Verified saving permissions in super-admin mode updates settings.tenantAdminControls.allowedPermissionToggles
- Verified groupChat: false forces off featureGroupChatV2Enabled and related group-chat sub-features
- Verified group sub-toggles (videoCallsGroupChats, audioCallsGroupChats, etc.) are gated when group chat master is disabled