### PR TITLE
fix: resolve startup hang when getPublicTenantData has no slug

### DIFF
--- a/src/api/tenant/getPublicTenantData.ts
+++ b/src/api/tenant/getPublicTenantData.ts
@@ -44,8 +44,7 @@ const getPublicTenantData = (settings: AppConfigInterface) => {
             });
     }
 
-    // console.log('🔍 getPublicTenantData: No slug, returning empty promise');
-    return new Promise<any>(() => {});
+    return Promise.resolve(null);
 };
 
 export default getPublicTenantData;


### PR DESCRIPTION
## What
- Replaced return new Promise(() => {}) with return Promise.resolve(null) in src/api/tenant/getPublicTenantData.ts

## Why
Closes #142 — when no subdomain slug is available, the function returned a promise that never resolves or rejects. The startup sequence awaiting this call would hang forever, leaving the app blank with no error shown to the user.

## Test
- [ ] Access Admin with a URL that has no recognizable subdomain — confirm the app no longer hangs at startup