### PR TITLE
fix(admin): self-heal 401 with token refresh + retry instead of forced logout

### DIFF
--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -75,6 +75,47 @@ const refreshTokens = (): Promise<void> => {
     );
 };
 
+let inflightTokenRefresh: Promise<boolean> | null = null;
+
+/**
+ * Refresh the access/refresh token via the BFF and repopulate the in-memory token
+ * store. Concurrent callers share a single in-flight refresh. Resolves to `true`
+ * when a fresh token was obtained, `false` otherwise (e.g. the refresh token is
+ * gone or already expired). Unlike {@link refreshTokens} this never logs the user
+ * out by itself — the caller decides what to do on failure. Used by fetchData to
+ * self-heal a single 401 (lapsed/empty access token) before forcing a logout.
+ */
+export const tryRefreshAccessToken = (): Promise<boolean> => {
+    if (inflightTokenRefresh) {
+        return inflightTokenRefresh;
+    }
+
+    inflightTokenRefresh = refreshAuthTokensViaBff()
+        .then((response) => {
+            if (!response?.access_token || !response.refresh_token) {
+                return false;
+            }
+
+            setSessionTokens(response.access_token, response.refresh_token);
+            setTokenExpiryInLocalStorage(
+                'auth.access_token_valid_until',
+                resolveExpiresInSeconds(response.access_token, response.expires_in),
+            );
+            setTokenExpiryInLocalStorage(
+                'auth.refresh_token_valid_until',
+                resolveExpiresInSeconds(response.refresh_token, response.refresh_expires_in),
+            );
+
+            return true;
+        })
+        .catch(() => false)
+        .finally(() => {
+            inflightTokenRefresh = null;
+        });
+
+    return inflightTokenRefresh;
+};
+
 const startTimers = ({
     accessTokenValidInMs,
     refreshTokenValidInMs,

--- a/src/api/fetchData.test.ts
+++ b/src/api/fetchData.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+// Node env: fetch/Request/AbortController all come from the same realm, avoiding
+// the jsdom-vs-undici "signal is not an AbortSignal" mismatch. No DOM is needed here.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// fetchData statically pulls in antd / i18next / appConfig / auth side effects.
+// Stub them so the unit stays focused on the self-healing 401 retry flow and we
+// can drive tryRefreshAccessToken / logout deterministically.
+const tryRefreshAccessToken = vi.fn();
+const getAccessTokenForRequests = vi.fn(() => 'access-token');
+vi.mock('./auth/auth', () => ({
+    getAccessTokenForRequests: () => getAccessTokenForRequests(),
+    tryRefreshAccessToken: () => tryRefreshAccessToken(),
+}));
+
+const logout = vi.fn();
+vi.mock('./auth/logout', () => ({ default: (...args: unknown[]) => logout(...args) }));
+
+vi.mock('./auth/accessSessionCookie', () => ({ getValueFromCookie: () => '' }));
+vi.mock('../utils/generateCsrfToken', () => ({ default: () => 'csrf-token' }));
+vi.mock('../utils/language', () => ({ DEFAULT_LANGUAGE: 'de', normalizeLanguage: (lang: string) => lang }));
+vi.mock('../appConfig', () => ({ default: { login: '/admin/login' }, CSRF_WHITELIST_HEADER: 'X-CSRF-Token' }));
+vi.mock('antd', () => ({ message: { error: vi.fn() } }));
+vi.mock('i18next', () => ({ default: { resolvedLanguage: 'de', language: 'de', t: (key: unknown) => key } }));
+
+// eslint-disable-next-line import/first
+import { fetchData, FETCH_METHODS, FETCH_ERRORS } from './fetchData';
+
+const response = (status: number, body: Record<string, unknown> = {}) => ({
+    status,
+    headers: { get: () => null },
+    json: async () => body,
+});
+
+const createAgency = () =>
+    fetchData({
+        url: 'https://api.test/service/agencyadmin/agencies',
+        method: FETCH_METHODS.POST,
+        responseHandling: [FETCH_ERRORS.CATCH_ALL],
+        bodyData: JSON.stringify({ name: 'Kontaktstelle Hafen' }),
+    });
+
+describe('fetchData – self-healing 401 retry (logout-on-create fix)', () => {
+    beforeEach(() => {
+        tryRefreshAccessToken.mockReset();
+        logout.mockReset();
+        getAccessTokenForRequests.mockReset();
+        getAccessTokenForRequests.mockReturnValue('access-token');
+    });
+
+    it('refreshes the token and retries once on 401, then succeeds without logging out', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(response(401))
+            .mockResolvedValueOnce(response(201, { ok: true }));
+        vi.stubGlobal('fetch', fetchMock);
+        tryRefreshAccessToken.mockResolvedValue(true);
+
+        const result = await createAgency();
+
+        expect(tryRefreshAccessToken).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(logout).not.toHaveBeenCalled();
+        expect((result as { status: number }).status).toBe(201);
+    });
+
+    it('logs out (once) when there is no valid session to refresh', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(response(401));
+        vi.stubGlobal('fetch', fetchMock);
+        tryRefreshAccessToken.mockResolvedValue(false);
+
+        await expect(createAgency()).rejects.toThrow(FETCH_ERRORS.UNAUTHORIZED);
+        expect(tryRefreshAccessToken).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledTimes(1); // no retry when the refresh fails
+        expect(logout).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not loop: if the retry is still 401, it logs out exactly once', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(response(401));
+        vi.stubGlobal('fetch', fetchMock);
+        tryRefreshAccessToken.mockResolvedValue(true);
+
+        await expect(createAgency()).rejects.toThrow(FETCH_ERRORS.UNAUTHORIZED);
+        expect(fetchMock).toHaveBeenCalledTimes(2); // original + exactly one retry
+        expect(tryRefreshAccessToken).toHaveBeenCalledTimes(1);
+        expect(logout).toHaveBeenCalledTimes(1);
+    });
+
+    it('never refreshes or logs out for skipAuth (public) requests on 401', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(response(401));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(
+            fetchData({
+                url: 'https://api.test/service/topic/public',
+                method: FETCH_METHODS.GET,
+                skipAuth: true,
+                responseHandling: [FETCH_ERRORS.CATCH_ALL],
+            }),
+        ).rejects.toBeTruthy();
+
+        expect(tryRefreshAccessToken).not.toHaveBeenCalled();
+        expect(logout).not.toHaveBeenCalled();
+    });
+});

--- a/src/api/fetchData.ts
+++ b/src/api/fetchData.ts
@@ -1,7 +1,7 @@
 import { message } from 'antd';
 import i18next from 'i18next';
 import { getValueFromCookie } from './auth/accessSessionCookie';
-import { getAccessTokenForRequests } from './auth/auth';
+import { getAccessTokenForRequests, tryRefreshAccessToken } from './auth/auth';
 import generateCsrfToken from '../utils/generateCsrfToken';
 import { DEFAULT_LANGUAGE, normalizeLanguage } from '../utils/language';
 
@@ -71,9 +71,12 @@ interface FetchDataProps {
     responseHandling?: string[];
     timeout?: number;
     signal?: AbortSignal;
+    // Internal flag: set on the single automatic retry after a token refresh so a
+    // genuinely-unauthenticated request cannot loop. Not part of the public API.
+    _retriedAfterRefresh?: boolean;
 }
 
-export const fetchData = (props: FetchDataProps): Promise<any> =>
+const executeFetchData = (props: FetchDataProps): Promise<any> =>
     new Promise((resolve, reject) => {
         const accessToken = getAccessTokenForRequests();
         // Check if manual authorization header is provided in headersData
@@ -158,8 +161,11 @@ export const fetchData = (props: FetchDataProps): Promise<any> =>
                         );
                     } else if (response.status === 403) {
                         window.location.href = '/admin/access-denied';
-                    } else if (response.status === 401) {;
-                        logout(true, routePathNames.login);
+                    } else if (response.status === 401) {
+                        // Don't force a logout here. fetchData()'s wrapper attempts a single
+                        // token refresh + retry before falling back to logout, so a lapsed or
+                        // empty access token self-heals instead of dropping the user on the
+                        // login page mid-action (e.g. while creating an agency).
                         reject(new Error(FETCH_ERRORS.UNAUTHORIZED));
                     } else if (props.responseHandling.includes(FETCH_ERRORS.CATCH_ALL_SILENT)) {
                         // Reject without showing a toast so the caller can decide how to handle it.
@@ -191,3 +197,34 @@ export const fetchData = (props: FetchDataProps): Promise<any> =>
                 }
             });
     });
+
+/**
+ * Public request helper. Wraps {@link executeFetchData} with a self-healing 401
+ * handler: when an authenticated request comes back 401 (typically a lapsed or
+ * empty access token in this tab), refresh the token via the BFF and retry the
+ * request exactly once. Only if the retry is still unauthorized — or there is no
+ * valid session to refresh — do we fall back to logging the user out. This stops
+ * the "logged out while creating an agency" forced-logout.
+ */
+export const fetchData = async (props: FetchDataProps): Promise<any> => {
+    try {
+        return await executeFetchData(props);
+    } catch (error) {
+        const isUnauthorized = error instanceof Error && error.message === FETCH_ERRORS.UNAUTHORIZED;
+
+        if (isUnauthorized && !props.skipAuth && !props._retriedAfterRefresh) {
+            const refreshed = await tryRefreshAccessToken();
+            if (refreshed) {
+                // Retry once through fetchData (not executeFetchData) so a retry that
+                // is still unauthorized also runs the logout fallback below.
+                return fetchData({ ...props, _retriedAfterRefresh: true });
+            }
+        }
+
+        if (isUnauthorized && !props.skipAuth) {
+            logout(true, routePathNames.login);
+        }
+
+        throw error;
+    }
+};


### PR DESCRIPTION
## Problem
Creating a *Beratungsstelle* (agency) — and any other mutating admin action — could log the user **straight out to the login page**.

Root cause (verified against live ingress + AgencyService config, not the deploy and not the recent agency-create fix):
- The create `POST /service/agencyadmin/agencies` reaches AgencyService and is rejected with **401** by the OAuth2 resource-server filter (the in-memory access token was empty or had lapsed in that tab). CSRF failures return 403, so the 401 is auth, not CSRF; `multitenancy.enabled=false`, so it is not the tenant filter; role failures return 403.
- `fetchData` reacted to **any** 401 by calling `logout()` immediately → forced logout, no chance to recover.

## Fix
`fetchData` now **refreshes the access token via the auth BFF and retries the request once** before falling back to logout:
- `auth.ts`: `tryRefreshAccessToken()` — deduped BFF refresh that repopulates the in-memory token store and never logs out by itself.
- `fetchData.ts`: split `executeFetchData` (raw) from `fetchData` (wrapper). The 401 branch no longer logs out; the wrapper refreshes + retries once, then logs out **only** if still unauthorized. Logout no longer fires for `skipAuth` (public) requests.
- Unit tests cover: refresh→retry→success (no logout), refresh fails→logout once (no retry), retry still 401→logout once (no loop), skipAuth 401→neither refresh nor logout.

A genuinely-dead session (no valid refresh token) still logs out; a transient/lapsed access token now self-heals so the user stays signed in and the action completes.

## Verification
- `npm run build` (tsc + vite) ✓
- `vitest run src/api/fetchData.test.ts` ✓ (4/4)
- Full suite: only 2 pre-existing failures in `Agency/Edit/index.test.tsx` (missing `QueryClientProvider`, present on clean `dev`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)