### PR TITLE
test: add unit tests for auth, login, permissions, and shared components

### DIFF
--- a/src/api/auth/accessSessionLocalStorage.test.ts
+++ b/src/api/auth/accessSessionLocalStorage.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    getLocalStorageItem,
+    getTokenExpiryFromLocalStorage,
+    removeTokenExpiryFromLocalStorage,
+    setTokenExpiryInLocalStorage,
+} from './accessSessionLocalStorage';
+
+describe('access session local storage helpers', () => {
+    const storage = new Map<string, string>();
+
+    beforeEach(() => {
+        storage.clear();
+        vi.stubGlobal('localStorage', {
+            getItem: vi.fn((key: string) => storage.get(key) ?? null),
+            removeItem: vi.fn((key: string) => {
+                storage.delete(key);
+            }),
+            setItem: vi.fn((key: string, value: string) => {
+                storage.set(key, value);
+            }),
+        });
+        vi.useRealTimers();
+    });
+
+    it('stores token expiry timestamps from relative seconds', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-29T10:00:00.000Z'));
+
+        setTokenExpiryInLocalStorage('auth.access_token_valid_until', 30);
+
+        expect(getLocalStorageItem('auth.access_token_valid_until')).toBe(
+            String(new Date('2026-06-29T10:00:30.000Z').getTime()),
+        );
+    });
+
+    it('returns parsed access and refresh token expiry timestamps', () => {
+        localStorage.setItem('auth.access_token_valid_until', '1000');
+        localStorage.setItem('auth.refresh_token_valid_until', '2000');
+
+        expect(getTokenExpiryFromLocalStorage()).toEqual({
+            accessTokenValidUntilTime: 1000,
+            refreshTokenValidUntilTime: 2000,
+        });
+    });
+
+    it('removes both stored token expiry values', () => {
+        localStorage.setItem('auth.access_token_valid_until', '1000');
+        localStorage.setItem('auth.refresh_token_valid_until', '2000');
+
+        removeTokenExpiryFromLocalStorage();
+
+        expect(localStorage.getItem('auth.access_token_valid_until')).toBeNull();
+        expect(localStorage.getItem('auth.refresh_token_valid_until')).toBeNull();
+    });
+});

--- a/src/api/auth/buildCookieAttributes.test.ts
+++ b/src/api/auth/buildCookieAttributes.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { buildCookieAttributes } from './buildCookieAttributes';
+
+describe('buildCookieAttributes', () => {
+    it('always includes path and strict same-site attributes', () => {
+        expect(buildCookieAttributes({ cookieSecure: false, cookieDomain: '' })).toBe('; path=/; SameSite=Strict');
+    });
+
+    it('adds secure, domain, and httpOnly attributes when configured', () => {
+        expect(
+            buildCookieAttributes({
+                cookieSecure: true,
+                cookieDomain: '.example.org',
+                httpOnly: true,
+            }),
+        ).toBe('; path=/; SameSite=Strict; Secure; Domain=.example.org; HttpOnly');
+    });
+});

--- a/src/api/auth/invalidateAuthSession.test.ts
+++ b/src/api/auth/invalidateAuthSession.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    clearAuthTokensViaBff: vi.fn(),
+    clearSessionTokens: vi.fn(),
+}));
+
+vi.mock('./authBffClient', () => ({
+    clearAuthTokensViaBff: mocks.clearAuthTokensViaBff,
+}));
+
+vi.mock('./tokenSessionStore', () => ({
+    clearSessionTokens: mocks.clearSessionTokens,
+}));
+
+import { invalidateAuthSession } from './invalidateAuthSession';
+
+describe('invalidateAuthSession', () => {
+    beforeEach(() => {
+        mocks.clearAuthTokensViaBff.mockReset();
+        mocks.clearSessionTokens.mockReset();
+    });
+
+    it('clears local session tokens and asks the BFF to clear auth cookies', async () => {
+        mocks.clearAuthTokensViaBff.mockResolvedValue(undefined);
+
+        await invalidateAuthSession();
+
+        expect(mocks.clearSessionTokens).toHaveBeenCalledTimes(1);
+        expect(mocks.clearAuthTokensViaBff).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fail when the BFF clear request fails', async () => {
+        mocks.clearAuthTokensViaBff.mockRejectedValue(new Error('offline'));
+
+        await expect(invalidateAuthSession()).resolves.toBeUndefined();
+        expect(mocks.clearSessionTokens).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/api/auth/tokenSessionStore.test.ts
+++ b/src/api/auth/tokenSessionStore.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+    clearSessionTokens,
+    getSessionAccessToken,
+    getSessionRefreshToken,
+    hasSessionTokens,
+    setSessionTokens,
+} from './tokenSessionStore';
+
+describe('tokenSessionStore', () => {
+    beforeEach(() => {
+        clearSessionTokens();
+    });
+
+    it('stores access and refresh tokens in memory', () => {
+        setSessionTokens('access', 'refresh');
+
+        expect(getSessionAccessToken()).toBe('access');
+        expect(getSessionRefreshToken()).toBe('refresh');
+        expect(hasSessionTokens()).toBe(true);
+    });
+
+    it('clears missing or empty token values', () => {
+        setSessionTokens('access', undefined);
+
+        expect(getSessionAccessToken()).toBe('access');
+        expect(getSessionRefreshToken()).toBe('');
+        expect(hasSessionTokens()).toBe(false);
+
+        clearSessionTokens();
+        expect(getSessionAccessToken()).toBe('');
+    });
+});

--- a/src/api/invitelinks/inviteLinkApiShared.test.ts
+++ b/src/api/invitelinks/inviteLinkApiShared.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildListQueryString, inviteLinkHeaders, normalizeListResponse } from './inviteLinkApiShared';
+
+const mocks = vi.hoisted(() => ({
+    parseUserAuthInfo: vi.fn(),
+}));
+
+vi.mock('../../utils/parseUserAuthInfo', () => ({
+    parseUserAuthInfo: mocks.parseUserAuthInfo,
+}));
+
+describe('invite link API shared helpers', () => {
+    beforeEach(() => {
+        mocks.parseUserAuthInfo.mockReset();
+    });
+
+    it('uses an explicit tenant id header when provided', () => {
+        expect(inviteLinkHeaders(42)).toEqual({ 'X-Tenant-Id': '42' });
+        expect(mocks.parseUserAuthInfo).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the authenticated user tenant id', () => {
+        mocks.parseUserAuthInfo.mockReturnValue({ tenantId: 7 });
+
+        expect(inviteLinkHeaders()).toEqual({ 'X-Tenant-Id': '7' });
+    });
+
+    it('falls back to tenant 1 when no positive tenant is available', () => {
+        mocks.parseUserAuthInfo.mockReturnValue({ tenantId: 0 });
+
+        expect(inviteLinkHeaders()).toEqual({ 'X-Tenant-Id': '1' });
+    });
+
+    it('builds pagination query strings', () => {
+        expect(buildListQueryString(2, 50)).toBe('page=2&size=50');
+    });
+
+    it('normalizes array responses into paged responses', () => {
+        expect(normalizeListResponse([{ id: 1 }, { id: 2 }], 3, 10)).toEqual({
+            content: [{ id: 1 }, { id: 2 }],
+            page: 3,
+            size: 10,
+            totalElements: 2,
+            totalPages: 1,
+        });
+    });
+
+    it('fills missing paged response fields with safe defaults', () => {
+        expect(normalizeListResponse({ content: undefined } as any, 1, 20)).toEqual({
+            content: [],
+            page: 1,
+            size: 20,
+            totalElements: 0,
+            totalPages: 0,
+        });
+    });
+});

--- a/src/api/invitelinks/topicInviteLinks.test.ts
+++ b/src/api/invitelinks/topicInviteLinks.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FETCH_METHODS } from '../fetchData';
+import {
+    buildTopicInviteLinkUrl,
+    createTopicInviteLink,
+    formatAnonymityLabel,
+    formatChatTypeLabel,
+    listTopicInviteLinks,
+} from './topicInviteLinks';
+import { invitelinksEndpoint } from './inviteLinkApiShared';
+
+const mocks = vi.hoisted(() => ({
+    fetchData: vi.fn(),
+}));
+
+vi.mock('../fetchData', async () => {
+    const actual = await vi.importActual<typeof import('../fetchData')>('../fetchData');
+
+    return {
+        ...actual,
+        fetchData: mocks.fetchData,
+    };
+});
+
+vi.mock('../../utils/parseUserAuthInfo', () => ({
+    parseUserAuthInfo: () => ({ tenantId: 9 }),
+}));
+
+describe('topic invite links API', () => {
+    beforeEach(() => {
+        mocks.fetchData.mockReset();
+    });
+
+    it('builds an invite URL with an encoded topic name', () => {
+        expect(buildTopicInviteLinkUrl('abc123', 'Youth & Family')).toContain('/invite/abc123/Youth%20%26%20Family');
+    });
+
+    it('omits empty topic names from invite URLs', () => {
+        expect(buildTopicInviteLinkUrl('abc123', ' undefined ')).toMatch(/\/invite\/abc123$/);
+    });
+
+    it('lists topic invite links with pagination and tenant headers', async () => {
+        mocks.fetchData.mockResolvedValueOnce([{ id: 1, token: 'token' }]);
+
+        const result = await listTopicInviteLinks({ page: 2, size: 5, tenantId: 77 });
+
+        expect(mocks.fetchData).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: `${invitelinksEndpoint}?page=2&size=5`,
+                method: FETCH_METHODS.GET,
+                headersData: { 'X-Tenant-Id': '77' },
+            }),
+        );
+        expect(result.content).toEqual([{ id: 1, token: 'token' }]);
+    });
+
+    it('creates a topic invite link with only supplied optional fields', async () => {
+        const responseBody = { id: 1, token: 'token' };
+        mocks.fetchData.mockResolvedValueOnce({ json: async () => responseBody });
+
+        const result = await createTopicInviteLink(
+            {
+                anonymity: 'FULL',
+                chatType: 'LIVE_CHAT',
+                expiresInDays: 7,
+                linkKind: 'TENANT',
+                notes: 'For testing',
+                topicId: 5,
+            },
+            77,
+        );
+
+        expect(mocks.fetchData).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: FETCH_METHODS.POST,
+                headersData: { 'X-Tenant-Id': '77' },
+            }),
+        );
+        expect(JSON.parse(mocks.fetchData.mock.calls[0][0].bodyData)).toEqual({
+            anonymity: 'FULL',
+            chatType: 'LIVE_CHAT',
+            expiresInDays: 7,
+            linkKind: 'TENANT',
+            notes: 'For testing',
+            topicId: 5,
+        });
+        expect(result).toEqual(responseBody);
+    });
+
+    it('formats known labels and falls back to raw values', () => {
+        expect(formatChatTypeLabel('LIVE_CHAT')).toBe('Live Chat');
+        expect(formatChatTypeLabel('UNKNOWN')).toBe('UNKNOWN');
+        expect(formatAnonymityLabel('FULL')).toBe('Full');
+        expect(formatAnonymityLabel('PARTIAL')).toBe('PARTIAL');
+    });
+});

--- a/src/api/settings/apiServerSettings.test.ts
+++ b/src/api/settings/apiServerSettings.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    fetchData: vi.fn(),
+}));
+
+vi.mock('../../appConfig', () => ({
+    serverSettingsEndpoint: '/api/settings',
+}));
+
+vi.mock('../fetchData', () => ({
+    FETCH_METHODS: { GET: 'GET' },
+    fetchData: mocks.fetchData,
+}));
+
+import { FETCH_METHODS } from '../fetchData';
+import { apiServerSettings } from './apiServerSettings';
+
+describe('apiServerSettings', () => {
+    it('loads public server settings without auth', async () => {
+        mocks.fetchData.mockResolvedValue({ useApiClusterSettings: { value: true } });
+
+        await expect(apiServerSettings()).resolves.toEqual({ useApiClusterSettings: { value: true } });
+
+        expect(mocks.fetchData).toHaveBeenCalledWith({
+            url: '/api/settings',
+            method: FETCH_METHODS.GET,
+            skipAuth: true,
+            responseHandling: [],
+        });
+    });
+});

--- a/src/api/settings/sendGlobalSmtpTestEmail.test.ts
+++ b/src/api/settings/sendGlobalSmtpTestEmail.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    fetchData: vi.fn(),
+}));
+
+vi.mock('../../appConfig', () => ({
+    globalSmtpTestEmailEndpoint: '/api/settings/smtp/test',
+}));
+
+vi.mock('../fetchData', () => ({
+    FETCH_ERRORS: { BAD_REQUEST_WITH_RESPONSE: 'BAD_REQUEST_WITH_RESPONSE' },
+    FETCH_METHODS: { POST: 'POST' },
+    fetchData: mocks.fetchData,
+}));
+
+import { FETCH_ERRORS, FETCH_METHODS } from '../fetchData';
+import { sendGlobalSmtpTestEmail } from './sendGlobalSmtpTestEmail';
+
+describe('sendGlobalSmtpTestEmail', () => {
+    it('posts the SMTP test payload and keeps bad-request response handling enabled', async () => {
+        const payload = {
+            host: 'smtp.example.org',
+            port: 587,
+            secure: false,
+            username: 'mailer',
+            password: 'secret',
+            from: 'from@example.org',
+            recipientEmail: 'recipient@example.org',
+            emailThemeColor: '#0055aa',
+        };
+        mocks.fetchData.mockResolvedValue({ status: 204 });
+
+        await expect(sendGlobalSmtpTestEmail(payload)).resolves.toEqual({ status: 204 });
+
+        expect(mocks.fetchData).toHaveBeenCalledWith({
+            url: '/api/settings/smtp/test',
+            method: FETCH_METHODS.POST,
+            bodyData: JSON.stringify(payload),
+            responseHandling: [FETCH_ERRORS.BAD_REQUEST_WITH_RESPONSE],
+        });
+    });
+});

--- a/src/components/CopyToClipboard/index.test.tsx
+++ b/src/components/CopyToClipboard/index.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CopyToClipboard } from './index';
+
+const mocks = vi.hoisted(() => ({
+    notificationSuccess: vi.fn(),
+}));
+
+vi.mock('antd', async () => {
+    const actual = await vi.importActual<typeof import('antd')>('antd');
+    return {
+        ...actual,
+        notification: {
+            ...actual.notification,
+            success: mocks.notificationSuccess,
+        },
+    };
+});
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => `translated:${key}` }),
+}));
+
+vi.mock('react-copy-to-clipboard', () => ({
+    CopyToClipboard: ({
+        children,
+        onCopy,
+    }: {
+        children: React.ReactElement<{ onClick?: () => void }>;
+        onCopy: () => void;
+    }) => React.cloneElement(children, { onClick: onCopy }),
+}));
+
+vi.mock('../../resources/img/svg/copy.svg', () => ({
+    ReactComponent: (props: React.HTMLAttributes<HTMLButtonElement>) => (
+        <button type="button" aria-label="copy" {...props} />
+    ),
+}));
+
+describe('CopyToClipboard', () => {
+    it('renders the copied text and shows a success notification after copy', async () => {
+        const user = userEvent.setup();
+        render(<CopyToClipboard copiedKey="custom.copy.success">https://oriso.test/invite/token</CopyToClipboard>);
+
+        expect(screen.getByText('https://oriso.test/invite/token')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'copy' }));
+
+        expect(mocks.notificationSuccess).toHaveBeenCalledWith({
+            message: 'translated:custom.copy.success',
+        });
+    });
+});

--- a/src/components/FeatureEnabled/index.test.tsx
+++ b/src/components/FeatureEnabled/index.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FeatureEnabled } from './index';
+import { ReleaseToggle } from '../../enums/ReleaseToggle';
+
+const mocks = vi.hoisted(() => ({
+    settings: { releaseToggles: {} as Record<string, boolean> },
+}));
+
+vi.mock('../../context/useAppConfig', () => ({
+    useAppConfigContext: () => ({ settings: mocks.settings }),
+}));
+
+describe('FeatureEnabled', () => {
+    it('renders children when the release toggle is enabled', () => {
+        mocks.settings.releaseToggles = { [ReleaseToggle.ConsultantBoundedToAgencies]: true };
+
+        render(
+            <FeatureEnabled feature={ReleaseToggle.ConsultantBoundedToAgencies}>
+                <div>Feature content</div>
+            </FeatureEnabled>,
+        );
+
+        expect(screen.getByText('Feature content')).toBeInTheDocument();
+    });
+
+    it('hides children when the release toggle is disabled', () => {
+        mocks.settings.releaseToggles = { [ReleaseToggle.ConsultantBoundedToAgencies]: false };
+
+        render(
+            <FeatureEnabled feature={ReleaseToggle.ConsultantBoundedToAgencies}>
+                <div>Feature content</div>
+            </FeatureEnabled>,
+        );
+
+        expect(screen.queryByText('Feature content')).not.toBeInTheDocument();
+    });
+});

--- a/src/components/ListingTable/StatusTag.test.tsx
+++ b/src/components/ListingTable/StatusTag.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AnonymityTag, StatusTag } from './StatusTag';
+
+describe('Listing table tags', () => {
+    it('renders invite link status text', () => {
+        render(<StatusTag status="ACTIVE" />);
+
+        expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+    });
+
+    it('renders anonymity labels with their original text', () => {
+        render(<AnonymityTag value="Name + Email" />);
+
+        expect(screen.getByText('Name + Email')).toBeInTheDocument();
+    });
+});

--- a/src/components/M3Switch/index.test.tsx
+++ b/src/components/M3Switch/index.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { M3Switch } from './index';
+
+describe('M3Switch', () => {
+    it('announces its checked state and toggles to the next value', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+
+        render(<M3Switch checked={false} label="Enable calls" onChange={onChange} />);
+
+        const toggle = screen.getByRole('switch', { name: 'Enable calls' });
+        expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+        await user.click(toggle);
+
+        expect(onChange).toHaveBeenCalledWith(true);
+    });
+
+    it('does not call onChange when disabled', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+
+        render(<M3Switch checked label="Enable calls" disabled onChange={onChange} />);
+
+        await user.click(screen.getByRole('switch', { name: 'Enable calls' }));
+
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/SearchInput/SearchInput.test.tsx
+++ b/src/components/SearchInput/SearchInput.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SearchInput from './SearchInput';
+
+const t = (key: string, fallback?: string) =>
+    ({
+        'search-placeholder': 'Search',
+        'searchInput.clear': 'Clear search',
+        'searchInput.submit': 'Run search',
+    }[key] ||
+        fallback ||
+        key);
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t }),
+}));
+
+describe('SearchInput', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('runs a debounced search after the minimum length is reached', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        const handleOnSearch = vi.fn();
+
+        render(<SearchInput handleOnSearch={handleOnSearch} minSearchLength={3} />);
+
+        await user.type(screen.getByRole('textbox'), 'ab');
+        vi.advanceTimersByTime(1000);
+        expect(handleOnSearch).not.toHaveBeenCalled();
+
+        await user.type(screen.getByRole('textbox'), 'c');
+        vi.advanceTimersByTime(1000);
+        expect(handleOnSearch).toHaveBeenCalledWith('abc');
+    });
+
+    it('runs an immediate search when Enter is pressed', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        const handleOnSearch = vi.fn();
+
+        render(<SearchInput handleOnSearch={handleOnSearch} searchOnChange={false} />);
+
+        await user.type(screen.getByRole('textbox'), 'tenant{Enter}');
+
+        expect(handleOnSearch).toHaveBeenCalledWith('tenant');
+    });
+
+    it('clears the value and notifies when the clear button is clicked', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        const handleOnSearchClear = vi.fn();
+        const onValueChange = vi.fn();
+
+        render(<SearchInput handleOnSearchClear={handleOnSearchClear} onValueChange={onValueChange} />);
+
+        await user.type(screen.getByRole('textbox'), 'agency');
+        await user.click(screen.getByRole('button', { name: 'Clear search' }));
+
+        expect(screen.getByRole('textbox')).toHaveValue('');
+        expect(onValueChange).toHaveBeenLastCalledWith('');
+        expect(handleOnSearchClear).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/Tenants/AppSettings/PermissionsSettings/permissionsSettingsUtils.test.ts
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/permissionsSettingsUtils.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+    applyForcedOffFields,
+    applyVisibleTogglesAsValues,
+    buildTenantAdminControlsPayload,
+    getForcedOffFields,
+    isSubToggleDisabled,
+    syncMasterTogglesToTenantAdminControls,
+} from './permissionsSettingsUtils';
+
+describe('permissions settings utils', () => {
+    it('resolves all feature fields forced off by hidden platform toggles', () => {
+        const forcedOffFields = getForcedOffFields({ anonymousChat: false } as any);
+
+        expect(forcedOffFields.has('featureAnonymousChatEnabled')).toBe(true);
+        expect(forcedOffFields.has('featureVideoCallsAnonymousChatsEnabled')).toBe(true);
+    });
+
+    it('applies forced-off fields without mutating the original settings object', () => {
+        const original = { featureAnonymousChatEnabled: true };
+        const result = applyForcedOffFields(original, new Set(['featureAnonymousChatEnabled']));
+
+        expect(result).toEqual({ featureAnonymousChatEnabled: false });
+        expect(original).toEqual({ featureAnonymousChatEnabled: true });
+    });
+
+    it('maps visible platform toggles into concrete feature values', () => {
+        const settings = applyVisibleTogglesAsValues({ calls: false, groupChat: true } as any);
+
+        expect(settings.featureCallsEnabled).toBe(false);
+        expect(settings.featureGroupChatV2Enabled).toBe(true);
+    });
+
+    it('syncs master feature values to tenant admin controls', () => {
+        const result = syncMasterTogglesToTenantAdminControls({
+            settings: {
+                featureAnonymousChatEnabled: false,
+                featureCallsEnabled: true,
+                featureGroupChatV2Enabled: true,
+                featureSupervisionEnabled: true,
+                featureVideoCallsAnonymousChatsEnabled: true,
+            },
+        });
+
+        expect(result.settings?.tenantAdminControls).toMatchObject({
+            allowedPermissionToggles: {
+                anonymousChat: false,
+                calls: true,
+                videoCallsAnonymousChats: false,
+            },
+        });
+    });
+
+    it('preserves existing toggles while building tenant admin controls payload', () => {
+        const result = buildTenantAdminControlsPayload(
+            { settings: { featureCallsEnabled: false } },
+            { groupChat: true } as any,
+            false,
+        );
+
+        expect(result).toMatchObject({
+            permissionsPageEnabled: false,
+            allowedPermissionToggles: {
+                calls: false,
+                groupChat: true,
+            },
+        });
+    });
+
+    it('disables sub toggles when their master toggle is off', () => {
+        expect(isSubToggleDisabled({ key: 'group', masterField: ['settings', 'featureGroupChatV2Enabled'] } as any, [], false)).toBe(true);
+        expect(isSubToggleDisabled({ key: 'oneOnOne' } as any, ['settings', 'featureAudioCallsOneOnOneChatsEnabled'], false)).toBe(true);
+        expect(isSubToggleDisabled({ key: 'anonymous' } as any, ['settings', 'featureAnonymousChatEnabled'], false)).toBe(false);
+    });
+});

--- a/src/components/Tenants/AppSettings/PermissionsSettings/permissionsToggleLogic.test.ts
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/permissionsToggleLogic.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildTogglePayload, syncMasterChildTogglesInForm } from './permissionsToggleLogic';
+
+const masterToggleChildren = {
+    featureCallsEnabled: ['featureAudioCallsEnabled', 'featureVideoCallsEnabled'],
+};
+
+describe('permissions toggle logic', () => {
+    it('builds a nested payload and disables children when a master toggle is turned off', () => {
+        expect(buildTogglePayload(['settings', 'featureCallsEnabled'], false, masterToggleChildren)).toEqual({
+            settings: {
+                featureAudioCallsEnabled: false,
+                featureCallsEnabled: false,
+                featureVideoCallsEnabled: false,
+            },
+        });
+    });
+
+    it('does not touch child toggles when a master toggle is turned on', () => {
+        expect(buildTogglePayload(['settings', 'featureCallsEnabled'], true, masterToggleChildren)).toEqual({
+            settings: {
+                featureCallsEnabled: true,
+            },
+        });
+    });
+
+    it('syncs child fields in an antd form when a master toggle is disabled', () => {
+        const form = { setFields: vi.fn() } as any;
+
+        syncMasterChildTogglesInForm(form, ['settings', 'featureCallsEnabled'], false, masterToggleChildren);
+
+        expect(form.setFields).toHaveBeenCalledWith([
+            { name: ['settings', 'featureAudioCallsEnabled'], value: false },
+            { name: ['settings', 'featureVideoCallsEnabled'], value: false },
+        ]);
+    });
+});

--- a/src/constants/client.test.ts
+++ b/src/constants/client.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { queryClient } from './client';
+
+describe('queryClient', () => {
+    it('disables query retries and window-focus refetches by default', () => {
+        const options = queryClient.getDefaultOptions();
+
+        expect(options.queries?.retry).toBe(false);
+        expect(options.queries?.refetchOnWindowFocus).toBe(false);
+    });
+});

--- a/src/constants/settingsTabs.test.ts
+++ b/src/constants/settingsTabs.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PermissionAction } from '../enums/PermissionAction';
+import { Resource } from '../enums/Resource';
+import { getDefaultSettingsPath, getSettingsTabs } from './settingsTabs';
+
+vi.mock('../appConfig', () => ({
+    default: {
+        themeSettings: '/settings',
+    },
+}));
+
+const baseContext = {
+    isSuperAdmin: false,
+    shouldShowThemeSettings: true,
+    can: vi.fn(() => true),
+    isTenantSettingsEditEnabled: true,
+    multitenancyWithSingleDomainEnabled: false,
+};
+
+describe('settings tabs', () => {
+    it('returns all super-admin tabs when permissions allow them', () => {
+        const tabs = getSettingsTabs({
+            ...baseContext,
+            isSuperAdmin: true,
+        });
+
+        expect(tabs.map((tab) => tab.to)).toEqual([
+            '/settings/global-config',
+            '/settings/general',
+            '/settings/legal',
+            '/settings/smtp',
+            '/settings/permissions',
+        ]);
+    });
+
+    it('hides tenant tabs when the related permission or feature flag is disabled', () => {
+        const can = vi.fn((action: PermissionAction | PermissionAction[], resource: Resource) => {
+            if (resource === Resource.LegalText) {
+                return false;
+            }
+            return action === PermissionAction.Update && resource === Resource.Tenant;
+        });
+
+        const tabs = getSettingsTabs({
+            ...baseContext,
+            can,
+            shouldShowThemeSettings: false,
+            isTenantSettingsEditEnabled: false,
+        });
+
+        expect(tabs.map((tab) => tab.to)).toEqual(['/settings/smtp', '/settings/permissions']);
+    });
+
+    it('uses the global settings label and icon for single-domain multitenancy', () => {
+        const tabs = getSettingsTabs({
+            ...baseContext,
+            multitenancyWithSingleDomainEnabled: true,
+        });
+
+        expect(tabs).toContainEqual({
+            to: '/settings/app-settings',
+            titleKey: 'tenants.edit.tabs.globalSettings',
+            iconName: 'global_settings',
+        });
+    });
+
+    it('falls back to legal settings when no tabs are available', () => {
+        const path = getDefaultSettingsPath({
+            ...baseContext,
+            shouldShowThemeSettings: false,
+            can: vi.fn(() => false),
+        });
+
+        expect(path).toBe('/settings/legal');
+    });
+});

--- a/src/constants/userTableSort.test.ts
+++ b/src/constants/userTableSort.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+    TENANT_ADMIN_ALLOWED_SORT_FIELDS,
+    USER_TABLE_API_SAFE_ORDER,
+    USER_TABLE_API_SAFE_SORT,
+    USER_TABLE_DEFAULT_ORDER,
+    USER_TABLE_DEFAULT_SORT,
+    USER_TABLE_PREFERRED_ORDER,
+    USER_TABLE_PREFERRED_SORT,
+    normalizeTenantAdminSortField,
+} from './userTableSort';
+
+describe('user table sort constants', () => {
+    it('keeps preferred defaults aligned with the exported default sort values', () => {
+        expect(USER_TABLE_DEFAULT_SORT).toBe(USER_TABLE_PREFERRED_SORT);
+        expect(USER_TABLE_DEFAULT_ORDER).toBe(USER_TABLE_PREFERRED_ORDER);
+        expect(USER_TABLE_API_SAFE_SORT).toBe('FIRSTNAME');
+        expect(USER_TABLE_API_SAFE_ORDER).toBe('ASC');
+    });
+
+    it('allows only tenant admin API supported sort fields', () => {
+        expect(TENANT_ADMIN_ALLOWED_SORT_FIELDS).toEqual([
+            'FIRSTNAME',
+            'LASTNAME',
+            'EMAIL',
+            'TENANT_ID',
+            'UPDATE_DATE',
+        ]);
+    });
+
+    it('normalizes allowed sort fields case-insensitively', () => {
+        expect(normalizeTenantAdminSortField('email')).toBe('EMAIL');
+        expect(normalizeTenantAdminSortField('update_date')).toBe('UPDATE_DATE');
+    });
+
+    it('falls back to the API-safe sort field for unsupported fields', () => {
+        expect(normalizeTenantAdminSortField('created_at')).toBe(USER_TABLE_API_SAFE_SORT);
+    });
+});

--- a/src/context/FeatureContext.test.tsx
+++ b/src/context/FeatureContext.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FeatureFlag } from '../enums/FeatureFlag';
+import { FeatureProvider, useFeatureContext } from './FeatureContext';
+
+const tenantData = {
+    settings: {
+        featureAppointmentsEnabled: true,
+        featureDemographicsEnabled: false,
+        featureTopicsEnabled: false,
+        topicsInRegistrationEnabled: true,
+    },
+} as any;
+
+const publicTenantData = {
+    settings: {
+        featureTopicsEnabled: true,
+        featureGroupChatV2Enabled: true,
+        featureCentralDataProtectionTemplateEnabled: false,
+    },
+} as any;
+
+const FeatureConsumer = () => {
+    const { isEnabled, toggleFeature } = useFeatureContext();
+
+    return (
+        <>
+            <output aria-label="appointments">{String(isEnabled(FeatureFlag.Appointments))}</output>
+            <output aria-label="topics">{String(isEnabled(FeatureFlag.Topics))}</output>
+            <output aria-label="registration-topics">{String(isEnabled(FeatureFlag.TopicsInRegistration))}</output>
+            <output aria-label="group-chat">{String(isEnabled(FeatureFlag.GroupChatV2))}</output>
+            <output aria-label="developer">{String(isEnabled(FeatureFlag.Developer))}</output>
+            <button type="button" onClick={() => toggleFeature(FeatureFlag.Developer)}>
+                Toggle developer
+            </button>
+        </>
+    );
+};
+
+describe('FeatureContext', () => {
+    it('maps tenant and public tenant settings to feature flags', () => {
+        render(
+            <FeatureProvider tenantData={tenantData} publicTenantData={publicTenantData}>
+                <FeatureConsumer />
+            </FeatureProvider>,
+        );
+
+        expect(screen.getByLabelText('appointments')).toHaveTextContent('true');
+        expect(screen.getByLabelText('topics')).toHaveTextContent('true');
+        expect(screen.getByLabelText('registration-topics')).toHaveTextContent('true');
+        expect(screen.getByLabelText('group-chat')).toHaveTextContent('true');
+        expect(screen.getByLabelText('developer')).toHaveTextContent('false');
+    });
+
+    it('toggles a feature in context state', () => {
+        render(
+            <FeatureProvider tenantData={{} as any} publicTenantData={{} as any}>
+                <FeatureConsumer />
+            </FeatureProvider>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Toggle developer' }));
+
+        expect(screen.getByLabelText('developer')).toHaveTextContent('true');
+    });
+});

--- a/src/context/useAppConfig.test.tsx
+++ b/src/context/useAppConfig.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { UseAppConfigProvider, useAppConfigContext } from './useAppConfig';
+
+vi.mock('../appConfig', () => ({
+    clusterFeatureFlags: {
+        useApiClusterSettings: true,
+    },
+}));
+
+const AppConfigConsumer = () => {
+    const { settings, setManualSettings, setServerSettings } = useAppConfigContext();
+
+    return (
+        <>
+            <output aria-label="api-cluster">{String(settings.useApiClusterSettings)}</output>
+            <output aria-label="tenant-creation">{String(settings.featureTenantCreationEnabled)}</output>
+            <output aria-label="release-toggle">
+                {String(settings.releaseToggles?.featureTenantCreationEnabled)}
+            </output>
+            <button
+                type="button"
+                onClick={() =>
+                    setServerSettings({
+                        featureTenantCreationEnabled: { value: true },
+                        releaseToggles: { featureTenantCreationEnabled: false },
+                    } as any)
+                }
+            >
+                Apply server settings
+            </button>
+            <button type="button" onClick={() => setManualSettings({ useApiClusterSettings: false })}>
+                Apply manual settings
+            </button>
+        </>
+    );
+};
+
+describe('useAppConfigContext', () => {
+    it('starts with cluster feature flag defaults', () => {
+        render(
+            <UseAppConfigProvider>
+                <AppConfigConsumer />
+            </UseAppConfigProvider>,
+        );
+
+        expect(screen.getByLabelText('api-cluster')).toHaveTextContent('true');
+    });
+
+    it('stores server settings values and their metadata', () => {
+        render(
+            <UseAppConfigProvider>
+                <AppConfigConsumer />
+            </UseAppConfigProvider>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Apply server settings' }));
+
+        expect(screen.getByLabelText('tenant-creation')).toHaveTextContent('true');
+        expect(screen.getByLabelText('release-toggle')).toHaveTextContent('false');
+    });
+
+    it('merges manual settings with the current config', () => {
+        render(
+            <UseAppConfigProvider>
+                <AppConfigConsumer />
+            </UseAppConfigProvider>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Apply manual settings' }));
+
+        expect(screen.getByLabelText('api-cluster')).toHaveTextContent('false');
+    });
+});

--- a/src/hooks/useComponentVisible.test.tsx
+++ b/src/hooks/useComponentVisible.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import useComponentVisible from './useComponentVisible';
+
+const VisibilityHarness = ({ initialIsVisible = false }: { initialIsVisible?: boolean }) => {
+    const { ref, isComponentVisible, setIsComponentVisible } = useComponentVisible(initialIsVisible);
+
+    return (
+        <>
+            <div ref={ref}>
+                <output aria-label="visibility">{String(isComponentVisible)}</output>
+                <button type="button" onClick={() => setIsComponentVisible(true)}>
+                    Show
+                </button>
+            </div>
+            <button type="button">Outside</button>
+        </>
+    );
+};
+
+describe('useComponentVisible', () => {
+    it('uses the provided initial visibility state', () => {
+        render(<VisibilityHarness initialIsVisible />);
+
+        expect(screen.getByLabelText('visibility')).toHaveTextContent('true');
+    });
+
+    it('can show the component via the returned setter', () => {
+        render(<VisibilityHarness />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show' }));
+
+        expect(screen.getByLabelText('visibility')).toHaveTextContent('true');
+    });
+
+    it('hides the component when Escape is pressed', () => {
+        render(<VisibilityHarness initialIsVisible />);
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+
+        expect(screen.getByLabelText('visibility')).toHaveTextContent('false');
+    });
+
+    it('hides the component when clicking outside the referenced element', () => {
+        render(<VisibilityHarness initialIsVisible />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Outside' }));
+
+        expect(screen.getByLabelText('visibility')).toHaveTextContent('false');
+    });
+});

--- a/src/hooks/useLoginMutation.hook.test.tsx
+++ b/src/hooks/useLoginMutation.hook.test.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider, setLogger } from 'react-query';
+import { tenantAccessEndpoint } from '../appConfig';
+import { FETCH_METHODS } from '../api/fetchData';
+import { ADMIN_PORTAL_ACCESS_DENIED, useLoginMutation } from './useLoginMutation.hook';
+
+const mocks = vi.hoisted(() => ({
+    apiServerSettings: vi.fn(),
+    fetchData: vi.fn(),
+    getAccessToken: vi.fn(),
+    hasAdminPortalAccess: vi.fn(),
+    onError: vi.fn(),
+    onSuccess: vi.fn(),
+    setServerSettings: vi.fn(),
+    setTokens: vi.fn(),
+}));
+
+vi.mock('../context/useAppConfig', () => ({
+    useAppConfigContext: () => ({
+        settings: { useApiClusterSettings: false },
+        setServerSettings: mocks.setServerSettings,
+    }),
+}));
+
+vi.mock('../api/auth/getAccessToken', () => ({
+    default: mocks.getAccessToken,
+}));
+
+vi.mock('../api/auth/auth', () => ({
+    setTokens: mocks.setTokens,
+}));
+
+vi.mock('../api/fetchData', async () => {
+    const actual = await vi.importActual<typeof import('../api/fetchData')>('../api/fetchData');
+
+    return {
+        ...actual,
+        fetchData: mocks.fetchData,
+    };
+});
+
+vi.mock('../api/settings/apiServerSettings', () => ({
+    apiServerSettings: mocks.apiServerSettings,
+}));
+
+vi.mock('../utils/adminPortalAccess', () => ({
+    hasAdminPortalAccess: mocks.hasAdminPortalAccess,
+}));
+
+const loginResponse = {
+    access_token: 'access-token',
+    expires_in: 300,
+    refresh_expires_in: 600,
+    refresh_token: 'refresh-token',
+};
+
+const renderLoginMutation = () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+
+    const TestComponent = () => {
+        const { mutate } = useLoginMutation('42');
+
+        return (
+            <button
+                type="button"
+                onClick={() =>
+                    mutate(
+                        {
+                            username: 'admin@example.com',
+                            password: 'correct-password',
+                            otp: '123456',
+                        },
+                        {
+                            onError: mocks.onError,
+                            onSuccess: mocks.onSuccess,
+                        },
+                    )
+                }
+            >
+                Login
+            </button>
+        );
+    };
+
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <TestComponent />
+        </QueryClientProvider>,
+    );
+};
+
+describe('useLoginMutation', () => {
+    beforeAll(() => {
+        setLogger({
+            error: () => undefined,
+            log: console.log,
+            warn: console.warn,
+        });
+    });
+
+    beforeEach(() => {
+        mocks.apiServerSettings.mockReset();
+        mocks.fetchData.mockReset();
+        mocks.getAccessToken.mockReset();
+        mocks.hasAdminPortalAccess.mockReset();
+        mocks.onError.mockReset();
+        mocks.onSuccess.mockReset();
+        mocks.setServerSettings.mockReset();
+        mocks.setTokens.mockReset();
+
+        mocks.getAccessToken.mockResolvedValue(loginResponse);
+        mocks.hasAdminPortalAccess.mockReturnValue(true);
+        mocks.fetchData.mockResolvedValue({ status: 200 });
+        mocks.setTokens.mockResolvedValue(undefined);
+    });
+
+    it('calls the login API, checks tenant access, and stores tokens on success', async () => {
+        const user = userEvent.setup();
+        renderLoginMutation();
+
+        await user.click(screen.getByRole('button', { name: 'Login' }));
+
+        await waitFor(() => {
+            expect(mocks.onSuccess).toHaveBeenCalledWith(
+                loginResponse,
+                { username: 'admin@example.com', password: 'correct-password', otp: '123456' },
+                undefined,
+            );
+        });
+        expect(mocks.getAccessToken).toHaveBeenCalledWith({
+            username: 'admin@example.com',
+            password: 'correct-password',
+            otp: '123456',
+        });
+        expect(mocks.fetchData).toHaveBeenCalledWith({
+            url: tenantAccessEndpoint,
+            method: FETCH_METHODS.GET,
+            headersData: {
+                Authorization: 'Bearer access-token',
+            },
+        });
+        expect(mocks.setTokens).toHaveBeenCalledWith('access-token', 300, 'refresh-token', 600);
+    });
+
+    it('blocks non-admin accounts before checking tenant access', async () => {
+        const user = userEvent.setup();
+        mocks.hasAdminPortalAccess.mockReturnValue(false);
+        renderLoginMutation();
+
+        await user.click(screen.getByRole('button', { name: 'Login' }));
+
+        await waitFor(() => {
+            expect(mocks.onError).toHaveBeenCalledWith(
+                new Error(ADMIN_PORTAL_ACCESS_DENIED),
+                { username: 'admin@example.com', password: 'correct-password', otp: '123456' },
+                undefined,
+            );
+        });
+        expect(mocks.fetchData).not.toHaveBeenCalled();
+        expect(mocks.setTokens).not.toHaveBeenCalled();
+    });
+});

--- a/src/hooks/useReleasesToggle.hook.test.tsx
+++ b/src/hooks/useReleasesToggle.hook.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ReleaseToggle } from '../enums/ReleaseToggle';
+import { useReleasesToggle } from './useReleasesToggle.hook';
+
+const mocks = vi.hoisted(() => ({
+    settings: {
+        releaseToggles: {
+            featureTenantCreationEnabled: true,
+            featureTenantAdminCanChangeTenantConfigurationEnabled: false,
+        },
+    },
+}));
+
+vi.mock('../context/useAppConfig', () => ({
+    useAppConfigContext: () => ({
+        settings: mocks.settings,
+    }),
+}));
+
+const ReleasesToggleHarness = () => {
+    const { isEnabled } = useReleasesToggle();
+
+    return (
+        <>
+            <output aria-label="tenant-creation">
+                {String(isEnabled(ReleaseToggle.TENANT_ADMIN_CREATING))}
+            </output>
+            <output aria-label="tenant-settings">
+                {String(isEnabled(ReleaseToggle.TENANT_ADMIN_SETTINGS_EDIT))}
+            </output>
+            <output aria-label="missing-toggle">{String(isEnabled(ReleaseToggle.COUNSELLING_RELATIONS))}</output>
+        </>
+    );
+};
+
+describe('useReleasesToggle', () => {
+    it('returns release toggle state from app config settings', () => {
+        render(<ReleasesToggleHarness />);
+
+        expect(screen.getByLabelText('tenant-creation')).toHaveTextContent('true');
+        expect(screen.getByLabelText('tenant-settings')).toHaveTextContent('false');
+        expect(screen.getByLabelText('missing-toggle')).toHaveTextContent('false');
+    });
+});

--- a/src/hooks/useUserPermission.test.tsx
+++ b/src/hooks/useUserPermission.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PermissionAction } from '../enums/PermissionAction';
+import { Resource } from '../enums/Resource';
+import { useUserPermissions } from './useUserPermission';
+
+vi.mock('../constants/userRolesToPermissions', () => ({
+    useUserRolesToPermission: () => ({
+        Tenant: { read: true, update: false },
+        LegalText: { update: true },
+    }),
+}));
+
+const PermissionsHarness = () => {
+    const { permissions, can } = useUserPermissions();
+
+    return (
+        <>
+            <output aria-label="tenant-read">{String(can(PermissionAction.Read, Resource.Tenant))}</output>
+            <output aria-label="tenant-update">{String(can(PermissionAction.Update, Resource.Tenant))}</output>
+            <output aria-label="any-tenant-action">
+                {String(can([PermissionAction.Update, PermissionAction.Read], Resource.Tenant))}
+            </output>
+            <output aria-label="missing-resource">{String(can(PermissionAction.Read, Resource.Agency))}</output>
+            <output aria-label="permissions">{JSON.stringify(permissions)}</output>
+        </>
+    );
+};
+
+describe('useUserPermissions', () => {
+    it('checks single actions, action arrays, and missing resources', () => {
+        render(<PermissionsHarness />);
+
+        expect(screen.getByLabelText('tenant-read')).toHaveTextContent('true');
+        expect(screen.getByLabelText('tenant-update')).toHaveTextContent('false');
+        expect(screen.getByLabelText('any-tenant-action')).toHaveTextContent('true');
+        expect(screen.getByLabelText('missing-resource')).toHaveTextContent('false');
+        expect(screen.getByLabelText('permissions')).toHaveTextContent('"Tenant"');
+    });
+});

--- a/src/hooks/useUserRoles.hook.test.tsx
+++ b/src/hooks/useUserRoles.hook.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserRole } from '../enums/UserRole';
+import { useUserRoles } from './useUserRoles.hook';
+
+const mocks = vi.hoisted(() => ({
+    getAccessTokenForRequests: vi.fn(),
+    parseJwt: vi.fn(),
+}));
+
+vi.mock('../api/auth/auth', () => ({
+    getAccessTokenForRequests: mocks.getAccessTokenForRequests,
+}));
+
+vi.mock('../utils/parseJWT', () => ({
+    default: mocks.parseJwt,
+}));
+
+const UserRolesHarness = () => {
+    const roles = useUserRoles();
+
+    return (
+        <>
+            <output aria-label="roles">{roles.roles.join(',')}</output>
+            <output aria-label="tenant-id">{String(roles.tenantId)}</output>
+            <output aria-label="super-admin">{String(roles.isSuperAdmin)}</output>
+            <output aria-label="tenant-scoped">{String(roles.isTenantScopedAdmin)}</output>
+            <output aria-label="technical">{String(roles.isTechnicalAccount)}</output>
+            <output aria-label="has-admin-role">{String(roles.hasRole([UserRole.AgencyAdmin, UserRole.UserAdmin]))}</output>
+        </>
+    );
+};
+
+describe('useUserRoles', () => {
+    beforeEach(() => {
+        mocks.getAccessTokenForRequests.mockReset();
+        mocks.parseJwt.mockReset();
+    });
+
+    it('returns no roles when no access token is available', () => {
+        mocks.getAccessTokenForRequests.mockReturnValue('');
+
+        render(<UserRolesHarness />);
+
+        expect(screen.getByLabelText('roles')).toHaveTextContent('');
+        expect(screen.getByLabelText('tenant-id')).toHaveTextContent('null');
+        expect(screen.getByLabelText('super-admin')).toHaveTextContent('false');
+    });
+
+    it('detects global super admins and technical accounts from token claims', () => {
+        mocks.getAccessTokenForRequests.mockReturnValue('token');
+        mocks.parseJwt.mockReturnValue({
+            tenantId: 0,
+            realm_access: {
+                roles: [UserRole.AgencyAdmin, UserRole.TenantAdmin, UserRole.Technical],
+            },
+        });
+
+        render(<UserRolesHarness />);
+
+        expect(screen.getByLabelText('roles')).toHaveTextContent('agency-admin,tenant-admin,technical');
+        expect(screen.getByLabelText('tenant-id')).toHaveTextContent('0');
+        expect(screen.getByLabelText('super-admin')).toHaveTextContent('true');
+        expect(screen.getByLabelText('technical')).toHaveTextContent('true');
+        expect(screen.getByLabelText('has-admin-role')).toHaveTextContent('true');
+    });
+
+    it('detects tenant scoped admins from string tenant ids', () => {
+        mocks.getAccessTokenForRequests.mockReturnValue('token');
+        mocks.parseJwt.mockReturnValue({
+            tenantId: '42',
+            realm_access: {
+                roles: [UserRole.TenantAdmin],
+            },
+        });
+
+        render(<UserRolesHarness />);
+
+        expect(screen.getByLabelText('tenant-id')).toHaveTextContent('42');
+        expect(screen.getByLabelText('tenant-scoped')).toHaveTextContent('true');
+        expect(screen.getByLabelText('super-admin')).toHaveTextContent('false');
+    });
+});

--- a/src/pages/ErrorPages.test.tsx
+++ b/src/pages/ErrorPages.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Error404 } from './Error404';
+import { AccessDenied } from './ErrorPages/AccessDenied';
+
+const mocks = vi.hoisted(() => ({
+    hasRole: vi.fn(),
+}));
+
+const translations: Record<string, string> = {
+    'errorPages.accessDenied.description': 'You do not have access to this area.',
+    'errorPages.accessDenied.title': 'Access denied',
+    'errorPages.notFound.description': 'This page does not exist.',
+    toHomePage: 'Go to homepage',
+};
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => translations[key] || key }),
+}));
+
+vi.mock('../components/Layout/PublicPageLayoutWrapper', () => ({
+    default: ({ children }: { children: React.ReactNode }) => <main>{children}</main>,
+}));
+
+vi.mock('../hooks/useUserRoles.hook', () => ({
+    useUserRoles: () => ({ hasRole: mocks.hasRole }),
+}));
+
+vi.mock('../resources/img/illustrations/unauthorized.svg', () => ({
+    ReactComponent: () => <svg aria-label="unauthorized" />,
+}));
+
+describe('error pages', () => {
+    it('renders a translated 404 page with a home link', () => {
+        render(
+            <MemoryRouter>
+                <Error404 />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByRole('heading', { name: '404' })).toBeInTheDocument();
+        expect(screen.getByText('This page does not exist.')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Go to homepage' })).toHaveAttribute('href', '/');
+    });
+
+    it('sends admin users back to the admin app from access denied', () => {
+        mocks.hasRole.mockReturnValue(true);
+
+        render(<AccessDenied />);
+
+        expect(screen.getByRole('heading', { name: 'Access denied' })).toBeInTheDocument();
+        expect(screen.getByText('You do not have access to this area.')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Go to homepage' })).toHaveAttribute('href', '/admin');
+    });
+
+    it('sends non-admin users back to the frontend app from access denied', () => {
+        mocks.hasRole.mockReturnValue(false);
+
+        render(<AccessDenied />);
+
+        expect(screen.getByRole('link', { name: 'Go to homepage' })).toHaveAttribute('href', '/app');
+    });
+});

--- a/src/pages/Login/LoginForm.test.tsx
+++ b/src/pages/Login/LoginForm.test.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoginForm from './LoginForm';
+import { FETCH_ERRORS } from '../../api/fetchData';
+import { ADMIN_PORTAL_ACCESS_DENIED } from '../../hooks/useLoginMutation.hook';
+import { TwoFactorType } from '../../enums/TwoFactorType';
+
+const mocks = vi.hoisted(() => ({
+    login: vi.fn(),
+    messageError: vi.fn(),
+    navigate: vi.fn(),
+}));
+
+const translations: Record<string, string> = {
+    'admin.login': 'Admin login',
+    username: 'Username',
+    'username.or.email': 'Username/Email',
+    password: 'Password',
+    otp: 'One-time password',
+    'password.forgot': 'Forgot password?',
+    'message.form.login.loginBtn': 'Sign in',
+    'message.form.login.username': 'Please enter username/email',
+    'message.form.login.password': 'Please enter password',
+    'message.form.login.otp': 'Please enter one-time password',
+    'message.form.login.otp.EMAIL': 'Please enter the code from your email for two-factor authentication.',
+    'message.form.login.otp.APP': 'Please enter the code from your app for two-factor authentication.',
+    'message.error.auth.adminOnly': 'This account cannot access the admin portal. Please use an admin account.',
+    'message.error.auth.login': 'Login failed. Please check username/email and password.',
+};
+
+const t = (key: string) => translations[key] || key;
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => Object.assign([t], { t, i18n: { language: 'en' } }),
+}));
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+    return {
+        ...actual,
+        useNavigate: () => mocks.navigate,
+    };
+});
+
+vi.mock('antd', async () => {
+    const actual = await vi.importActual<typeof import('antd')>('antd');
+    return {
+        ...actual,
+        message: {
+            ...actual.message,
+            error: mocks.messageError,
+        },
+    };
+});
+
+vi.mock('../../hooks/usePublicTenantData.hook', () => ({
+    usePublicTenantData: () => ({ data: { id: 42 } }),
+}));
+
+vi.mock('../../hooks/useLoginMutation.hook', async () => {
+    const actual = await vi.importActual<typeof import('../../hooks/useLoginMutation.hook')>(
+        '../../hooks/useLoginMutation.hook',
+    );
+
+    return {
+        ...actual,
+        useLoginMutation: () => ({ mutate: mocks.login }),
+    };
+});
+
+vi.mock('../../components/CustomIcons/Lock', () => ({
+    default: () => <span data-testid="lock-icon" />,
+}));
+
+vi.mock('../../components/CustomIcons/Person', () => ({
+    default: () => <span data-testid="person-icon" />,
+}));
+
+vi.mock('../../components/CustomIcons/Verified', () => ({
+    default: () => <span data-testid="verified-icon" />,
+}));
+
+const fillRequiredFields = async () => {
+    const user = userEvent.setup();
+
+    await user.type(screen.getByPlaceholderText('Username/Email'), 'admin@example.com');
+    await user.type(screen.getByPlaceholderText('Password'), 'correct-password');
+
+    return user;
+};
+
+describe('LoginForm', () => {
+    beforeAll(() => {
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: vi.fn().mockImplementation((query: string) => ({
+                addEventListener: vi.fn(),
+                addListener: vi.fn(),
+                dispatchEvent: vi.fn(),
+                matches: false,
+                media: query,
+                onchange: null,
+                removeEventListener: vi.fn(),
+                removeListener: vi.fn(),
+            })),
+        });
+    });
+
+    beforeEach(() => {
+        mocks.login.mockReset();
+        mocks.messageError.mockReset();
+        mocks.navigate.mockReset();
+        consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        consoleWarnSpy.mockRestore();
+    });
+
+    it('keeps sign in disabled until username and password are entered', async () => {
+        const user = userEvent.setup();
+        render(<LoginForm />);
+
+        const signInButton = screen.getByRole('button', { name: 'Sign in' });
+        expect(signInButton).toBeDisabled();
+
+        await user.type(screen.getByPlaceholderText('Username/Email'), 'admin@example.com');
+        expect(signInButton).toBeDisabled();
+
+        await user.type(screen.getByPlaceholderText('Password'), 'correct-password');
+        expect(signInButton).toBeEnabled();
+    });
+
+    it('submits the entered username and password to the login mutation', async () => {
+        render(<LoginForm />);
+        const user = await fillRequiredFields();
+
+        await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+        await waitFor(() => {
+            expect(mocks.login).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    password: 'correct-password',
+                    username: 'admin@example.com',
+                }),
+                expect.objectContaining({
+                    onError: expect.any(Function),
+                    onSuccess: expect.any(Function),
+                }),
+            );
+        });
+    });
+
+    it('navigates to the admin area after a successful login', async () => {
+        mocks.login.mockImplementation((_values, options) => options.onSuccess());
+        render(<LoginForm />);
+        const user = await fillRequiredFields();
+
+        await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+        await waitFor(() => {
+            expect(mocks.navigate).toHaveBeenCalledWith('/admin');
+        });
+    });
+
+    it('shows a login error message for invalid credentials', async () => {
+        mocks.login.mockImplementation((_values, options) => options.onError(new Error('invalid-login')));
+        render(<LoginForm />);
+        const user = await fillRequiredFields();
+
+        await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+        await waitFor(() => {
+            expect(mocks.messageError).toHaveBeenCalledWith('Login failed. Please check username/email and password.');
+        });
+    });
+
+    it('shows an admin-only error message when the account has no admin portal access', async () => {
+        mocks.login.mockImplementation((_values, options) => options.onError(new Error(ADMIN_PORTAL_ACCESS_DENIED)));
+        render(<LoginForm />);
+        const user = await fillRequiredFields();
+
+        await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+        await waitFor(() => {
+            expect(mocks.messageError).toHaveBeenCalledWith(
+                'This account cannot access the admin portal. Please use an admin account.',
+            );
+        });
+    });
+
+    it('reveals and validates the OTP field when two-factor authentication is required', async () => {
+        mocks.login.mockImplementationOnce((_values, options) =>
+            options.onError({
+                message: FETCH_ERRORS.BAD_REQUEST,
+                options: { data: { otpType: TwoFactorType.Email } },
+            }),
+        );
+        render(<LoginForm />);
+        const user = await fillRequiredFields();
+
+        await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+        expect(await screen.findByPlaceholderText('One-time password')).toBeInTheDocument();
+        expect(
+            screen.getByText('Please enter the code from your email for two-factor authentication.'),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+        expect(await screen.findByText('Please enter one-time password')).toBeInTheDocument();
+    });
+});

--- a/src/router/ProtectedRoute.test.tsx
+++ b/src/router/ProtectedRoute.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ProtectedRoute } from './ProtectedRoute';
+
+const mocks = vi.hoisted(() => ({
+    bootstrapAuthSession: vi.fn(),
+    getAccessTokenForRequests: vi.fn(),
+    getRefreshTokenForRequests: vi.fn(),
+    getTokenExpiryFromLocalStorage: vi.fn(),
+    hasAdminPortalAccess: vi.fn(),
+    logout: vi.fn(),
+}));
+
+vi.mock('../components/Layout/Initialization', () => ({
+    Initialization: () => <div>Initializing</div>,
+}));
+
+vi.mock('../api/auth/accessSessionLocalStorage', () => ({
+    getTokenExpiryFromLocalStorage: mocks.getTokenExpiryFromLocalStorage,
+}));
+
+vi.mock('../api/auth/auth', () => ({
+    bootstrapAuthSession: mocks.bootstrapAuthSession,
+    getAccessTokenForRequests: mocks.getAccessTokenForRequests,
+    getRefreshTokenForRequests: mocks.getRefreshTokenForRequests,
+}));
+
+vi.mock('../api/auth/logout', () => ({
+    default: mocks.logout,
+}));
+
+vi.mock('../utils/adminPortalAccess', () => ({
+    hasAdminPortalAccess: mocks.hasAdminPortalAccess,
+}));
+
+const renderProtectedRoute = () =>
+    render(
+        <MemoryRouter initialEntries={['/admin/settings']}>
+            <Routes>
+                <Route
+                    path="/admin/settings"
+                    element={
+                        <ProtectedRoute>
+                            <div>Protected content</div>
+                        </ProtectedRoute>
+                    }
+                />
+                <Route path="/admin/login" element={<div>Login page</div>} />
+            </Routes>
+        </MemoryRouter>,
+    );
+
+describe('ProtectedRoute', () => {
+    beforeEach(() => {
+        mocks.bootstrapAuthSession.mockReset();
+        mocks.getAccessTokenForRequests.mockReset();
+        mocks.getRefreshTokenForRequests.mockReset();
+        mocks.getTokenExpiryFromLocalStorage.mockReset();
+        mocks.hasAdminPortalAccess.mockReset();
+        mocks.logout.mockReset();
+
+        mocks.bootstrapAuthSession.mockResolvedValue(true);
+        mocks.getAccessTokenForRequests.mockReturnValue('access-token');
+        mocks.getRefreshTokenForRequests.mockReturnValue('refresh-token');
+        mocks.getTokenExpiryFromLocalStorage.mockReturnValue({
+            accessTokenValidUntilTime: Date.now() + 60_000,
+            refreshTokenValidUntilTime: Date.now() + 120_000,
+        });
+        mocks.hasAdminPortalAccess.mockReturnValue(true);
+    });
+
+    it('shows the initialization state while the auth session bootstraps', () => {
+        mocks.bootstrapAuthSession.mockReturnValue(new Promise(() => undefined));
+
+        renderProtectedRoute();
+
+        expect(screen.getByText('Initializing')).toBeInTheDocument();
+    });
+
+    it('renders protected content when valid admin tokens are available', async () => {
+        renderProtectedRoute();
+
+        expect(await screen.findByText('Protected content')).toBeInTheDocument();
+        expect(mocks.logout).not.toHaveBeenCalled();
+    });
+
+    it('redirects to login when session tokens are missing', async () => {
+        mocks.getAccessTokenForRequests.mockReturnValue('');
+
+        renderProtectedRoute();
+
+        expect(await screen.findByText('Login page')).toBeInTheDocument();
+        expect(mocks.logout).toHaveBeenCalledWith(true);
+    });
+
+    it('redirects to login when the tokens are expired', async () => {
+        mocks.getTokenExpiryFromLocalStorage.mockReturnValue({
+            accessTokenValidUntilTime: Date.now() - 60_000,
+            refreshTokenValidUntilTime: Date.now() - 30_000,
+        });
+
+        renderProtectedRoute();
+
+        expect(await screen.findByText('Login page')).toBeInTheDocument();
+        expect(mocks.logout).toHaveBeenCalledWith(true);
+    });
+
+    it('logs out and redirects when the token has no admin portal access', async () => {
+        mocks.hasAdminPortalAccess.mockReturnValue(false);
+
+        renderProtectedRoute();
+
+        await waitFor(() => {
+            expect(mocks.logout).toHaveBeenCalledWith(true, '/admin/login');
+        });
+        expect(screen.getByText('Login page')).toBeInTheDocument();
+    });
+});

--- a/src/utils/language.test.ts
+++ b/src/utils/language.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+    DEFAULT_LANGUAGE,
+    LANGUAGE_COOKIE_KEY,
+    LANGUAGE_STORAGE_KEY,
+    detectBrowserLanguage,
+    getInitialLanguage,
+    getStoredLanguage,
+    isSupportedLanguage,
+    normalizeLanguage,
+    storeLanguage,
+    updateDocumentLanguage,
+} from './language';
+
+const storage: Record<string, string> = {};
+
+describe('language utilities', () => {
+    beforeEach(() => {
+        Object.keys(storage).forEach((key) => delete storage[key]);
+        Object.defineProperty(globalThis, 'localStorage', {
+            configurable: true,
+            value: {
+                getItem: (key: string) => storage[key] ?? null,
+                setItem: (key: string, value: string) => {
+                    storage[key] = value;
+                },
+            },
+        });
+        document.cookie = `${LANGUAGE_COOKIE_KEY}=;path=/;Max-Age=0`;
+        document.documentElement.lang = '';
+    });
+
+    it('normalizes supported locale strings', () => {
+        expect(isSupportedLanguage('de')).toBe(true);
+        expect(isSupportedLanguage('fr')).toBe(false);
+        expect(normalizeLanguage('de-DE')).toBe('de');
+        expect(normalizeLanguage('fr-FR')).toBeNull();
+    });
+
+    it('stores and reads the preferred language from cookie/localStorage', () => {
+        storeLanguage('de');
+
+        expect(globalThis.localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe('de');
+        expect(getStoredLanguage()).toBe('de');
+        expect(getInitialLanguage()).toBe('de');
+    });
+
+    it('updates the document language attribute', () => {
+        updateDocumentLanguage('en');
+
+        expect(document.documentElement.lang).toBe('en');
+    });
+
+    it('falls back to the default language for non-German browsers', () => {
+        expect(detectBrowserLanguage()).toBe(DEFAULT_LANGUAGE);
+    });
+});

--- a/src/utils/themeSeeds.test.ts
+++ b/src/utils/themeSeeds.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { buildSeedUpdate, getAccentDark, getAccentLight, readSeeds } from './themeSeeds';
+
+describe('theme seed helpers', () => {
+    it('prefers new seed names while keeping compatibility aliases', () => {
+        expect(getAccentDark({ accentDark: '#111111', primary: '#222222' })).toBe('#111111');
+        expect(getAccentDark({ primary: '#222222' })).toBe('#222222');
+        expect(getAccentLight({ accentLight: '#aaaaaa', accent: '#bbbbbb' })).toBe('#aaaaaa');
+        expect(getAccentLight({ accent: '#bbbbbb' })).toBe('#bbbbbb');
+    });
+
+    it('reads backend theming fields into seed aliases', () => {
+        expect(readSeeds({ primaryColor: '#123456', accent: '#abcdef' })).toEqual({
+            accent: '#abcdef',
+            accentDark: '#123456',
+            accentLight: '#abcdef',
+            primary: '#123456',
+        });
+    });
+
+    it('builds backend update payloads from seed values', () => {
+        expect(buildSeedUpdate({ accentDark: '#111111', accentLight: '#eeeeee' })).toEqual({
+            accent: '#eeeeee',
+            primaryColor: '#111111',
+            secondaryColor: null,
+            signal: null,
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for previously untested admin modules across authentication, routing, login flows, invite links, permissions settings, shared UI components, and utilities. All tests use **Vitest** with **React Testing Library** — no production code changes.

**Scope:** 16 test files · ~1,163 lines · **55 new test cases**

## What's covered

### Auth, login & routing

- **`ProtectedRoute`** — bootstrap loading state, valid admin session access, redirect on missing/expired tokens, logout when admin portal access is denied
- **`LoginForm`** — disabled submit until credentials entered, login submission, post-login navigation, invalid credentials, admin-only access error, 2FA OTP field validation
- **`useLoginMutation`** — successful login with tenant access check and token storage, blocking non-admin accounts
- **`tokenSessionStore`** — in-memory access/refresh token storage and clearing empty values

### API helpers

- **`inviteLinkApiShared`** — tenant ID header resolution, pagination query strings, array-to-paged response normalization, safe defaults for missing fields
- **`topicInviteLinks`** — invite URL building with encoded topic names, list/create API calls, label formatting and fallbacks

### Permissions settings

- **`permissionsSettingsUtils`** — forced-off platform toggles, feature value mapping, tenant admin control sync, master/sub-toggle relationships
- **`permissionsToggleLogic`** — nested payload building, disabling child toggles when master is off, Ant Design form sync

### UI components

- **`CopyToClipboard`** — copy action and success notification
- **`FeatureEnabled`** — renders/hides children based on release toggle
- **`StatusTag`** — invite link status and anonymity labels
- **`M3Switch`** — checked state announcement, toggle behavior, disabled state
- **`SearchInput`** — debounced search, Enter key search, clear button behavior

### Pages & utilities

- **`ErrorPages`** — translated 404 page, access-denied redirects for admin vs non-admin users
- **`language`** — locale normalization, cookie/localStorage persistence, document language attribute, browser fallback
- **`themeSeeds`** — seed name aliases, backend theming field mapping, update payload building

## Testing approach

- Vitest with `vi.mock` for API calls, auth/session helpers, routing, and i18n
- React Testing Library + `userEvent` for form interactions and component behavior
- `jsdom` environment for DOM-dependent tests (login, routing, clipboard, search)

## Test plan

- [ ] `npm test` — all unit tests pass
- [ ] CI passes on PR
- [ ] No production code changes — tests only