### PR TITLE
fix: stop tracking public/env.js (#104)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ yarn-error.log*
 
 .env
 graphify-out/*
+
+# Generated at container start by scripts/generate-runtime-env.js — never commit personal configs here
+public/env.js

--- a/public/env.js
+++ b/public/env.js
@@ -1,3 +1,0 @@
-// Runtime config injected at container start (see scripts/generate-runtime-env.js).
-// Local development falls back to VITE_* values from .env when this file is empty.
-window.__APP_CONFIG__ = window.__APP_CONFIG__ || {};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,15 +40,14 @@ export default ({ mode }) => {
         },
         configureServer(server) {
             const envPath = `${process.cwd()}/public/env.js`;
+            // public/env.js is gitignored. Serve an in-memory fallback so the dev
+            // server works on a fresh checkout without the file being present.
+            const fallback = 'window.__APP_CONFIG__ = window.__APP_CONFIG__ || {};\n';
 
             const runtimeEnvPath = `${(process.env.BASE || '/admin').replace(/\/$/, '')}/env.js`;
-            server.middlewares.use(runtimeEnvPath, (_req, res, next) => {
-                if (!existsSync(envPath)) {
-                    next();
-                    return;
-                }
+            server.middlewares.use(runtimeEnvPath, (_req, res) => {
                 res.setHeader('Content-Type', 'application/javascript');
-                res.end(readFileSync(envPath));
+                res.end(existsSync(envPath) ? readFileSync(envPath) : fallback);
             });
         },
     });


### PR DESCRIPTION
## What
- Added `public/env.js` to `.gitignore` and removed it from git tracking (`git rm --cached`)
- Updated `vite.config.ts` `configureServer` to serve a neutral in-memory fallback (`window.__APP_CONFIG__ = window.__APP_CONFIG__ || {};`) when the file is absent, so dev server works on a fresh checkout
- `scripts/generate-runtime-env.js` (production container entrypoint) is untouched

## Why
Closes #104 — `public/env.js` was tracked in git, allowing personal local configs to be committed by accident. This already happened in 9fd581b (`API_URL: localhost:8088`), which broke every other machine's dev environment until PR #103 reverted it.
