### PR TITLE
[codex] fix admin active delete date filtering

### DIFF
--- a/src/api/agency/getAgencyData.ts
+++ b/src/api/agency/getAgencyData.ts
@@ -4,6 +4,7 @@ import { FETCH_METHODS, fetchData } from '../fetchData';
 import removeEmbedded from '../../utils/removeEmbedded';
 import { AgencyData } from '../../types/agency';
 import { ResponseList } from '../../types/ResponseList';
+import { isActiveDeleteDate } from '../../utils/deleteDate';
 
 export const DEFAULT_SORT = 'NAME';
 export const DEFAULT_ORDER = 'ASC';
@@ -22,7 +23,7 @@ const getAgencyData = (params: TableState & { search?: string }) => {
     order = order.toUpperCase();
 
     const resolveAgencyStatus = (el: any) => {
-        if (el.deleteDate !== 'null') {
+        if (!isActiveDeleteDate(el.deleteDate)) {
             return 'IN_DELETION';
         }
         return 'CREATED';

--- a/src/components/GrantConsultantIdentityModal/index.tsx
+++ b/src/components/GrantConsultantIdentityModal/index.tsx
@@ -6,6 +6,7 @@ import { SelectFormField } from '../SelectFormField';
 import { useAgenciesData } from '../../hooks/useAgencysData';
 import { convertToOptions } from '../../utils/convertToOptions';
 import { grantConsultantIdentityData } from '../../api/admins/grantConsultantIdentityData';
+import { isActiveDeleteDate } from '../../utils/deleteDate';
 
 interface GrantConsultantIdentityModalProps {
     adminId: string;
@@ -34,7 +35,7 @@ export const GrantConsultantIdentityModal = ({
     const tenantIdNumber = tenantId !== undefined && tenantId !== null ? parseInt(`${tenantId}`, 10) : undefined;
     const availableAgencies = (agenciesData?.data || []).filter(
         (agency) =>
-            agency.deleteDate === 'null' &&
+            isActiveDeleteDate(agency.deleteDate) &&
             (tenantIdNumber === undefined || agency.tenantId === tenantIdNumber),
     );
 

--- a/src/pages/Agency/Edit/components/RegistrationSettings/index.tsx
+++ b/src/pages/Agency/Edit/components/RegistrationSettings/index.tsx
@@ -12,6 +12,7 @@ import { useConsultantsOrAdminsData } from '../../../../../hooks/useConsultantsO
 import { PostCodeRanges } from './PostCodeRanges';
 import styles from './styles.module.scss';
 import { convertToOptions } from '../../../../../utils/convertToOptions';
+import { isActiveRecord } from '../../../../../utils/deleteDate';
 
 interface RegistrationSettingsProps {
     asFields?: boolean;
@@ -33,9 +34,7 @@ export const RegistrationSettings = ({ asFields }: RegistrationSettingsProps) =>
         enabled: showConsultantAssignment,
     });
     const consultantOptions = useMemo(() => {
-        const activeConsultants = (consultants?.data || []).filter(
-            ({ deleteDate }) => deleteDate === undefined || deleteDate === 'null',
-        );
+        const activeConsultants = (consultants?.data || []).filter(isActiveRecord);
 
         return convertToOptions(activeConsultants, ['firstname', 'lastname', 'email'], 'id');
     }, [consultants?.data]);

--- a/src/pages/InviteLinks/index.tsx
+++ b/src/pages/InviteLinks/index.tsx
@@ -10,6 +10,7 @@ import { useUserRoles } from '../../hooks/useUserRoles.hook';
 import { parseUserAuthInfo } from '../../utils/parseUserAuthInfo';
 import { appURL } from '../../appConfig';
 import { ListingTable } from '../../components/ListingTable';
+import { isActiveDeleteDate } from '../../utils/deleteDate';
 
 interface TenantOption {
     id: number;
@@ -53,7 +54,7 @@ export const InviteLinksPage = () => {
     const filteredAgencies = useMemo(() => {
         const all = (agenciesResp?.data as any[]) || [];
         if (!selectedTenantId) return [];
-        return all.filter((a: any) => a.deleteDate === 'null' && a.tenantId === Number(selectedTenantId));
+        return all.filter((a: any) => isActiveDeleteDate(a.deleteDate) && a.tenantId === Number(selectedTenantId));
     }, [agenciesResp, selectedTenantId]);
 
     const loadLinks = useCallback(() => {

--- a/src/pages/users/Edit/index.tsx
+++ b/src/pages/users/Edit/index.tsx
@@ -30,6 +30,7 @@ import { extractApiErrorMessage } from '../../../utils/extractApiErrorMessage';
 import { useTenantTopics } from '../../../hooks/useTenantTopics';
 import { useCounselorById } from '../../../hooks/useCounselorById';
 import { GrantConsultantIdentityModal } from '../../../components/GrantConsultantIdentityModal';
+import { isActiveDeleteDate } from '../../../utils/deleteDate';
 
 const mergeTopicOptions = (current: Option[], incoming: Option[]): Option[] => {
     const seen = new Set(current.map(({ value }) => value));
@@ -59,8 +60,7 @@ export const UserEditOrAdd = () => {
     });
     const singleData = consultantsResponse?.data.find((c) => c.id === id);
     const isAdminUserForm = typeOfUsers === TypeOfUser.AgencyAdmins || typeOfUsers === TypeOfUser.TenantAdmins;
-    const canGrantConsultantIdentity =
-        isEditing && isAdminUserForm && !!singleData && !singleData.hasOtherIdentity;
+    const canGrantConsultantIdentity = isEditing && isAdminUserForm && !!singleData && !singleData.hasOtherIdentity;
     const [isReadOnly, setReadOnly] = useState(isEditing);
     const [submitted] = useState(false);
     const [tenantsData, setTenantsData] = useState([]);
@@ -101,7 +101,7 @@ export const UserEditOrAdd = () => {
             if (!tenantId) return [];
             return data?.filter(
                 ({ deleteDate, tenantId: agencyTenantId }) =>
-                    deleteDate === 'null' && agencyTenantId === parseInt(tenantId, 10),
+                    isActiveDeleteDate(deleteDate) && agencyTenantId === parseInt(tenantId, 10),
             );
         };
 
@@ -359,7 +359,9 @@ export const UserEditOrAdd = () => {
                                                             return Promise.resolve();
                                                         }
                                                         return Promise.reject(
-                                                            new Error(t('profile.passwordChange.error.passwordsNotMatch')),
+                                                            new Error(
+                                                                t('profile.passwordChange.error.passwordsNotMatch'),
+                                                            ),
                                                         );
                                                     },
                                                 }),

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -13,7 +13,7 @@ export interface AdminData {
     agencyIds: string[];
     username: string;
     key: string;
-    deleteDate?: string;
+    deleteDate?: string | null;
     status: Status;
     twoFactorAuth?: boolean;
     agencyAssignmentFailed?: boolean;

--- a/src/types/agency.d.ts
+++ b/src/types/agency.d.ts
@@ -35,7 +35,7 @@ export interface AgencyData {
     teamAgency: boolean;
     consultingType: string;
     status: string | undefined;
-    deleteDate: string | undefined;
+    deleteDate: string | null | undefined;
     createDate?: string; // Already returned by backend
     updateDate?: string; // Already returned by backend
     dioceseId?: string;

--- a/src/types/counselor.d.ts
+++ b/src/types/counselor.d.ts
@@ -17,7 +17,7 @@ export interface CounselorData {
     formalLanguage: boolean;
     absent: boolean;
     absenceMessage?: string;
-    deleteDate?: string;
+    deleteDate?: string | null;
     status: Status;
     twoFactorAuth?: boolean;
     isGroupchatConsultant?: boolean;

--- a/src/utils/deleteDate.test.ts
+++ b/src/utils/deleteDate.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { isActiveDeleteDate, isActiveRecord } from './deleteDate';
+
+describe('deleteDate helpers', () => {
+    it.each([undefined, null, 'null'])('treats %s as active', (deleteDate) => {
+        expect(isActiveDeleteDate(deleteDate)).toBe(true);
+        expect(isActiveRecord({ deleteDate })).toBe(true);
+    });
+
+    it('treats timestamp strings as deleted', () => {
+        expect(isActiveDeleteDate('2026-06-25T12:00:00')).toBe(false);
+        expect(isActiveRecord({ deleteDate: '2026-06-25T12:00:00' })).toBe(false);
+    });
+});

--- a/src/utils/deleteDate.ts
+++ b/src/utils/deleteDate.ts
@@ -1,0 +1,8 @@
+type DeletableRecord = {
+    deleteDate?: string | null;
+};
+
+export const isActiveDeleteDate = (deleteDate?: string | null) =>
+    deleteDate === undefined || deleteDate === null || deleteDate === 'null';
+
+export const isActiveRecord = ({ deleteDate }: DeletableRecord) => isActiveDeleteDate(deleteDate);


### PR DESCRIPTION
## Summary
- Treat `deleteDate: null`, `deleteDate: "null"`, and missing `deleteDate` as active records in admin selection/filter flows.
- Fixes the add-agency consultant picker showing `Keine Daten` when UserService returns active consultants with real JSON `null` delete dates.
- Reuses the same predicate for agency status, user agency filtering, invite-link agency filtering, and grant-consultant-identity agency filtering.

## Root cause
Pre-Dev UserService returns active consultants with `deleteDate: null`, while parts of Admin only accepted the legacy string value `"null"`. That filtered active consultants out of the agency registration settings picker, preventing new agencies from being assigned a counselor during creation and leaving the visibility toggle disabled.

## Validation
- `npm test -- --run src/utils/deleteDate.test.ts`
- `npm run build`
- Browser evidence on `https://admin.oriso-dev.site/admin/agency/add/general` before the fix showed the consultant dropdown rendering `Keine Daten` despite the API reporting active consultants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
