### PR TITLE
deduplicate hal response parsing into shared utility

### DIFF
--- a/src/api/admins/addAgencyAdminData.ts
+++ b/src/api/admins/addAgencyAdminData.ts
@@ -33,7 +33,7 @@ export const addAgencyAdminData = (adminData: Record<string, any>): Promise<Admi
             }),
         })
             .then(parseHalResponse)
-            .then((data: AdminData | { _embedded: AdminData } | null) => {
+            .then((data: unknown) => {
                 let embeddedData: AdminData | null = data as AdminData | null;
                 if (data && typeof data === 'object' && '_embedded' in data) {
                     // eslint-disable-next-line no-underscore-dangle

--- a/src/api/admins/addAgencyAdminData.ts
+++ b/src/api/admins/addAgencyAdminData.ts
@@ -2,6 +2,7 @@ import { FETCH_ERRORS, FETCH_METHODS, fetchData } from '../fetchData';
 import { agencyAdminEndpoint } from '../../appConfig';
 import { AdminData } from '../../types/admin';
 import { putAgenciesForAgencyAdmin } from '../agency/putAgenciesForAdmin';
+import { parseHalResponse } from '../../utils/parseHalResponse';
 
 /**
  * add new admin
@@ -10,29 +11,6 @@ import { putAgenciesForAgencyAdmin } from '../agency/putAgenciesForAdmin';
  */
 export const addAgencyAdminData = (adminData: Record<string, any>): Promise<AdminData> => {
     const { firstname, lastname, email, username, twoFactorAuth, tenantId, password } = adminData;
-    const parseSuccessfulResponse = async (response: unknown) => {
-        if (!(response instanceof Response)) {
-            return response;
-        }
-
-        if (response.status === 204) {
-            return null;
-        }
-
-        const contentType = response.headers.get('content-type') || '';
-        // The backend returns HAL responses (application/hal+json), so match any JSON content type
-        // rather than the exact "application/json".
-        if (!contentType.includes('json')) {
-            return null;
-        }
-
-        const rawBody = await response.clone().text();
-        if (!rawBody.trim()) {
-            return null;
-        }
-
-        return JSON.parse(rawBody);
-    };
 
     return (
         fetchData({
@@ -54,7 +32,7 @@ export const addAgencyAdminData = (adminData: Record<string, any>): Promise<Admi
                 ...(password ? { password } : {}),
             }),
         })
-            .then(parseSuccessfulResponse)
+            .then(parseHalResponse)
             .then((data: AdminData | { _embedded: AdminData } | null) => {
                 let embeddedData: AdminData | null = data as AdminData | null;
                 if (data && typeof data === 'object' && '_embedded' in data) {

--- a/src/api/admins/editAgencyAdminData.ts
+++ b/src/api/admins/editAgencyAdminData.ts
@@ -30,12 +30,7 @@ export const editAgencyAdminData = async (id: string, formData: AdminData): Prom
                 twoFactorAuth,
             }),
         })
-            .then((response) => {
-                if (response.status === 200) {
-                    return response.json();
-                }
-                return response.json();
-            })
+            .then((response) => response.json())
             // eslint-disable-next-line no-underscore-dangle
             .then((data: { _embedded: CounselorData }) => data?._embedded)
     );

--- a/src/api/counselor/addCounselorData.ts
+++ b/src/api/counselor/addCounselorData.ts
@@ -62,12 +62,7 @@ export const addCounselorData = (counselorData: Record<string, any>): Promise<Co
             ],
             bodyData: JSON.stringify(strippedCounselor),
         })
-            .then((response) => {
-                if (response.status === 200) {
-                    return response.json();
-                }
-                return response.json();
-            })
+            .then((response) => response.json())
             // eslint-disable-next-line no-underscore-dangle
             .then((data: { _embedded: CounselorData }) => data?._embedded)
             .then((data) => {

--- a/src/hooks/useAddOrUpdateTenantAdmin.hook.ts
+++ b/src/hooks/useAddOrUpdateTenantAdmin.hook.ts
@@ -4,6 +4,7 @@ import { tenantAdminsEndpoint } from '../appConfig';
 import { CounselorData } from '../types/counselor';
 import { TENANT_QUERY_KEY } from './useSingleTenantData';
 import { TENANT_ADMIN_QUERY_KEY, TENANT_ADMINS_QUERY_KEY, useTenantUserAdminData } from './useTenantUserAdminData';
+import { parseHalResponse } from '../utils/parseHalResponse';
 
 interface UseAddOrUpdateTenantAdminOptions
     extends UseMutationOptions<CounselorData, Error, CounselorData, Error | Response> {
@@ -13,29 +14,6 @@ interface UseAddOrUpdateTenantAdminOptions
 export const useAddOrUpdateTenantAdmin = ({ id, ...options }: UseAddOrUpdateTenantAdminOptions) => {
     const queryClient = useQueryClient();
     const { data } = useTenantUserAdminData({ id, enabled: !!id && id !== 'add' });
-
-    const normalizeSuccessfulResponse = async (response: unknown) => {
-        if (response instanceof Response) {
-            if (response.status === 204) {
-                return null;
-            }
-
-            const contentType = response.headers.get('content-type') || '';
-            // The backend returns HAL responses (application/hal+json), so match any JSON content
-            // type rather than the exact "application/json".
-            if (!contentType.includes('json')) {
-                return null;
-            }
-
-            const textBody = await response.clone().text();
-            if (!textBody.trim()) {
-                return null;
-            }
-
-            return JSON.parse(textBody);
-        }
-        return response;
-    };
 
     return useMutation(
         async (formData) => {
@@ -63,7 +41,7 @@ export const useAddOrUpdateTenantAdmin = ({ id, ...options }: UseAddOrUpdateTena
                 bodyData,
             });
 
-            const normalizedResponse = await normalizeSuccessfulResponse(response);
+            const normalizedResponse = await parseHalResponse(response);
             if (normalizedResponse && typeof normalizedResponse === 'object' && '_embedded' in normalizedResponse) {
                 // eslint-disable-next-line no-underscore-dangle
                 const embeddedData = (normalizedResponse as { _embedded: CounselorData })._embedded;

--- a/src/utils/parseHalResponse.ts
+++ b/src/utils/parseHalResponse.ts
@@ -1,0 +1,28 @@
+/**
+ * Parses a HAL+JSON response from the backend.
+ * Returns null for 204 No Content, non-JSON, or empty body.
+ * Returns the parsed JSON object otherwise.
+ * Pass-through for non-Response values (e.g. pre-parsed objects from fetchData).
+ */
+export const parseHalResponse = async (response: unknown): Promise<unknown> => {
+    if (!(response instanceof Response)) {
+        return response;
+    }
+
+    if (response.status === 204) {
+        return null;
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    // Backend returns HAL responses (application/hal+json) — match any JSON content type.
+    if (!contentType.includes('json')) {
+        return null;
+    }
+
+    const rawBody = await response.clone().text();
+    if (!rawBody.trim()) {
+        return null;
+    }
+
+    return JSON.parse(rawBody);
+};


### PR DESCRIPTION
## What
- Extracted repeated HAL response parsing into a shared utility
- Removed pointless if-else blocks with identical branches

## Why
Closes #162 - copy-paste in HAL parsing means bugs get fixed in one place but missed in others.

## Test
- [ ] Agency/consultant list pages load correctly
- [ ] HAL-paginated API responses still parsed as expected