### PR TITLE
fix: re-enable auth guards and remove debug bypasses

### DIFF
--- a/src/api/auth/getAccessToken.ts
+++ b/src/api/auth/getAccessToken.ts
@@ -12,10 +12,6 @@ const getKeycloakAccessToken = (loginProps: {
     new Promise((resolve, reject) => {
         const { username, password, otp, tryUnencryptedForEmail } = loginProps;
 
-        // console.log('🔍 getKeycloakAccessToken: loginEndpoint:', loginEndpoint);
-        // console.log('🔍 getKeycloakAccessToken: username:', username);
-        // console.log('🔍 getKeycloakAccessToken: tryUnencryptedForEmail:', tryUnencryptedForEmail);
-
         const dataBody = `username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}${
             otp ? `&otp=${otp}` : ``
         }&client_id=app&grant_type=password`;
@@ -31,18 +27,15 @@ const getKeycloakAccessToken = (loginProps: {
 
         fetch(req)
             .then((response) => {
-                // console.log('🔍 getKeycloakAccessToken: response status:', response.status);
                 if (response.status === 200) {
                     response
                         .json()
                         .then((dataResponse: LoginData) => {
-                            // console.log('🔍 getKeycloakAccessToken: SUCCESS - got tokens');
                             resolve(dataResponse);
                         })
                         .catch(reject);
                 } else if (response.status === 400) {
                     response.json().then((data) => {
-                        // console.log('🔍 getKeycloakAccessToken: 400 error:', data);
                         reject(
                             new FetchErrorWithOptions(FETCH_ERRORS.BAD_REQUEST, {
                                 data,
@@ -50,7 +43,6 @@ const getKeycloakAccessToken = (loginProps: {
                         );
                     });
                 } else if (response.status === 401) {
-                    // console.log('🔍 getKeycloakAccessToken: 401 error');
                     if (!tryUnencryptedForEmail) {
                         getKeycloakAccessToken({
                             ...loginProps,
@@ -62,12 +54,10 @@ const getKeycloakAccessToken = (loginProps: {
                         reject(FETCH_ERRORS.UNAUTHORIZED);
                     }
                 } else {
-                    // console.log('🔍 getKeycloakAccessToken: Other error status:', response.status);
                     reject(new Error('keycloakLogin'));
                 }
             })
             .catch(() => {
-                // console.log('🔍 getKeycloakAccessToken: Fetch error:', error);
                 reject(new Error('keycloakLogin'));
             });
     });

--- a/src/api/fetchData.ts
+++ b/src/api/fetchData.ts
@@ -157,11 +157,8 @@ export const fetchData = (props: FetchDataProps): Promise<any> =>
                                 : new Error(FETCH_ERRORS.CONFLICT),
                         );
                     } else if (response.status === 403) {
-                        // Temporarily disabled to allow admin pages to work while we fix role mapping
-                        // window.location.href = '/admin/access-denied';
-                        reject(new Error('403 Forbidden'));
-                    } else if (response.status === 401) {
-                        // console.log('🔍 fetchData: 401 Unauthorized - session expired, logging out');
+                        window.location.href = '/admin/access-denied';
+                    } else if (response.status === 401) {;
                         logout(true, routePathNames.login);
                         reject(new Error(FETCH_ERRORS.UNAUTHORIZED));
                     } else if (props.responseHandling.includes(FETCH_ERRORS.CATCH_ALL_SILENT)) {

--- a/src/components/Layout/ProtectedPageLayoutWrapper.tsx
+++ b/src/components/Layout/ProtectedPageLayoutWrapper.tsx
@@ -68,10 +68,7 @@ const ProtectedPageLayoutWrapper = ({ children }: any) => {
 
     useEffect(() => {
         if (subdomain !== tenantData.subdomain && !settings.multitenancyWithSingleDomainEnabled) {
-            // console.log('🔍 ProtectedPageLayoutWrapper: Subdomain mismatch, but not logging out for debugging');
-            // console.log('🔍 ProtectedPageLayoutWrapper: subdomain:', subdomain);
-            // console.log('🔍 ProtectedPageLayoutWrapper: tenantData.subdomain:', tenantData.subdomain);
-            // logout(true);
+            logout(true);
         }
     }, [subdomain, tenantData.subdomain]);
 


### PR DESCRIPTION
## What
- Re-enabled 403 Forbidden redirect to `/admin/access-denied` in `fetchData.ts`
- Re-enabled logout on expired refresh token in `auth.ts` (was silently swallowing expired sessions)
- Re-enabled subdomain mismatch logout in `ProtectedPageLayoutWrapper.tsx`
- Removed "temporarily relaxed validation for debugging" comment from `ProtectedRoute.tsx`
- Removed ~33 commented `console.log` debug statements across 4 auth files (`auth.ts`, `accessSessionCookie.ts`, `getAccessToken.ts`, `ProtectedRoute.tsx`)

## Why
Closes #136 — auth safety mechanisms were deliberately disabled with debugging comments, leaving users able to access protected admin pages after session expiry and across tenant subdomain mismatches.

## Test
- [ ] Log into admin panel, wait for token expiry — confirm redirect to login page
- [ ] Access an agency admin page with a non-matching subdomain — confirm logout occurs
- [ ] Confirm 403 response redirects to `/admin/access-denied` page
- [ ] Confirm no `console.log` output in browser console during normal auth flows