### PR TITLE
fix(admin): keep agency menu and create button for mixed-role admins

### DIFF
--- a/src/components/Layout/ProtectedPageLayoutWrapper.tsx
+++ b/src/components/Layout/ProtectedPageLayoutWrapper.tsx
@@ -144,17 +144,18 @@ const ProtectedPageLayoutWrapper = ({ children }: any) => {
                                 </li>
                             )}
 
-                            {can(PermissionAction.Read, Resource.Agency) && !hasRole(UserRole.RestrictedAgencyAdmin) && (
-                                <li className="menuItem">
-                                    <NavLink
-                                        to={routePathNames.agency}
-                                        className={classNames({ active: checkActive(routePathNames.agency) })}
-                                    >
-                                        <NavIcon path={routePathNames.agency} />
-                                        <span lang={navLanguage}>{navLabel('sidebar.agency', 'agency')}</span>
-                                    </NavLink>
-                                </li>
-                            )}
+                            {can(PermissionAction.Read, Resource.Agency) &&
+                                (hasRole(UserRole.AgencyAdmin) || !hasRole(UserRole.RestrictedAgencyAdmin)) && (
+                                    <li className="menuItem">
+                                        <NavLink
+                                            to={routePathNames.agency}
+                                            className={classNames({ active: checkActive(routePathNames.agency) })}
+                                        >
+                                            <NavIcon path={routePathNames.agency} />
+                                            <span lang={navLanguage}>{navLabel('sidebar.agency', 'agency')}</span>
+                                        </NavLink>
+                                    </li>
+                                )}
 
                             {(can(PermissionAction.Read, Resource.Consultant) ||
                                 can(PermissionAction.Read, Resource.AgencyAdminUser) ||

--- a/src/constants/userRolesToPermissions.ts
+++ b/src/constants/userRolesToPermissions.ts
@@ -5,12 +5,18 @@ import { useTenantData } from '../hooks/useTenantData.hook';
 import { useUserRoles } from '../hooks/useUserRoles.hook';
 import { UserPermissions } from '../types/UserPermission';
 
+// Roles are merged in this order; later entries override earlier ones (lodash.merge).
+// RestrictedAgencyAdmin only NARROWS agency permissions (no create/delete), so it must
+// have the LOWEST precedence: when an account also holds a broader role such as
+// AgencyAdmin or TenantAdmin, that broader grant must win. Keeping it first means a
+// mixed-role platform admin (e.g. agency-admin + restricted-agency-admin) is not
+// silently downgraded to read/update-only.
 const rolesPriority: UserRole[] = [
+    UserRole.RestrictedAgencyAdmin,
     UserRole.AgencyAdmin,
     UserRole.TopicAdmin,
     UserRole.UserAdmin,
     UserRole.SingleTenantAdmin,
-    UserRole.RestrictedAgencyAdmin,
     UserRole.TenantAdmin,
 ];
 


### PR DESCRIPTION
## Problem
On PreDev the platform admin (`chucknorris`) could no longer see the **Beratungsstellen** (agency) menu in the admin panel, nor create agencies. On oriso.org it still works.

## Root cause
The PreDev admin account holds **both** `agency-admin` **and** `restricted-agency-admin` (the latter was granted on 2026-06-23 for the agency-admin-creation realm-role fix). oriso.org's admin only has `agency-admin`. Two latent issues are triggered by that combination:

1. **Menu hidden** — the sidebar item was gated by `!hasRole(RestrictedAgencyAdmin)` (introduced 2026-06-05), so *any* account with the restricted role loses the agency menu, even a full agency-admin.
2. **"New" button hidden** — `rolesPriority` merged `restricted-agency-admin` **after** `agency-admin`, so its narrower grant (`create:false, delete:false`) overrode the full role via `lodash.merge`, making `can(Create, Agency)` false.

## Fix
- Show the agency menu when the account is a full `agency-admin`, even if it also has `restricted-agency-admin`.
- Move `restricted-agency-admin` to the **lowest** merge precedence so a broader role's grants win. A restricted-only admin is unaffected.

## Verification
- `tsc --noEmit` clean on changed files; eslint clean.
- Backend `GET /agencyadmin/agencies` returns 12 agencies for this account (200); create flow endpoints (`/topic/`, `/tenantadmin/search`) return 200; `useConsultingTypesForAgencies` is off so the 403-ing dioceses call is not made.
- Restores parity with oriso.org for mixed-role/platform admins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated role handling so broader admin roles can take precedence when users have multiple roles.
  * Restored visibility of the Agency menu item for Agency Admin users who were previously hidden by restricted-role logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->