### PR TITLE
test(admin): wrap AgencyPageEdit render in QueryClientProvider

### DIFF
--- a/src/pages/Agency/Edit/index.test.tsx
+++ b/src/pages/Agency/Edit/index.test.tsx
@@ -2,7 +2,16 @@ import React from 'react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { AgencyPageEdit } from './index';
+
+// Render AgencyPageEdit inside a QueryClientProvider so child components that use
+// react-query (e.g. RegistrationSettings → useConsultantsOrAdminsData) don't throw
+// "No QueryClient set". Retries are off so a missing queryFn never hangs the test.
+const renderWithClient = (ui: React.ReactElement) => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
 
 const mocks = vi.hoisted(() => ({
     mutate: vi.fn(),
@@ -126,6 +135,10 @@ vi.mock('../../../hooks/useTenantTopics', () => ({
     useTenantTopics: () => ({ data: [], isLoading: false }),
 }));
 
+vi.mock('../../../hooks/useConsultantsOrAdminsData', () => ({
+    useConsultantsOrAdminsData: () => ({ data: { data: [] }, isLoading: false }),
+}));
+
 vi.mock('../../../hooks/useUserRoles.hook', () => ({
     useUserRoles: () => ({
         hasRole: () => true,
@@ -168,7 +181,7 @@ describe('AgencyPageEdit create flow', () => {
     });
 
     it('renders the tenant assignment field for super-admin agency creation', async () => {
-        render(<AgencyPageEdit />);
+        renderWithClient(<AgencyPageEdit />);
 
         expect(await screen.findByText('Trägerzuordnung')).toBeInTheDocument();
         expect(mocks.searchTenantData).toHaveBeenCalledWith({ perPage: 1000 });
@@ -176,7 +189,7 @@ describe('AgencyPageEdit create flow', () => {
 
     it('does not submit a new agency without a selected tenant', async () => {
         const user = userEvent.setup();
-        render(<AgencyPageEdit />);
+        renderWithClient(<AgencyPageEdit />);
 
         fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'Neue Beratungsstelle' } });
         fireEvent.change(screen.getByPlaceholderText('PLZ'), { target: { value: '86161' } });


### PR DESCRIPTION
Fixes the two pre-existing failing `AgencyPageEdit` create-flow tests (`src/pages/Agency/Edit/index.test.tsx`) that errored with **"No QueryClient set"**.

`AgencyPageEdit` renders `RegistrationSettings` → `useConsultantsOrAdminsData` (react-query `useQuery`), but the test rendered the component without a `QueryClientProvider`.

- Wrap the render in a `QueryClientProvider` (retries off) via a small `renderWithClient` helper.
- Mock `useConsultantsOrAdminsData` so the unit stays pure (no network).

`npx vitest run src/pages/Agency/Edit/index.test.tsx` → 2/2 pass. Full suite 47/47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for agency editing flows by updating the test setup to better match real app behavior.
  * Added safer test handling for data fetching so affected tests no longer hang when query data is unavailable.
  * Expanded test mocks to support cases where no consultant/admin data is returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->