### PR TITLE
fix missing closing paren in addAgencyAdminData breaking typescript build

### DIFF
--- a/src/api/admins/addAgencyAdminData.ts
+++ b/src/api/admins/addAgencyAdminData.ts
@@ -72,5 +72,6 @@ export const addAgencyAdminData = (adminData: Record<string, any>): Promise<Admi
             return putAgenciesForAgencyAdmin(embeddedData.id, adminData.agencies?.map(({ value }) => value) || [])
                 .then(() => embeddedData)
                 .catch(() => ({ ...embeddedData, agencyAssignmentFailed: true }));
-        });
+        })
+    );
 };

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1408,7 +1408,7 @@
     "theme.builder.preview.recipient": "A. Kräger",
     "theme.builder.preview.error": "Beispielhinweis im Fehlerfarbton",
     "theme.builder.preview.inputPlaceholder": "Nachricht an Ratsuchende:r schreiben",
-    "theme.builder.preview.send": "Senden"
+    "theme.builder.preview.send": "Senden",
     "twoFactorAuth.switch.type.EMAIL": "E-Mail",
     "twoFactorAuth.switch.type.label": "Ihr 2. Faktor",
     "twoFactorAuth.title": "Zwei-Faktor-Authentifizierung",


### PR DESCRIPTION
## What
- Added missing `)` to close the `return (` expression in `addAgencyAdminData.ts`
- The `.then()` chain was correctly closed with `})` but the outer parenthesised `return (` had no matching `)`

## Why
Closes #154 — this syntax error (`TS1005: ')' expected` at line 75) was introduced in commit `6237dbb` (PR #153 merge) and is currently **blocking the TypeScript build and failing CI on every open PR** in the repo.

## Test
- [ ] CI passes on this PR
- [ ] `tsc` compiles clean locally