### PR TITLE
remove dead rocket.chat auth headers from fetchdata

### DIFF
--- a/src/api/fetchData.ts
+++ b/src/api/fetchData.ts
@@ -66,7 +66,6 @@ interface FetchDataProps {
     url: string;
     method: string;
     headersData?: object;
-    rcValidation?: boolean;
     bodyData?: string;
     skipAuth?: boolean;
     responseHandling?: string[];
@@ -91,13 +90,6 @@ export const fetchData = (props: FetchDataProps): Promise<any> =>
 
         const csrfToken = generateCsrfToken();
 
-        const rcHeaders = props.rcValidation
-            ? {
-                  rcToken: getValueFromCookie('rc_token'),
-                  rcUserId: getValueFromCookie('rc_uid'),
-              }
-            : null;
-
         const localDevelopmentHeader = isLocalDevelopment ? { [CSRF_WHITELIST_HEADER]: csrfToken } : null;
 
         const controller = new AbortController();
@@ -121,7 +113,6 @@ export const fetchData = (props: FetchDataProps): Promise<any> =>
                 ...authorization,
                 'X-CSRF-TOKEN': csrfToken,
                 ...otherHeadersData,
-                ...rcHeaders,
                 ...localDevelopmentHeader,
             },
             credentials: 'include',


### PR DESCRIPTION
## What
- Removed rcToken/rcUserId headers from the central fetchData function

## Why
Closes #163 - RC auth headers are dead after the Matrix migration. Sending them on every request is noise and leaks legacy credential field names.

## Test
- [ ] All API calls still work (headers were ignored by backend already)
- [ ] No TypeScript errors