### PR TITLE
Fachbereich DPP editor in the agency legal view (per topic)

### DIFF
--- a/src/api/agency/dpp.test.ts
+++ b/src/api/agency/dpp.test.ts
@@ -11,8 +11,23 @@ vi.mock('../../appConfig', () => ({ agencyEndpointBase: '/service/agencyadmin/ag
 
 // eslint-disable-next-line import/first
 import { publishDepartmentDpp } from './publishDepartmentDpp';
+// eslint-disable-next-line import/first
+import { getDepartmentDpp } from './getDepartmentDpp';
 
 beforeEach(() => fetchData.mockClear());
+
+describe('getDepartmentDpp', () => {
+    it('GETs the Fachbereich DPP endpoint with auth', () => {
+        getDepartmentDpp(7, 42);
+        expect(fetchData).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/service/agencyadmin/agencies/7/topics/42/dpp',
+                method: 'GET',
+                skipAuth: false,
+            }),
+        );
+    });
+});
 
 describe('publishDepartmentDpp', () => {
     it('PUTs the Fachbereich DPP endpoint with the content map and publish flag', () => {

--- a/src/api/agency/getDepartmentDpp.ts
+++ b/src/api/agency/getDepartmentDpp.ts
@@ -1,0 +1,15 @@
+import { agencyEndpointBase } from '../../appConfig';
+import { DepartmentDataProtectionContent } from '../../types/dpp';
+import { FETCH_ERRORS, FETCH_METHODS, fetchData } from '../fetchData';
+
+/**
+ * Reads a department's (Fachbereich = agency × topic) stored data privacy policy (content + status)
+ * so the admin editor can be prefilled instead of overwriting on publish.
+ */
+export const getDepartmentDpp = (agencyId: number, topicId: number) =>
+    fetchData({
+        url: `${agencyEndpointBase}/${agencyId}/topics/${topicId}/dpp`,
+        method: FETCH_METHODS.GET,
+        skipAuth: false,
+        responseHandling: [FETCH_ERRORS.CATCH_ALL],
+    }) as Promise<DepartmentDataProtectionContent>;

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/DepartmentDataProtectionContainer.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/DepartmentDataProtectionContainer.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DepartmentDataProtectionContainer } from './index';
+
+const { useDepartmentDpp, publishMutate, useTranslation } = vi.hoisted(() => ({
+    useDepartmentDpp: vi.fn(),
+    publishMutate: vi.fn(),
+    useTranslation: vi.fn(() => ({ i18n: { language: 'de' } })),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation }));
+vi.mock('../../../../../hooks/useDepartmentDpp.hook', () => ({ useDepartmentDpp }));
+vi.mock('../../../../../hooks/usePublishDepartmentDpp.hook', () => ({
+    usePublishDepartmentDpp: () => ({ mutate: publishMutate, isPending: false }),
+}));
+
+// Stub the card to a plain node that echoes props and exposes onSave.
+vi.mock('../DepartmentDataProtectionCard', () => ({
+    DepartmentDataProtectionCard: ({ initialContent, publicationStatus, departmentName, onSave }: any) => (
+        <div
+            data-testid="card"
+            data-content={initialContent}
+            data-status={publicationStatus}
+            data-name={departmentName}
+        >
+            <button type="button" onClick={() => onSave('<p>edited</p>', true)}>
+                save
+            </button>
+        </div>
+    ),
+}));
+
+beforeEach(() => {
+    publishMutate.mockClear();
+    useTranslation.mockReturnValue({ i18n: { language: 'de-DE' } });
+});
+
+describe('DepartmentDataProtectionContainer', () => {
+    it('renders nothing while loading', () => {
+        useDepartmentDpp.mockReturnValue({ data: undefined, isLoading: true });
+        const { container } = render(
+            <DepartmentDataProtectionContainer agencyId={7} topicId={42} departmentName="Sucht" />,
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('prefills the editor with the active-language content and status', () => {
+        useDepartmentDpp.mockReturnValue({
+            data: { content: '{"de":"<p>DE</p>","en":"<p>EN</p>"}', publicationStatus: 'PUBLISHED' },
+            isLoading: false,
+        });
+        render(
+            <DepartmentDataProtectionContainer agencyId={7} topicId={42} departmentName="Sucht" />,
+        );
+        const card = screen.getByTestId('card');
+        expect(card).toHaveAttribute('data-content', '<p>DE</p>');
+        expect(card).toHaveAttribute('data-status', 'PUBLISHED');
+        expect(card).toHaveAttribute('data-name', 'Sucht');
+    });
+
+    it('publishes the edited HTML under the active language', async () => {
+        const user = userEvent.setup();
+        useDepartmentDpp.mockReturnValue({
+            data: { content: null, publicationStatus: 'DRAFT' },
+            isLoading: false,
+        });
+        render(<DepartmentDataProtectionContainer agencyId={7} topicId={42} />);
+
+        await user.click(screen.getByRole('button', { name: 'save' }));
+
+        expect(publishMutate).toHaveBeenCalledWith({ content: { de: '<p>edited</p>' }, publish: true });
+    });
+
+    it('falls back to empty content when nothing is stored', () => {
+        useDepartmentDpp.mockReturnValue({ data: { content: null, publicationStatus: 'DRAFT' }, isLoading: false });
+        render(<DepartmentDataProtectionContainer agencyId={7} topicId={42} />);
+        expect(screen.getByTestId('card')).toHaveAttribute('data-content', '');
+    });
+});

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/index.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from 'react-i18next';
+import { useDepartmentDpp } from '../../../../../hooks/useDepartmentDpp.hook';
+import { usePublishDepartmentDpp } from '../../../../../hooks/usePublishDepartmentDpp.hook';
+import { DepartmentDataProtectionCard } from '../DepartmentDataProtectionCard';
+
+interface DepartmentDataProtectionContainerProps {
+    agencyId: number;
+    topicId: number;
+    departmentName?: string;
+}
+
+/** Reads the stored multilingual JSON content and returns the HTML for the active language. */
+const pickLanguage = (jsonContent: string | null | undefined, lang: string): string => {
+    if (!jsonContent) {
+        return '';
+    }
+    try {
+        const map = JSON.parse(jsonContent) as Record<string, string>;
+        return map[lang] ?? Object.values(map)[0] ?? '';
+    } catch {
+        // Not a JSON map (older/plain content) — show it as-is.
+        return jsonContent;
+    }
+};
+
+/**
+ * Container for one Fachbereich's (agency × topic) data privacy policy card: loads the stored
+ * content + status to prefill the editor, and wires the publish/draft mutation (which refreshes the
+ * read query on success).
+ */
+export const DepartmentDataProtectionContainer = ({
+    agencyId,
+    topicId,
+    departmentName,
+}: DepartmentDataProtectionContainerProps) => {
+    const { i18n } = useTranslation();
+    const lang = i18n.language?.split('-')[0] || 'de';
+
+    const { data, isLoading } = useDepartmentDpp(agencyId, topicId);
+    const { mutate: publish, isPending } = usePublishDepartmentDpp(agencyId, topicId);
+
+    if (isLoading) {
+        return null;
+    }
+
+    return (
+        <DepartmentDataProtectionCard
+            // remount when the stored content changes (e.g. after a publish) so the editor resets to it
+            key={`${agencyId}-${topicId}-${data?.content ?? ''}`}
+            departmentName={departmentName}
+            initialContent={pickLanguage(data?.content, lang)}
+            publicationStatus={data?.publicationStatus}
+            onSave={(html, doPublish) => publish({ content: { [lang]: html }, publish: doPublish })}
+            saving={isPending}
+        />
+    );
+};
+
+export default DepartmentDataProtectionContainer;

--- a/src/hooks/useDepartmentDpp.hook.ts
+++ b/src/hooks/useDepartmentDpp.hook.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { getDepartmentDpp } from '../api/agency/getDepartmentDpp';
+
+export const DEPARTMENT_DPP_KEY = 'department-dpp';
+
+/** Loads a Fachbereich's (agency × topic) stored data privacy policy to prefill the editor. */
+export const useDepartmentDpp = (agencyId: number, topicId: number) =>
+    useQuery({
+        queryKey: [DEPARTMENT_DPP_KEY, agencyId, topicId],
+        queryFn: () => getDepartmentDpp(agencyId, topicId),
+        enabled: Number.isFinite(agencyId) && Number.isFinite(topicId),
+    });

--- a/src/hooks/usePublishDepartmentDpp.hook.ts
+++ b/src/hooks/usePublishDepartmentDpp.hook.ts
@@ -1,5 +1,6 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { publishDepartmentDpp } from '../api/agency/publishDepartmentDpp';
+import { DEPARTMENT_DPP_KEY } from './useDepartmentDpp.hook';
 
 interface PublishDepartmentDppVariables {
     /** Language → HTML map of the department data privacy policy. */
@@ -9,8 +10,11 @@ interface PublishDepartmentDppVariables {
 }
 
 /** Publishes or draft-saves a Fachbereich's (agency × topic) own data privacy policy. */
-export const usePublishDepartmentDpp = (agencyId: number, topicId: number) =>
-    useMutation({
+export const usePublishDepartmentDpp = (agencyId: number, topicId: number) => {
+    const queryClient = useQueryClient();
+    return useMutation({
         mutationFn: ({ content, publish }: PublishDepartmentDppVariables) =>
             publishDepartmentDpp(agencyId, topicId, content, publish),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: [DEPARTMENT_DPP_KEY, agencyId, topicId] }),
     });
+};

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -25,6 +25,7 @@ import { ResponsibleSettings } from './components/ResponsibleSettings';
 import { ContactSettings } from './components/ContactSettings';
 import { LegalTextSettings } from './components/LegalTextSettings';
 import { DataProcessingAgreement } from '../../../components/Tenants/LegalSettings/components/DataProcessingAgreement';
+import { DepartmentDataProtectionContainer } from '../../../components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer';
 import styles from '../../../components/Page/styles.module.scss';
 import { CardEditable } from '../../../components/CardEditable';
 import { PermissionsSettings } from '../../../components/Tenants/AppSettings/PermissionsSettings';
@@ -382,6 +383,18 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
                 <CardDeck.Item>
                     <DataProcessingAgreement />
                 </CardDeck.Item>
+                {agencyData?.id &&
+                    (agencyData.topics || [])
+                        .filter((topic) => topic.id != null)
+                        .map((topic) => (
+                            <CardDeck.Item key={`dpp-${topic.id}`}>
+                                <DepartmentDataProtectionContainer
+                                    agencyId={Number(agencyData.id)}
+                                    topicId={topic.id as number}
+                                    departmentName={topic.name}
+                                />
+                            </CardDeck.Item>
+                        ))}
             </CardDeck>
         </>
     );

--- a/src/types/dpp.ts
+++ b/src/types/dpp.ts
@@ -5,3 +5,10 @@ export type DepartmentPublicationStatus = 'DRAFT' | 'PUBLISHED';
 export interface DepartmentDataProtectionResponse {
     publicationStatus: DepartmentPublicationStatus;
 }
+
+/** Stored Fachbereich DPP returned by the read endpoint (prefill). */
+export interface DepartmentDataProtectionContent {
+    /** Multilingual JSON language→HTML map string; null/absent if never authored. */
+    content?: string | null;
+    publicationStatus: DepartmentPublicationStatus;
+}


### PR DESCRIPTION
Wires the Fachbereich (agency × topic) data-privacy-policy editor into the agency **legal-settings** view — one card per topic of the agency — completing the DPP admin UI end to end (backend read endpoint: ORISO-AgencyService #84).

- `getDepartmentDpp` + `useDepartmentDpp` query hook prefill the editor with stored content + status.
- `usePublishDepartmentDpp` invalidates the read query on success.
- `DepartmentDataProtectionContainer` maps the multilingual JSON to the active language, renders the card, wires publish/draft.
- Mount: `Agency/Edit` legal CardDeck renders one `DepartmentDataProtectionContainer` per topic (keyed, only topics with an id).
- Tests: api GET + container 4; full suite 270 pass (72 files); tsc clean; build OK.

**Placement note:** shown per Fachbereich inside the agency's Legal settings, after the (placeholder) DPA card. Open to feedback on placement before merge.

Affected repos: ORISO-Admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)