### PR TITLE
Implement platform, tenant, and agency permission settings (#107)

### DIFF
--- a/src/api/agency/getAgencyAdminControls.ts
+++ b/src/api/agency/getAgencyAdminControls.ts
@@ -1,0 +1,11 @@
+import { agencyServiceAdminEndpoint } from '../../appConfig';
+import { AgencyAdminControls } from '../../types/AgencyAdminControls';
+import { FETCH_ERRORS, FETCH_METHODS, fetchData } from '../fetchData';
+
+export const getAgencyAdminControls = () =>
+    fetchData({
+        url: `${agencyServiceAdminEndpoint}/controls`,
+        method: FETCH_METHODS.GET,
+        skipAuth: false,
+        responseHandling: [FETCH_ERRORS.CATCH_ALL],
+    }) as Promise<AgencyAdminControls>;

--- a/src/api/agency/updateAgencyAdminControls.ts
+++ b/src/api/agency/updateAgencyAdminControls.ts
@@ -1,0 +1,12 @@
+import { agencyServiceAdminEndpoint } from '../../appConfig';
+import { AgencyAdminControls } from '../../types/AgencyAdminControls';
+import { FETCH_ERRORS, FETCH_METHODS, fetchData } from '../fetchData';
+
+export const updateAgencyAdminControls = (body: AgencyAdminControls) =>
+    fetchData({
+        url: `${agencyServiceAdminEndpoint}/controls`,
+        method: FETCH_METHODS.PUT,
+        skipAuth: false,
+        bodyData: JSON.stringify(body),
+        responseHandling: [FETCH_ERRORS.CATCH_ALL],
+    }) as Promise<AgencyAdminControls>;

--- a/src/api/agency/updateAgencyData.ts
+++ b/src/api/agency/updateAgencyData.ts
@@ -2,8 +2,8 @@ import { FETCH_ERRORS, FETCH_METHODS, fetchData, FETCH_SUCCESS } from '../fetchD
 import { agencyEndpointBase } from '../../appConfig';
 import { withLegacyDioceseId } from '../legacyCaritasApiDefaults';
 import { AgencyData } from '../../types/agency';
-import updateAgencyType from './updateAgencyType';
 import getConsultingType4Tenant from '../consultingtype/getConsultingType4Tenant';
+import updateAgencyType from './updateAgencyType';
 import updateAgencyPostCodeRange from './updateAgencyPostCodeRange';
 
 /**
@@ -27,7 +27,7 @@ export const updateAgencyData = async (agencyModel: AgencyData, formInput: Agenc
 
     const topicIds = topics
         ?.map((topic) => (typeof topic === 'string' ? topic : topic?.id))
-        .filter((id) => !Number.isNaN(Number(id)));
+        .filter((topicId) => !Number.isNaN(Number(topicId)));
 
     const agencyDataRequestBody = withLegacyDioceseId({
         name: formInput.name,
@@ -37,13 +37,14 @@ export const updateAgencyData = async (agencyModel: AgencyData, formInput: Agenc
         city: formInput.city,
         consultingType: consultingTypeId,
         teamAgency: formInput.teamAgency,
-        offline: !formInput.online, // Convert from 'online' form field to 'offline' API field
+        offline: formInput.online !== undefined ? !formInput.online : formInput.offline,
         external: false,
         demographics: formInput.demographics,
         counsellingRelations: formInput.counsellingRelations,
         dataProtection: formInput.dataProtection,
         content: formInput.content,
         agencyLogo: formInput.agencyLogo,
+        settings: formInput.settings,
     });
 
     return fetchData({
@@ -53,7 +54,9 @@ export const updateAgencyData = async (agencyModel: AgencyData, formInput: Agenc
         responseHandling: [FETCH_ERRORS.CATCH_ALL, FETCH_SUCCESS.CONTENT],
         bodyData: JSON.stringify(agencyDataRequestBody),
     }).then(async (response) => {
-        await updateAgencyPostCodeRange(agencyId, formInput.postCodes, '');
+        if (formInput.postCodes !== undefined) {
+            await updateAgencyPostCodeRange(agencyId, formInput.postCodes, '');
+        }
         // eslint-disable-next-line no-underscore-dangle
         return response?._embedded;
     });

--- a/src/appConfig.ts
+++ b/src/appConfig.ts
@@ -19,6 +19,7 @@ export const clusterFeatureFlags = {
 
 export const supportedLanguages = ['de', 'en', 'fr', 'ru', 'tr', 'uk', 'ti'];
 
+export const agencyServiceAdminEndpoint = `${agencyServiceURL}/service/agencyadmin`;
 export const agencyDataAgencyId = (agencyId: string) => `${agencyServiceURL}/service/agencyadmin/agencies/${agencyId}`;
 export const agencyEndpointBase = `${agencyServiceURL}/service/agencyadmin/agencies`;
 export const agencyPostcodeRangeEndpointBase = `${agencyServiceURL}/service/agencyadmin/postcoderanges`;

--- a/src/components/Tenants/AppSettings/PermissionsSettings/AgencyPermissionsSettings.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/AgencyPermissionsSettings.tsx
@@ -1,23 +1,26 @@
 import { useCallback, useMemo } from 'react';
-import { useSingleTenantData } from '../../../../hooks/useSingleTenantData';
-import { useTenantAdminDataMutation } from '../../../../hooks/useTenantAdminDataMutation.hook';
+import { useAgencyData } from '../../../../hooks/useAgencyData';
+import { useAgencyUpdate } from '../../../../hooks/useAgencyUpdate';
 import { buildTogglePayload } from './permissionsToggleLogic';
 import { applyForcedOffFields, DEFAULT_PERMISSION_SETTINGS, getForcedOffFields } from './permissionsSettingsUtils';
 import { PermissionsSettingsView } from './PermissionsSettingsView';
-import type { PermissionsSettingsCommonArgs, ToggleAfterChangeHandler } from './types';
+import type { ChatTypeCardKey, ToggleAfterChangeHandler } from './types';
 
-export const TenantPermissionsSettings = ({
-    tenantId,
+type AgencyPermissionsSettingsProps = {
+    agencyId: string;
+    excludeCardKeys?: Array<ChatTypeCardKey>;
+    superAdminMode?: boolean;
+};
+
+export const AgencyPermissionsSettings = ({
+    agencyId,
     excludeCardKeys,
     superAdminMode = false,
-}: PermissionsSettingsCommonArgs & { superAdminMode?: boolean }) => {
-    const { data: tenantData, isLoading } = useSingleTenantData({ id: tenantId });
-    const { mutate: updateTenantSettings } = useTenantAdminDataMutation({
-        id: tenantId,
-        successMessageKey: 'tenants.message.settingsUpdate',
-    });
+}: AgencyPermissionsSettingsProps) => {
+    const { data: agencyData, isLoading } = useAgencyData({ id: agencyId });
+    const { mutate: updateAgency } = useAgencyUpdate(agencyId);
 
-    const allowedPermissionToggles = tenantData?.settings?.tenantAdminControls?.allowedPermissionToggles;
+    const allowedPermissionToggles = agencyData?.settings?.agencyAdminControls?.allowedPermissionToggles;
     const restrictedFields = useMemo(
         () => (superAdminMode ? new Set<string>() : getForcedOffFields(allowedPermissionToggles)),
         [superAdminMode, allowedPermissionToggles],
@@ -25,26 +28,31 @@ export const TenantPermissionsSettings = ({
 
     const initialValues = useMemo(
         () => ({
-            ...tenantData,
             settings: {
                 ...DEFAULT_PERMISSION_SETTINGS,
-                ...applyForcedOffFields(tenantData?.settings ?? {}, restrictedFields),
+                ...applyForcedOffFields(agencyData?.settings, restrictedFields),
             },
         }),
-        [tenantData, restrictedFields],
+        [agencyData?.settings, restrictedFields],
     );
 
-    const formStateKey = useMemo(() => Array.from(restrictedFields).sort().join('|'), [restrictedFields]);
+    const formStateKey = useMemo(
+        () =>
+            [agencyId, superAdminMode ? 'super-admin' : 'agency-admin', ...Array.from(restrictedFields).sort()].join(
+                '|',
+            ),
+        [agencyId, superAdminMode, restrictedFields],
+    );
 
     const handleToggleUpdate = useCallback<ToggleAfterChangeHandler>(
         (fieldPath, value, currentFormData) => {
-            if (!tenantData) return;
+            if (!agencyData) return;
 
             const toggleUpdate = buildTogglePayload(fieldPath, value) as { settings?: Record<string, boolean> };
-            updateTenantSettings({
+            updateAgency({
                 settings: applyForcedOffFields(
                     {
-                        ...tenantData.settings,
+                        ...agencyData.settings,
                         ...(currentFormData?.settings ?? {}),
                         ...toggleUpdate.settings,
                     },
@@ -52,22 +60,28 @@ export const TenantPermissionsSettings = ({
                 ),
             });
         },
-        [tenantData, updateTenantSettings, restrictedFields],
+        [agencyData, restrictedFields, updateAgency],
     );
 
     const handleSave = useCallback(
         (formData: unknown) => {
             const savedFormData = formData as { settings?: Record<string, unknown> };
-            updateTenantSettings({
-                settings: applyForcedOffFields(savedFormData.settings, restrictedFields),
+            updateAgency({
+                settings: applyForcedOffFields(
+                    {
+                        ...agencyData?.settings,
+                        ...savedFormData.settings,
+                    },
+                    restrictedFields,
+                ),
             });
         },
-        [updateTenantSettings, restrictedFields],
+        [agencyData?.settings, updateAgency, restrictedFields],
     );
 
     return (
         <PermissionsSettingsView
-            tenantId={tenantId}
+            tenantId={`agency-${agencyId}`}
             disableSubTogglesWhenMasterOff={!superAdminMode}
             excludeCardKeys={excludeCardKeys}
             isLoading={isLoading}

--- a/src/components/Tenants/AppSettings/PermissionsSettings/SuperAdminPermissionsSettings.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/SuperAdminPermissionsSettings.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useMemo } from 'react';
+import { useAgencyAdminControls } from '../../../../hooks/useAgencyAdminControls.hook';
+import { useAgencyAdminControlsMutation } from '../../../../hooks/useAgencyAdminControlsMutation.hook';
 import { useTenantAdminControls } from '../../../../hooks/useTenantAdminControls.hook';
 import { useTenantAdminControlsMutation } from '../../../../hooks/useTenantAdminControlsMutation.hook';
 import { buildTogglePayload } from './permissionsToggleLogic';
 import {
+    buildAgencyAdminControlsPayload,
     applyVisibleTogglesAsValues,
     buildTenantAdminControlsPayload,
 } from './permissionsSettingsUtils';
@@ -10,8 +13,10 @@ import { PermissionsSettingsView } from './PermissionsSettingsView';
 import type { PermissionsSettingsCommonArgs, ToggleAfterChangeHandler } from './types';
 
 export const SuperAdminPermissionsSettings = ({ tenantId, excludeCardKeys }: PermissionsSettingsCommonArgs) => {
-    const { data: platformControls, isLoading } = useTenantAdminControls(true);
+    const { data: platformControls, isLoading: isLoadingTenantControls } = useTenantAdminControls(true);
+    const { data: agencyPlatformControls, isLoading: isLoadingAgencyControls } = useAgencyAdminControls(true);
     const { mutate: updateTenantAdminControls } = useTenantAdminControlsMutation({ successMessageKey: false });
+    const { mutate: updateAgencyAdminControls } = useAgencyAdminControlsMutation({ successMessageKey: false });
 
     const allowedPermissionToggles = platformControls?.allowedPermissionToggles;
     const restrictedFields = useMemo(() => new Set<string>(), []);
@@ -25,8 +30,22 @@ export const SuperAdminPermissionsSettings = ({ tenantId, excludeCardKeys }: Per
                     platformControls?.permissionsPageEnabled ?? true,
                 ),
             );
+            updateAgencyAdminControls(
+                buildAgencyAdminControlsPayload(
+                    formData,
+                    agencyPlatformControls?.allowedPermissionToggles,
+                    agencyPlatformControls?.permissionsPageEnabled ?? true,
+                ),
+            );
         },
-        [updateTenantAdminControls, allowedPermissionToggles, platformControls?.permissionsPageEnabled],
+        [
+            updateTenantAdminControls,
+            updateAgencyAdminControls,
+            allowedPermissionToggles,
+            platformControls?.permissionsPageEnabled,
+            agencyPlatformControls?.allowedPermissionToggles,
+            agencyPlatformControls?.permissionsPageEnabled,
+        ],
     );
 
     const initialValues = useMemo(
@@ -59,10 +78,10 @@ export const SuperAdminPermissionsSettings = ({ tenantId, excludeCardKeys }: Per
 
     return (
         <PermissionsSettingsView
-            tenantId={tenantId}
+            tenantId={tenantId || 'platform'}
             disableSubTogglesWhenMasterOff={false}
             excludeCardKeys={excludeCardKeys}
-            isLoading={isLoading}
+            isLoading={isLoadingTenantControls || isLoadingAgencyControls}
             initialValues={initialValues}
             formStateKey="platform"
             restrictedFields={restrictedFields}

--- a/src/components/Tenants/AppSettings/PermissionsSettings/index.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/index.tsx
@@ -17,9 +17,13 @@ export const PermissionsSettings = ({
     ...props
 }: PermissionsSettingsArgs) => {
     if (mode === 'agency') {
+        if (!props.agencyId) {
+            return null;
+        }
+
         return (
             <AgencyPermissionsSettings
-                agencyId={props.agencyId!}
+                agencyId={props.agencyId}
                 excludeCardKeys={props.excludeCardKeys}
                 superAdminMode={superAdminMode}
             />

--- a/src/components/Tenants/AppSettings/PermissionsSettings/index.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/index.tsx
@@ -1,10 +1,40 @@
+import { AgencyPermissionsSettings } from './AgencyPermissionsSettings';
 import { SuperAdminPermissionsSettings } from './SuperAdminPermissionsSettings';
 import { TenantPermissionsSettings } from './TenantPermissionsSettings';
-import type { PermissionsSettingsCommonArgs } from './types';
+import type { PermissionsSettingsCommonArgs, PermissionsSettingsMode } from './types';
 
 interface PermissionsSettingsArgs extends PermissionsSettingsCommonArgs {
+    mode?: PermissionsSettingsMode;
     superAdminControlMode?: boolean;
+    /** When true, platform restrictions are not applied while editing tenant/agency permissions. */
+    superAdminMode?: boolean;
 }
 
-export const PermissionsSettings = ({ superAdminControlMode = false, ...props }: PermissionsSettingsArgs) =>
-    superAdminControlMode ? <SuperAdminPermissionsSettings {...props} /> : <TenantPermissionsSettings {...props} />;
+export const PermissionsSettings = ({
+    mode,
+    superAdminControlMode = false,
+    superAdminMode = false,
+    ...props
+}: PermissionsSettingsArgs) => {
+    if (mode === 'agency') {
+        return (
+            <AgencyPermissionsSettings
+                agencyId={props.agencyId!}
+                excludeCardKeys={props.excludeCardKeys}
+                superAdminMode={superAdminMode}
+            />
+        );
+    }
+
+    if (mode === 'superAdmin' || superAdminControlMode) {
+        return <SuperAdminPermissionsSettings tenantId={props.tenantId} excludeCardKeys={props.excludeCardKeys} />;
+    }
+
+    return (
+        <TenantPermissionsSettings
+            tenantId={props.tenantId}
+            excludeCardKeys={props.excludeCardKeys}
+            superAdminMode={superAdminMode}
+        />
+    );
+};

--- a/src/components/Tenants/AppSettings/PermissionsSettings/permissionsSettingsUtils.test.ts
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/permissionsSettingsUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     applyForcedOffFields,
     applyVisibleTogglesAsValues,
+    buildAgencyAdminControlsPayload,
     buildTenantAdminControlsPayload,
     getForcedOffFields,
     isSubToggleDisabled,
@@ -61,6 +62,23 @@ describe('permissions settings utils', () => {
         expect(result).toMatchObject({
             permissionsPageEnabled: false,
             allowedPermissionToggles: {
+                calls: false,
+                groupChat: true,
+            },
+        });
+    });
+
+    it('preserves agency appearance toggle while building agency admin controls payload', () => {
+        const result = buildAgencyAdminControlsPayload(
+            { settings: { featureCallsEnabled: false } },
+            { appearance: true, groupChat: true },
+            false,
+        );
+
+        expect(result).toMatchObject({
+            permissionsPageEnabled: false,
+            allowedPermissionToggles: {
+                appearance: true,
                 calls: false,
                 groupChat: true,
             },

--- a/src/components/Tenants/AppSettings/PermissionsSettings/permissionsSettingsUtils.ts
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/permissionsSettingsUtils.ts
@@ -1,5 +1,6 @@
 import { PermissionToggleVisibility } from '../../../../types/PermissionToggleVisibility';
 import { AgencyAdminControls } from '../../../../types/AgencyAdminControls';
+import { AgencyAdminAllowedPermissionToggles } from '../../../../types/AgencyAdminAllowedPermissionToggles';
 import { TenantAdminControls } from '../../../../types/TenantAdminControls';
 import type { TenantSettings } from '../../../../types/tenant';
 import type { ChatTypeCardDef } from './types';
@@ -233,7 +234,7 @@ export const buildTenantAdminControlsPayload = (
 
 export const buildAgencyAdminControlsPayload = (
     formData: { settings?: Record<string, unknown> },
-    existingToggles?: PermissionToggleVisibility,
+    existingToggles?: AgencyAdminAllowedPermissionToggles,
     permissionsPageEnabled = true,
 ): AgencyAdminControls => {
     const synced = syncMasterTogglesToAdminControls(formData, 'agencyAdminControls');

--- a/src/components/Tenants/AppSettings/PermissionsSettings/permissionsSettingsUtils.ts
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/permissionsSettingsUtils.ts
@@ -1,4 +1,5 @@
 import { PermissionToggleVisibility } from '../../../../types/PermissionToggleVisibility';
+import { AgencyAdminControls } from '../../../../types/AgencyAdminControls';
 import { TenantAdminControls } from '../../../../types/TenantAdminControls';
 import type { TenantSettings } from '../../../../types/tenant';
 import type { ChatTypeCardDef } from './types';
@@ -160,7 +161,12 @@ export const applyVisibleTogglesAsValues = (visibleToggles?: PermissionToggleVis
     return settings;
 };
 
-export const syncMasterTogglesToTenantAdminControls = (formData: { settings?: Record<string, unknown> }) => {
+type AdminControlsAttribute = 'tenantAdminControls' | 'agencyAdminControls';
+
+const syncMasterTogglesToAdminControls = (
+    formData: { settings?: Record<string, unknown> },
+    controlsAttribute: AdminControlsAttribute,
+) => {
     const settings: Record<string, unknown> = { ...(formData?.settings ?? {}) };
     const next = { ...formData, settings };
     const isEnabled = (key: string) => settings[key] !== false;
@@ -168,10 +174,10 @@ export const syncMasterTogglesToTenantAdminControls = (formData: { settings?: Re
     const groupEnabled = isEnabled('featureGroupChatV2Enabled');
     const oneOnOneEnabled = isEnabled('featureCallsEnabled');
     const supervisionEnabled = isEnabled('featureSupervisionEnabled');
-    const existingTenantAdminControls = (settings.tenantAdminControls as Record<string, unknown> | undefined) ?? {};
+    const existingAdminControls = (settings[controlsAttribute] as Record<string, unknown> | undefined) ?? {};
 
-    settings.tenantAdminControls = {
-        ...existingTenantAdminControls,
+    settings[controlsAttribute] = {
+        ...existingAdminControls,
         allowedPermissionToggles: {
             anonymousChat: anonymousEnabled,
             groupChat: groupEnabled,
@@ -205,6 +211,9 @@ export const syncMasterTogglesToTenantAdminControls = (formData: { settings?: Re
     return next;
 };
 
+export const syncMasterTogglesToTenantAdminControls = (formData: { settings?: Record<string, unknown> }) =>
+    syncMasterTogglesToAdminControls(formData, 'tenantAdminControls');
+
 export const buildTenantAdminControlsPayload = (
     formData: { settings?: Record<string, unknown> },
     existingToggles?: PermissionToggleVisibility,
@@ -212,6 +221,23 @@ export const buildTenantAdminControlsPayload = (
 ): TenantAdminControls => {
     const synced = syncMasterTogglesToTenantAdminControls(formData);
     const syncedControls = synced.settings?.tenantAdminControls as TenantAdminControls | undefined;
+
+    return {
+        permissionsPageEnabled,
+        allowedPermissionToggles: {
+            ...existingToggles,
+            ...syncedControls?.allowedPermissionToggles,
+        },
+    };
+};
+
+export const buildAgencyAdminControlsPayload = (
+    formData: { settings?: Record<string, unknown> },
+    existingToggles?: PermissionToggleVisibility,
+    permissionsPageEnabled = true,
+): AgencyAdminControls => {
+    const synced = syncMasterTogglesToAdminControls(formData, 'agencyAdminControls');
+    const syncedControls = synced.settings?.agencyAdminControls as AgencyAdminControls | undefined;
 
     return {
         permissionsPageEnabled,

--- a/src/components/Tenants/AppSettings/PermissionsSettings/types.ts
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/types.ts
@@ -7,10 +7,14 @@ export type ToggleAfterChangeHandler = (
 export type ChatTypeCardKey = 'oneOnOne' | 'liveChat' | 'group' | 'groupInternal';
 
 export type PermissionsSettingsCommonArgs = {
-    tenantId: string;
+    tenantId?: string;
+    /** When set, edits agency-level feature flags using agency data only. */
+    agencyId?: string;
     /** Hide chat-type cards by key (e.g. liveChat on super-admin settings — managed under Global Configs). */
     excludeCardKeys?: Array<ChatTypeCardKey>;
 };
+
+export type PermissionsSettingsMode = 'superAdmin' | 'tenant' | 'agency';
 
 export type ChatTypeCardDef = {
     key: ChatTypeCardKey;

--- a/src/hooks/useAgencyAdminControls.hook.ts
+++ b/src/hooks/useAgencyAdminControls.hook.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAgencyAdminControls } from '../api/agency/getAgencyAdminControls';
+
+export const AGENCY_ADMIN_CONTROLS_KEY = 'agency-admin-controls';
+
+export const useAgencyAdminControls = (enabled = true) =>
+    useQuery({
+        queryKey: [AGENCY_ADMIN_CONTROLS_KEY],
+        queryFn: getAgencyAdminControls,
+        enabled,
+        staleTime: 60_000,
+    });

--- a/src/hooks/useAgencyAdminControlsMutation.hook.ts
+++ b/src/hooks/useAgencyAdminControlsMutation.hook.ts
@@ -1,0 +1,34 @@
+import { notification } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { useMutation, useQueryClient, UseMutationOptions } from '@tanstack/react-query';
+import { updateAgencyAdminControls } from '../api/agency/updateAgencyAdminControls';
+import { AgencyAdminControls } from '../types/AgencyAdminControls';
+import { AGENCY_ADMIN_CONTROLS_KEY } from './useAgencyAdminControls.hook';
+
+interface AgencyAdminControlsMutationOptions
+    extends UseMutationOptions<AgencyAdminControls, unknown, Partial<AgencyAdminControls>> {
+    successMessageKey?: string | false;
+}
+
+export const useAgencyAdminControlsMutation = ({
+    successMessageKey = 'tenants.message.settingsUpdate',
+    ...options
+}: AgencyAdminControlsMutationOptions = {}) => {
+    const { t } = useTranslation();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: updateAgencyAdminControls,
+        ...options,
+        onSuccess: (responseData, updatedData, onMutateResult, context) => {
+            queryClient.setQueryData([AGENCY_ADMIN_CONTROLS_KEY], responseData);
+            if (successMessageKey !== false) {
+                notification.success({
+                    message: t(successMessageKey),
+                    duration: 3,
+                });
+            }
+            options?.onSuccess?.(responseData, updatedData, onMutateResult, context);
+        },
+    });
+};

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -319,10 +319,14 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
     };
 
     const renderFunctionalitiesSettings = () => (
-        <>
-            <h3 className={styles.backHeadline}>{t('settings.subhead.functionAccess')}</h3>
-            {agencyTenantId ? <PermissionsSettings tenantId={agencyTenantId} /> : null}
-        </>
+        <Row gutter={[20, 10]}>
+            <Col xs={12}>
+                <h3 className={styles.backHeadline}>{t('settings.subhead.functionAccess')}</h3>
+            </Col>
+            <Col xs={12}>
+                {id ? <PermissionsSettings mode="agency" agencyId={id} superAdminMode={isSuperAdmin} /> : null}
+            </Col>
+        </Row>
     );
 
     const renderLegacyFunctionalitiesSettings = () => (

--- a/src/pages/TenantSettings/PermissionsSettings/index.tsx
+++ b/src/pages/TenantSettings/PermissionsSettings/index.tsx
@@ -5,5 +5,10 @@ export const PermissionsSettingsPage = () => {
     const { tenantId, isSuperAdmin } = useUserRoles();
     const resolvedTenantId = tenantId && tenantId > 0 ? `${tenantId}` : '';
 
-    return <PermissionsSettings tenantId={resolvedTenantId} superAdminControlMode={isSuperAdmin} />;
+    return (
+        <PermissionsSettings
+            mode={isSuperAdmin ? 'superAdmin' : 'tenant'}
+            tenantId={resolvedTenantId}
+        />
+    );
 };

--- a/src/pages/Tenants/Edit/GlobalSettings/index.tsx
+++ b/src/pages/Tenants/Edit/GlobalSettings/index.tsx
@@ -16,7 +16,12 @@ export const TenantGlobalSettings = () => {
                     <p>{t('tenants.globalSettings.superAdminWarning.description')}</p>
                 </div>
                 <div className={styles.permissionsCardWrap}>
-                    <PermissionsSettings mode="tenant" tenantId={id || ''} superAdminMode />
+                    <PermissionsSettings
+                        mode="tenant"
+                        tenantId={id || ''}
+                        superAdminMode
+                        excludeCardKeys={['liveChat']}
+                    />
                 </div>
             </Col>
         </Row>

--- a/src/pages/Tenants/Edit/GlobalSettings/index.tsx
+++ b/src/pages/Tenants/Edit/GlobalSettings/index.tsx
@@ -16,7 +16,7 @@ export const TenantGlobalSettings = () => {
                     <p>{t('tenants.globalSettings.superAdminWarning.description')}</p>
                 </div>
                 <div className={styles.permissionsCardWrap}>
-                    <PermissionsSettings tenantId={id || ''} superAdminControlMode excludeCardKeys={['liveChat']} />
+                    <PermissionsSettings mode="tenant" tenantId={id || ''} superAdminMode />
                 </div>
             </Col>
         </Row>

--- a/src/types/AgencyAdminAllowedPermissionToggles.ts
+++ b/src/types/AgencyAdminAllowedPermissionToggles.ts
@@ -1,0 +1,5 @@
+import { PermissionToggleVisibility } from './PermissionToggleVisibility';
+
+export type AgencyAdminAllowedPermissionToggles = PermissionToggleVisibility & {
+    appearance?: boolean;
+};

--- a/src/types/AgencyAdminControls.ts
+++ b/src/types/AgencyAdminControls.ts
@@ -1,0 +1,6 @@
+import { AgencyAdminAllowedPermissionToggles } from './AgencyAdminAllowedPermissionToggles';
+
+export type AgencyAdminControls = {
+    permissionsPageEnabled?: boolean | null;
+    allowedPermissionToggles?: AgencyAdminAllowedPermissionToggles;
+};

--- a/src/types/AgencySettings.ts
+++ b/src/types/AgencySettings.ts
@@ -1,0 +1,35 @@
+import { AgencyAdminControls } from './AgencyAdminControls';
+
+export type AgencyFeatureSettings = {
+    featureAnonymousChatEnabled?: boolean;
+    featureGroupChatV2Enabled?: boolean;
+    featureCallsEnabled?: boolean;
+    featureSupervisionEnabled?: boolean;
+    featureSupervisionAnonymousChatsEnabled?: boolean;
+    featureSupervisionOneOnOneChatsEnabled?: boolean;
+    featureAudioCallsEnabled?: boolean;
+    featureAudioCallsAnonymousChatsEnabled?: boolean;
+    featureAudioCallsOneOnOneChatsEnabled?: boolean;
+    featureAudioCallsGroupChatsEnabled?: boolean;
+    featureAudioCallsSupervisionChatsEnabled?: boolean;
+    featureVideoCallsEnabled?: boolean;
+    featureVideoCallsAnonymousChatsEnabled?: boolean;
+    featureVideoCallsOneOnOneChatsEnabled?: boolean;
+    featureVideoCallsGroupChatsEnabled?: boolean;
+    featureVideoCallsSupervisionChatsEnabled?: boolean;
+    featureThreadsEnabled?: boolean;
+    featureThreadsAnonymousChatsEnabled?: boolean;
+    featureThreadsGroupChatsEnabled?: boolean;
+    featureThreadsOneOnOneEnabled?: boolean;
+    featureThreadsSupervisionChatsEnabled?: boolean;
+    featureVoiceMessagesEnabled?: boolean;
+    featureVoiceMessagesAnonymousChatsEnabled?: boolean;
+    featureVoiceMessagesOneOnOneChatsEnabled?: boolean;
+    featureVoiceMessagesGroupChatsEnabled?: boolean;
+    featureVoiceMessagesSupervisionChatsEnabled?: boolean;
+    agencyAdminControls?: AgencyAdminControls;
+};
+
+export type AgencyPermissionSettings = {
+    settings?: AgencyFeatureSettings;
+};

--- a/src/types/agency.d.ts
+++ b/src/types/agency.d.ts
@@ -1,5 +1,6 @@
 import { PostCodeRange } from '../api/agency/getAgencyPostCodeRange';
 import { CounsellingRelation } from '../enums/CounsellingRelation';
+import { AgencyFeatureSettings } from './AgencySettings';
 import { TopicData } from './topic';
 
 export interface AgencyDemographicsData {
@@ -59,4 +60,5 @@ export interface AgencyData {
     agencyLogo: string | null;
     tenantId: number;
     tenantName?: string;
+    settings?: AgencyFeatureSettings;
 }


### PR DESCRIPTION
## Fix: Implement platform, tenant, and agency permission settings (#107)

## Relates Issues: https://github.com/OpenResilienceInitiative/ORISO-Admin/issues/107

## Summary
- Add a three-mode `PermissionsSettings` router (`superAdmin`, `tenant`, `agency`) wired to tenant settings, global tenant settings, agency edit, and tenant permissions pages.
- Super admins manage platform controls via `tenantAdminControls` / `agencyAdminControls` APIs with dual-write on save; tenant and agency admins read/write effective settings through existing tenant/agency update flows.
- Introduce `superAdminMode` prop (passed from page level via `useUserRoles`) so super admins editing tenant/agency permissions bypass platform restrictions without calling `useUserRoles` inside the settings component.
- Fix permission toggles appearing disabled when `restrictedFields` is empty by enabling `editMode` on the permissions card (toggles auto-save) and disabling master-toggle sub-lock in `superAdminMode`.

## Testing
- As super admin, open Tenant Settings → Permissions and verify platform toggles save and persist after refresh.
- As super admin, open Tenants → Edit → Global Settings and verify all toggles are editable (`superAdminMode`) and save correctly.
- As super admin, open Agency → Edit → Funktionszugriff and verify toggles are editable and persist via agency update.
- As tenant admin, open Permissions and verify toggles restricted by `tenantAdminControls.allowedPermissionToggles` are disabled.
- As agency admin, open Funktionszugriff and verify toggles restricted by `agencyAdminControls.allowedPermissionToggles` are disabled.
- Toggle a permission on agency edit and confirm no unwanted `/postcoderanges` API call is made.
- Verify carousel scroll position is not reset when saving super-admin platform controls.
- Verify sub-toggles remain locked when master toggle is off for tenant/agency admins, but not in `superAdminMode`.

Uploading 2026-06-12 08-34-34.mp4…





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing and updating agency admin controls.
  * Expanded permissions settings to work in tenant, agency, and super admin modes.
  * Agency settings can now include feature configuration and admin control options.

* **Bug Fixes**
  * Improved permission settings behavior so changes save more reliably.
  * Fixed update handling so postcode ranges are only refreshed when provided.
  * Refined how online/offline status is sent to better match form input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->