### PR TITLE
fix(auth): re-read fresh token expiry after refresh before arming renewal timer (#156)

### DIFF
--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -189,9 +189,15 @@ export const handleTokenRefresh = (): Promise<void> => {
                     resolve();
                 } else if (accessTokenValidInMs <= 0) {
                     refreshTokens().then(() => {
+                        // refreshTokens() has just renewed the access token and written the
+                        // fresh expiry to localStorage. Re-read it here: the pre-refresh
+                        // accessTokenValidInMs is <= 0, so reusing it would compute a negative
+                        // refresh interval and arm no renewal timer at all (silent re-expiry).
+                        const refreshedTime = new Date().getTime();
+                        const refreshedExpiry = getTokenExpiryFromLocalStorage();
                         startTimers({
-                            accessTokenValidInMs,
-                            refreshTokenValidInMs,
+                            accessTokenValidInMs: refreshedExpiry.accessTokenValidUntilTime - refreshedTime,
+                            refreshTokenValidInMs: refreshedExpiry.refreshTokenValidUntilTime - refreshedTime,
                         });
                         resolve();
                     });


### PR DESCRIPTION
## Problem (residual of AD-H08 / #156)
In `handleTokenRefresh` (`src/api/auth/auth.ts`), the access-token-expired branch did:
```ts
} else if (accessTokenValidInMs <= 0) {
    refreshTokens().then(() => {
        startTimers({ accessTokenValidInMs, refreshTokenValidInMs }); // <-- stale values
        resolve();
    });
}
```
Both `accessTokenValidInMs` and `refreshTokenValidInMs` were computed **before** `refreshTokens()` ran, and `accessTokenValidInMs` is `<= 0` on this branch. After the refresh renews the token, `startTimers` still received the stale (negative) value, computed `accessTokenRefreshIntervalInMs = accessTokenValidInMs - RENEW_BEFORE_EXPIRY_IN_MS < 0`, and armed **no renewal interval at all** — so the just-refreshed access token would silently lapse again at its next expiry with no scheduled proactive renewal.

## Fix
Re-read the expiry from `localStorage` (which `refreshTokens()` → `setTokens()` just updated) once the refresh resolves, and arm the timers from those fresh values.

## Severity / context
This is the **last residue** flagged when re-verifying #156 on dev. The user-visible *silent session expiry* symptom is already mitigated on dev by (a) the refresh-token logout timeout in `startTimers` and (b) `fetchData`'s 401 self-heal + retry-once. This change restores the **proactive** renewal timer so staying signed in no longer depends on a 401 round-trip. The other two AD-H08 defects (commented-out logouts, 5xx hang) were already fixed on dev.

## Verification
- `CI=false npm run build` passes.
- Single-file change (`src/api/auth/auth.ts`).

Closes #156.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>