### PR TITLE
feat(users): enable sorting by username in user management tables

### DIFF
--- a/src/pages/users/management/useUserTableColumns.tsx
+++ b/src/pages/users/management/useUserTableColumns.tsx
@@ -27,6 +27,7 @@ const SORT_FIELD_BY_COLUMN: Partial<Record<UserTableColumnKey, string>> = {
     lastname: 'LASTNAME',
     firstname: 'FIRSTNAME',
     email: 'EMAIL',
+    username: 'USERNAME',
     tenantOrgName: 'NAME',
 };
 

--- a/src/pages/users/management/userTableConfigs.ts
+++ b/src/pages/users/management/userTableConfigs.ts
@@ -58,7 +58,7 @@ const baseIdentityColumns = (): UserTableColumnConfig[] => [
     col('lastname', true, true, 130),
     col('firstname', true, true, 120),
     col('email', true, true, 150),
-    col('username', true, false, 150),
+    col('username', true, true, 150),
 ];
 
 const tenantAdminIdentityColumns = (): UserTableColumnConfig[] => [


### PR DESCRIPTION
## What

Makes the **Username** column in the user management tables (Consultants & Agency Admins) sortable—previously, only First Name, Last Name, and Email supported sorting.

## Why / Background

The starting point was the Agency Admins page (`/admin/users/agency-admins`): sorting was missing for Username, Status, and Counseling Centers. After checking the backend, **only Username** is cleanly sortable server-side:

- **Agency Admins:** The `Admin` entity has `@SortableField` on `username`, and `Sort.FieldEnum` includes `USERNAME` (Lucene/Hibernate Search).
- **Consultants:** `username` is a sortable `Consultant` property (JPA).

Deliberately **not** implemented:
- **Status** – No status dimension exists for Agency Admins (no DB field, hard delete only, no activate/deactivate); sorting would be meaningless.
- **Counseling Centers** – Many-to-many relationship, and the agency *name* is not available in the `UserService` (`AdminAgency` only has `agencyId`); would require index denormalization + reindexing.

Tenant/Platform Admins remain unchanged (their search backend does not support `USERNAME`—only `FIRSTNAME`, `LASTNAME`, `EMAIL`, `TENANT_ID`, `UPDATE_DATE`).

## Change

- `userTableConfigs.ts`: Set `sortable: true` for the `username` column in `baseIdentityColumns()`.
- `useUserTableColumns.tsx`: Added `username: 'USERNAME'` to the `SORT_FIELD_BY_COLUMN` mapping.

## Test

- `tsc --noEmit`: No new errors caused by this change (the only TS errors in the checkout relate to unrelated missing `@tiptap/*` dependencies in `TipTapField.tsx`).
- Manual verification: Check for the sort arrow on the "Username" column on the Agency Admins and Consultants pages. 

## Summary by CodeRabbit

* **New Features** 
* Username column in the user management table is now sortable, allowing users to organize the user list by username.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->