### PR TITLE
[codex] Guard admin login by role

### DIFF
--- a/src/hooks/useLoginMutation.hook.ts
+++ b/src/hooks/useLoginMutation.hook.ts
@@ -7,6 +7,7 @@ import { tenantAccessEndpoint } from '../appConfig';
 import { useAppConfigContext } from '../context/useAppConfig';
 import { TwoFactorType } from '../enums/TwoFactorType';
 import { LoginData } from '../types/loginData';
+import { hasAdminPortalAccess } from '../utils/adminPortalAccess';
 
 interface LoginParams {
     username: string;
@@ -16,10 +17,12 @@ interface LoginParams {
 
 interface ErrorLogin {
     message: string;
-    options: {
+    options?: {
         data: { otpType: TwoFactorType };
     };
 }
+
+export const ADMIN_PORTAL_ACCESS_DENIED = 'adminPortalAccessDenied';
 
 export const useLoginMutation = (tenantId: string) => {
     const { settings, setServerSettings } = useAppConfigContext();
@@ -29,6 +32,10 @@ export const useLoginMutation = (tenantId: string) => {
         async ({ username, password, otp }: any) => {
             // console.log('🔍 useLoginMutation: Starting login process');
             return getAccessToken({ username, password, otp }).then((data) => {
+                if (!hasAdminPortalAccess(data.access_token)) {
+                    return Promise.reject(new Error(ADMIN_PORTAL_ACCESS_DENIED));
+                }
+
                 // console.log('🔍 useLoginMutation: Got access token, checking tenant access');
                 // We'll check in the server if we're allowed to access the app
                 return fetchData({

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -43,6 +43,7 @@
     "message.error.default": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
     "message.error.unexpected": "Der Vorgang wurde abgebrochen.",
     "message.error.auth.login": "Login fehlgeschlagen. Bitte überprüfen Sie Benutzernamen/E-Mail und Passwort.",
+    "message.error.auth.adminOnly": "Dieses Konto kann nicht auf die Verwaltung zugreifen. Bitte verwenden Sie ein Admin-Konto.",
     "message.error.auth.setPassword": "Passwortänderung fehlgeschlagen! Bitte überprüfen Sie, ob Sie den richtigen Link geöffnet haben. Sie können auch einen neuen Link anfordern.",
     "message.error.auth.resetPassword": "Zurücksetzen fehlgeschlagen.",
     "message.error.upload.filetype": "Sie können nur JPG-/PNG- oder ICO-Formate auswählen.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -27,6 +27,7 @@
     "message.form.login.otp.APP": "Please enter the code from your app for two-factor authentication.",
     "message.form.login.otp.EMAIL": "Please enter the code from your email for two-factor authentication.",
     "message.error.auth.login": "Login failed. Please check username/email and password.",
+    "message.error.auth.adminOnly": "This account cannot access the admin portal. Please use an admin account.",
     "message.error.password.minLength": "Password must be at least 8 characters long.",
     "message.error.password.policy": "Password must include upper and lower case letters, at least one number, and at least one special character.",
     "message.error.PASSWORD_NOT_VALID": "The password does not meet the security requirements. Use at least 8 characters with upper and lower case letters, at least one number, and one special character (e.g. @Consultantshazia1).",

--- a/src/pages/Login/LoginForm.tsx
+++ b/src/pages/Login/LoginForm.tsx
@@ -8,7 +8,7 @@ import CustomPersonIcon from '../../components/CustomIcons/Person';
 import routePathNames from '../../appConfig';
 import CustomVerifiedIcon from '../../components/CustomIcons/Verified';
 import { FETCH_ERRORS } from '../../api/fetchData';
-import { useLoginMutation } from '../../hooks/useLoginMutation.hook';
+import { ADMIN_PORTAL_ACCESS_DENIED, useLoginMutation } from '../../hooks/useLoginMutation.hook';
 import { TwoFactorType } from '../../enums/TwoFactorType';
 import { usePublicTenantData } from '../../hooks/usePublicTenantData.hook';
 
@@ -33,7 +33,9 @@ const LoginForm = () => {
             onError: (error) => {
                 if (error.message === FETCH_ERRORS.BAD_REQUEST) {
                     setOtpDisabled(false);
-                    setTwoFactorType(error.options.data.otpType);
+                    setTwoFactorType(error.options?.data.otpType || TwoFactorType.None);
+                } else if (error.message === ADMIN_PORTAL_ACCESS_DENIED) {
+                    message.error(t('message.error.auth.adminOnly'));
                 } else {
                     message.error(t('message.error.auth.login'));
                 }

--- a/src/router/ProtectedRoute.tsx
+++ b/src/router/ProtectedRoute.tsx
@@ -6,6 +6,7 @@ import { getTokenExpiryFromLocalStorage } from '../api/auth/accessSessionLocalSt
 import { bootstrapAuthSession, getAccessTokenForRequests, getRefreshTokenForRequests } from '../api/auth/auth';
 import logout from '../api/auth/logout';
 import { Initialization } from '../components/Layout/Initialization';
+import { hasAdminPortalAccess } from '../utils/adminPortalAccess';
 
 interface ProtectedRouteTypes {
     children: React.ReactNode;
@@ -50,6 +51,11 @@ export const ProtectedRoute = ({ children }: ProtectedRouteTypes) => {
     if (refreshTokenValidInMs <= 0 && accessTokenValidInMs <= 0) {
         logout(true);
         return <Navigate to={routePathNames.login} state={{ from: location }} />;
+    }
+
+    if (!hasAdminPortalAccess(accessToken)) {
+        logout(true, routePathNames.login);
+        return <Navigate to={routePathNames.login} replace />;
     }
 
     // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/src/utils/adminPortalAccess.ts
+++ b/src/utils/adminPortalAccess.ts
@@ -1,0 +1,26 @@
+import { UserRole } from '../enums/UserRole';
+import parseJwt from './parseJWT';
+
+const ADMIN_PORTAL_ROLES = [
+    UserRole.TenantAdmin,
+    UserRole.SingleTenantAdmin,
+    UserRole.UserAdmin,
+    UserRole.AgencyAdmin,
+    UserRole.RestrictedAgencyAdmin,
+    UserRole.TopicAdmin,
+];
+
+export const hasAdminPortalRole = (roles: string[] = []) => ADMIN_PORTAL_ROLES.some((role) => roles.includes(role));
+
+export const hasAdminPortalAccess = (accessToken?: string) => {
+    if (!accessToken) {
+        return false;
+    }
+
+    try {
+        const payload = parseJwt(accessToken);
+        return hasAdminPortalRole(payload?.realm_access?.roles || []);
+    } catch {
+        return false;
+    }
+};


### PR DESCRIPTION
## Summary
- add a shared admin-portal role guard for Keycloak access tokens
- reject counsellor-only tokens during admin login before storing the admin session
- clear stale non-admin sessions from protected admin routes and return to login
- show a specific login error when an account is valid but not allowed in admin

## Root cause
The admin login flow accepted any valid Keycloak token, persisted it, and only later discovered that counsellor-only users lacked admin permissions. That left counsellors on `/admin/access-denied` instead of rejecting them at login.

## Validation
- `npm run build`
  - passes
  - existing warnings remain in unrelated files/CSS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin-only access checks for the login flow and protected areas of the app.
  * Users without the required admin access are now redirected back to sign in.

* **Bug Fixes**
  * Improved login error handling for restricted accounts.
  * Added clear error messages in English and German when an account can’t access the admin portal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->