### PR TITLE
chore: make CodeRabbit manual

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,14 +13,14 @@ reviews:
   poem: false
 
   auto_review:
-    enabled: true
-    auto_incremental_review: true
-    drafts: true
+    enabled: false
+    description_keyword: "coderabbit: review"
+    auto_incremental_review: false
+    drafts: false
+    labels:
+      - "coderabbit"
     base_branches:
       - "dev"
-      - "main"
-      - "release/.*"
-      - "hotfix/.*"
 
   path_filters:
     - "!node_modules/**"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 
 ## Review Expectations
 
-- CodeRabbit and Cursor should compare PRs against `origin/dev` for normal ORISO Admin feature work.
+- Cursor should compare PRs against `origin/dev` for normal ORISO Admin feature work.
+- CodeRabbit is optional/manual and should not be treated as the primary automated reviewer.
 - Automated review should flag missing tests, duplicated admin patterns, unsafe auth/API changes, and mergeability risks.
 - Only auto-fix issues that are clearly scoped and testable. Leave architectural or ambiguous changes as review comments.


### PR DESCRIPTION
## Summary
- make CodeRabbit auto-review manual/optional
- document Cursor as the primary automated ORISO Admin reviewer
- keep the target branch on dev only

## Validation
- Ruby YAML parser loaded .coderabbit.yaml successfully
- config/docs-only change; no product runtime tests required