### PR TITLE
Fix(admin): load runtime env.js from base path so admin login works

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 
         <title>Online-Beratung Admin</title>
         <!-- Vite prefixes the base path (dev: devHtml transform, build: public asset rewrite) -->
-        <script src="/env.js"></script>
+        <script src="%BASE_URL%/env.js"></script>
         <script>
             const global = globalThis;
         </script>


### PR DESCRIPTION
## Problem
After the recent merge, **nobody can log in at https://admin.oriso.org/admin/login**.

Root cause: the admin SPA is a Vite app served under base path `/admin/`. `index.html` loaded the runtime config with:

```html
<script src="/env.js"></script>   <!-- absolute ROOT path -->
```

But nginx serves `.js` files literally from the web root, while the container entrypoint writes the runtime config to `/usr/share/nginx/html/admin/env.js`. So:

1. `GET /env.js` → **404** (`open() ".../html/env.js" failed` in nginx log)
2. `window.__APP_CONFIG__` is never defined → SPA has no API/Keycloak URL
3. the login request falls back to a relative URL and hits the admin origin → **405** (`POST /auth/realms/online-beratung/.../token` on `admin.oriso.org`)
4. → login impossible

This was a regression: the working version referenced `%BASE_URL%/env.js` (compare the still-present `manifest.json` link), which a prior change replaced with the bare `/env.js`.

## Fix
Restore the base-aware reference so it builds to `/admin/env.js`, where the entrypoint actually writes the file:

```diff
-        <script src="/env.js"></script>
+        <script src="%BASE_URL%/env.js"></script>
```

One line, no behavior change beyond the path.

## Verified on the live cluster
- Keycloak password grant for the admin user: **HTTP 200**, valid token, all admin roles present.
- CORS: `access-control-allow-origin: https://admin.oriso.org` correct.
- The only failure is the `/env.js` 404 → confirmed in the nginx access log, including real failed login attempts.

## Deploy note
Merging builds a fresh `oriso-admin:dev` image. The cluster pins the image by digest and is upgraded manually, so a deploy step (point the `oriso-admin` deployment at the new build) is required after merge for the fix to reach production.