### PR TITLE
[codex] Fix agency tenant assignment on create

### DIFF
--- a/src/api/agency/addAgencyData.test.ts
+++ b/src/api/agency/addAgencyData.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAgencyTenantId } from './addAgencyData';
+
+describe('resolveAgencyTenantId', () => {
+    it('prefers the explicitly selected tenant from the agency form', () => {
+        expect(resolveAgencyTenantId('42', 7)).toBe(42);
+    });
+
+    it('falls back to a tenant-admin token tenant', () => {
+        expect(resolveAgencyTenantId(undefined, '7')).toBe(7);
+    });
+
+    it('rejects the super-admin tenant 0 when no tenant was selected', () => {
+        expect(resolveAgencyTenantId(undefined, 0)).toBeUndefined();
+    });
+
+    it('rejects missing tenant context when no tenant was selected', () => {
+        expect(resolveAgencyTenantId(undefined, undefined)).toBeUndefined();
+    });
+
+    it('rejects explicit tenant 0 even when provided as a string', () => {
+        expect(resolveAgencyTenantId('0', 0)).toBeUndefined();
+    });
+});

--- a/src/api/agency/addAgencyData.ts
+++ b/src/api/agency/addAgencyData.ts
@@ -56,6 +56,22 @@ async function createAgency(agencyDataRequestBody: string) {
     });
 }
 
+export function resolveAgencyTenantId(selectedTenantIdValue: unknown, tokenTenantIdValue: unknown): number | undefined {
+    const selectedTenantId = Number(selectedTenantIdValue);
+
+    if (Number.isFinite(selectedTenantId) && selectedTenantId > 0) {
+        return selectedTenantId;
+    }
+
+    const tokenTenantId = Number(tokenTenantIdValue);
+
+    if (Number.isFinite(tokenTenantId) && tokenTenantId > 0) {
+        return tokenTenantId;
+    }
+
+    return undefined;
+}
+
 /**
  * add new agency
  * @param agencyData
@@ -64,9 +80,12 @@ async function createAgency(agencyDataRequestBody: string) {
 async function addAgencyData(agencyData: Record<string, any>) {
     // Prefer explicitly selected tenant from form (superadmin flow).
     // Fallback to JWT tenant for tenant-admin users.
-    const { tenantId: tokenTenantId = 1 } = parseUserAuthInfo();
-    const selectedTenantId = Number(agencyData?.tenantId);
-    const tenantId = Number.isFinite(selectedTenantId) && selectedTenantId > 0 ? selectedTenantId : tokenTenantId;
+    const { tenantId: tokenTenantId } = parseUserAuthInfo();
+    const tenantId = resolveAgencyTenantId(agencyData?.tenantId, tokenTenantId);
+
+    if (!tenantId) {
+        throw new Error('A valid tenantId is required to create an agency.');
+    }
 
     const consultingTypeId =
         agencyData.consultingType !== null && agencyData.consultingType !== undefined

--- a/src/pages/Agency/Edit/index.test.tsx
+++ b/src/pages/Agency/Edit/index.test.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AgencyPageEdit } from './index';
+
+const mocks = vi.hoisted(() => ({
+    mutate: vi.fn(),
+    navigate: vi.fn(),
+    searchTenantData: vi.fn(),
+}));
+
+const translations: Record<string, string> = {
+    'agency.edit.general.headline': 'Zur Übersicht',
+    'agency.edit.settings.general.title': 'Allgemeine Informationen',
+    'agency.edit.general.general_information': 'Allgemeine Informationen',
+    'agency.edit.general.general_information.name': 'Name',
+    'agency.edit.general.general_information.description': 'Beschreibung',
+    'agency.edit.general.address.postcode': 'PLZ',
+    'agency.edit.general.address.city': 'Stadt',
+    'agency.edit.settings.title': 'Einstellungen zum Beratungsangebot',
+    'agency.edit.general.more_settings.tenant.title': 'Trägerzuordnung',
+    'agency.form.registrationSettings.title': 'Sichtbarkeit in der Registrierung',
+    'agency.form.registrationSettings.onlineWarning': 'Beratungsstelle sichtbar machen',
+    'agency.form.registrationSettings.onlineDescription': 'Sichtbar stellen',
+    'agency.form.registrationSettings.postCodeTitle': 'Für welches Gebiet ist die Beratungsstelle sichtbar?',
+    'agency.form.registrationSettings.allPostCode': 'Für alle PLZ-Gebiete',
+    'agency.form.registrationSettings.onlySelectedPostCodes': 'PLZ-Gebiete definieren',
+    'agency.postcode.minimum': 'Die PLZ muss aus 5 Zahlen bestehen.',
+    'btn.cancel': 'Abbrechen',
+    'form.errors.required': 'Bitte füllen Sie das markierte Feld aus.',
+    plsSelect: 'Bitte wählen',
+    save: 'Speichern',
+};
+
+const t = (key: string) => translations[key] || key;
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => Object.assign([t], { t, i18n: { language: 'de' } }),
+}));
+
+vi.mock('react-router', async () => {
+    const actual = await vi.importActual<typeof import('react-router')>('react-router');
+    return {
+        ...actual,
+        useNavigate: () => mocks.navigate,
+        useParams: () => ({ id: 'add' }),
+    };
+});
+
+vi.mock('../../../components/Page', () => {
+    const Page = ({ children, isLoading }: { children: React.ReactNode; isLoading?: boolean }) => (
+        <div data-testid="page">{isLoading ? 'loading' : children}</div>
+    );
+    Page.BackWithActions = function PageBackWithActions({
+        children,
+        title,
+    }: {
+        children: React.ReactNode;
+        title?: React.ReactNode;
+    }) {
+        return (
+            <div>
+                <h1>{title}</h1>
+                {children}
+            </div>
+        );
+    };
+    return { Page };
+});
+
+vi.mock('../../../components/Card', () => ({
+    Card: function Card({ children, titleKey }: { children: React.ReactNode; titleKey: string }) {
+        return (
+            <section>
+                <h2>{t(titleKey)}</h2>
+                {children}
+            </section>
+        );
+    },
+}));
+
+vi.mock('../../../components/CardEditable', () => ({
+    CardEditable: function CardEditable({ children }: { children: React.ReactNode }) {
+        return <div>{children}</div>;
+    },
+}));
+
+vi.mock('../../../components/Tenants/AppSettings/PermissionsSettings', () => ({
+    PermissionsSettings: () => <div />,
+}));
+
+vi.mock('../../../components/Tenants/LegalSettings/components/DataProcessingAgreement', () => ({
+    DataProcessingAgreement: () => <div />,
+}));
+
+vi.mock('../../../context/FeatureContext', () => ({
+    useFeatureContext: () => ({ isEnabled: () => false }),
+}));
+
+vi.mock('../../../hooks/useReleasesToggle.hook', () => ({
+    useReleasesToggle: () => ({ isEnabled: () => false }),
+}));
+
+vi.mock('../../../hooks/useAgencyData', () => ({
+    useAgencyData: () => ({ data: undefined, isLoading: false }),
+}));
+
+vi.mock('../../../hooks/useAgencyPostCodesData', () => ({
+    useAgencyPostCodesData: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('../../../hooks/useAgencyUpdate', () => ({
+    useAgencyUpdate: () => ({ mutate: mocks.mutate }),
+}));
+
+vi.mock('../../../hooks/useAgencyLegalDataMissing', () => ({
+    useAgencyLegalDataMissing: () => false,
+}));
+
+vi.mock('../../../hooks/useAgencyHasConsultants', () => ({
+    useAgencyHasConsultants: () => ({ data: false, isLoading: false }),
+}));
+
+vi.mock('../../../hooks/useTenantTopics', () => ({
+    useTenantTopics: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock('../../../hooks/useUserRoles.hook', () => ({
+    useUserRoles: () => ({
+        hasRole: () => true,
+        isSuperAdmin: true,
+        isTechnicalAccount: false,
+        isTenantScopedAdmin: false,
+        roles: [],
+        tenantId: 0,
+    }),
+}));
+
+vi.mock('../../../api/tenant/searchTenantData', () => ({
+    searchTenantData: mocks.searchTenantData,
+}));
+
+describe('AgencyPageEdit create flow', () => {
+    beforeAll(() => {
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: vi.fn().mockImplementation((query: string) => ({
+                addEventListener: vi.fn(),
+                addListener: vi.fn(),
+                dispatchEvent: vi.fn(),
+                matches: false,
+                media: query,
+                onchange: null,
+                removeEventListener: vi.fn(),
+                removeListener: vi.fn(),
+            })),
+        });
+    });
+
+    beforeEach(() => {
+        mocks.mutate.mockReset();
+        mocks.navigate.mockReset();
+        mocks.searchTenantData.mockReset();
+        mocks.searchTenantData.mockResolvedValue({
+            data: [{ id: 7, name: 'Caritas Augsburg' }],
+        });
+    });
+
+    it('renders the tenant assignment field for super-admin agency creation', async () => {
+        render(<AgencyPageEdit />);
+
+        expect(await screen.findByText('Trägerzuordnung')).toBeInTheDocument();
+        expect(mocks.searchTenantData).toHaveBeenCalledWith({ perPage: 1000 });
+    });
+
+    it('does not submit a new agency without a selected tenant', async () => {
+        const user = userEvent.setup();
+        render(<AgencyPageEdit />);
+
+        fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'Neue Beratungsstelle' } });
+        fireEvent.change(screen.getByPlaceholderText('PLZ'), { target: { value: '86161' } });
+        fireEvent.change(screen.getByPlaceholderText('Stadt'), { target: { value: 'Augsburg' } });
+        await user.click(screen.getByRole('button', { name: 'Speichern' }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Bitte füllen Sie das markierte Feld aus.')).toBeInTheDocument();
+        });
+        expect(mocks.mutate).not.toHaveBeenCalled();
+    });
+});

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -27,6 +27,7 @@ import { DataProcessingAgreement } from '../../../components/Tenants/LegalSettin
 import styles from '../../../components/Page/styles.module.scss';
 import { CardEditable } from '../../../components/CardEditable';
 import { PermissionsSettings } from '../../../components/Tenants/AppSettings/PermissionsSettings';
+import { useUserRoles } from '../../../hooks/useUserRoles.hook';
 
 function hasOnlyDefaultRangeDefined(data: PostCodeRange[]) {
     return data?.length === 0 || (data?.length === 1 && data[0].from === '00000' && data[0].until === '99999');
@@ -67,6 +68,7 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
     const { data: postCodes, isLoading: isLoadingPostCodes } = useAgencyPostCodesData({ id });
     const { isEnabled } = useFeatureContext();
     const { isEnabled: isReleaseToggleEnabled } = useReleasesToggle();
+    const { isSuperAdmin } = useUserRoles();
     const [form] = Form.useForm();
     const { mutate } = useAgencyUpdate(id);
     const legalDataMissing = useAgencyLegalDataMissing(agencyData);
@@ -168,6 +170,23 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
         (formData) => {
             setSubmitted(true);
 
+            const selectedTenantId = Number(formData?.tenantId);
+            if (isSuperAdmin && (!Number.isFinite(selectedTenantId) || selectedTenantId <= 0)) {
+                form.setFields([
+                    {
+                        name: 'tenantId',
+                        errors: [t('form.errors.required')],
+                    },
+                ]);
+                notification.error({
+                    message: t('agency.edit.general.more_settings.tenant.title'),
+                    description: t('form.errors.required'),
+                    duration: 5,
+                });
+                setSubmitted(false);
+                return;
+            }
+
             mutate(buildAgencyUpdateData(formData), {
                 onError: () => {
                     setSubmitted(false);
@@ -184,7 +203,7 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
                 },
             });
         },
-        [buildAgencyUpdateData, isEditing, mutate, navigate, t],
+        [buildAgencyUpdateData, form, isEditing, isSuperAdmin, mutate, navigate, t],
     );
 
     const onSaveCard = useCallback(
@@ -272,6 +291,9 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
                     <Col xs={12} lg={6}>
                         <AgencyGeneralInformation />
                         <RegistrationSettings consultingTypeId={agencyData?.consultingType} />
+                    </Col>
+                    <Col xs={12} lg={6}>
+                        <AgencySettings isEditMode={isEditing} />
                     </Col>
                 </Row>
             </Form>


### PR DESCRIPTION
## Problem
Super-admins could open the agency creation flow without seeing the tenant assignment field. Submitting that flow could resolve to tenant `0` or a silent fallback instead of requiring an explicit tenant, which could create invalid agency records or trigger auth/API failures.

## Solution
- Restore the existing agency settings section in the create form so super-admins see the tenant assignment control.
- Block super-admin submits when no positive tenant id is selected.
- Harden the create API helper so tenant `0`, missing tenant context, and invalid tenant values never proceed to the agency POST.
- Add focused component and API tests for the regression and guard behavior.

## Tracking
Tracked in #193.

## Validation
- `npx eslint src/api/agency/addAgencyData.ts src/pages/Agency/Edit/index.tsx src/api/agency/addAgencyData.test.ts src/pages/Agency/Edit/index.test.tsx`
- `npm test` (5 files, 16 tests)
- `npm run build`
- Local browser smoke: `http://127.0.0.1:9002/admin/agency/add` redirects to login without an active admin session, as expected.
- GitHub CI: passing.
- CodeRabbit: passing/skipped.

## Remaining risk
The live super-admin flow still needs an authenticated manual check before production deploy, because local browser verification cannot pass the protected route without a valid admin session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
