### PR TITLE
fix: add 30s default timeout to all fetchData requests

### DIFF
--- a/src/api/fetchData.ts
+++ b/src/api/fetchData.ts
@@ -100,9 +100,8 @@ export const fetchData = (props: FetchDataProps): Promise<any> =>
         const localDevelopmentHeader = isLocalDevelopment ? { [CSRF_WHITELIST_HEADER]: csrfToken } : null;
 
         const controller = new AbortController();
-        if (props.timeout) {
-            setTimeout(() => controller.abort(), props.timeout);
-        }
+        const timeoutMs = props.timeout ?? 30_000;
+        setTimeout(() => controller.abort(), timeoutMs);
         if (props.signal) {
             props.signal.addEventListener('abort', () => controller.abort());
         }


### PR DESCRIPTION
## What
- Added const timeoutMs = props.timeout ?? 30_000 default in src/api/fetchData.ts

## Why
Closes #143 — every API call in Admin that omits an explicit timeout could hang indefinitely. This covers all agency, tenant, counselor, topic and settings API calls. 30s default ensures requests fail with a timeout error instead of blocking the UI forever.

## Test
- [x] Throttle network in devtools, trigger any Admin API call — confirm it fails gracefully after ~30s rather than hanging