### PR TITLE
chore: add admin Storybook verification gate

### DIFF
--- a/.github/workflows/ci-feature-branch.yml
+++ b/.github/workflows/ci-feature-branch.yml
@@ -18,3 +18,6 @@ jobs:
       uses: ./.github/actions/node-build
       with:
         node_version: '22.12.0'
+
+    - name: Build Storybook
+      run: npm run build-storybook

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         node_version: '22.12.0'
 
+    - name: Build Storybook
+      run: npm run build-storybook
+
     - name: Create Docker image
       uses: ./.github/actions/docker-build-push
       with:

--- a/docs/admin-mui9-antd-inventory.md
+++ b/docs/admin-mui9-antd-inventory.md
@@ -1,0 +1,36 @@
+# Admin MUI 9 and AntD Inventory
+
+This branch verifies the current `origin/dev` admin modernization baseline before cutting smaller UI follow-up PRs.
+
+## Current baseline
+
+- React 19.2.7, Vite 8.1.2, Storybook 10.4.6, Cypress 15.18.0, and MUI 9.1.x are already present on `origin/dev`.
+- Storybook uses the Vite builder and exposes `@storybook/addon-mcp`.
+- `src/components/mui/MuiFormField.tsx` is the first shared MUI form adapter. It still wraps AntD `Form.Item`, so validation and existing form state stay compatible while presentation moves to MUI.
+
+## AntD usage that remains
+
+AntD is still a broad dependency across the admin panel and should not be removed globally in one review. The largest remaining groups are:
+
+- Layout and shell: `src/components/Layout/**`, `src/App.tsx`, `src/index.tsx`, `.storybook/preview.tsx`.
+- Forms and fields: `src/components/Form*`, `src/components/SelectFormField`, `src/components/SliderFormField`, `src/components/TranslatableFormField`, `src/components/ModalForm`.
+- Data display and editing: `src/components/ListingTable`, `src/components/ResizableTable`, `src/components/EditableTable`, status tags, cards, and modals.
+- Admin pages: `src/pages/Tenants`, `src/pages/Agency`, `src/pages/users`, `src/pages/Topics`, `src/pages/Links`, `src/pages/Profile`, `src/pages/Logs`.
+- Legal settings/DPP cards: `DataProcessingAgreementCard`, `DepartmentDataProtectionCard`, and `LegalVersionViewer` still use AntD controls while their stories provide the current regression surface.
+
+## Reviewable migration shape
+
+Recommended next PRs:
+
+1. Migrate shared buttons, alerts, text inputs, password inputs, and simple selects through shared MUI adapters.
+2. Move modal/card/table-heavy flows only after story and browser coverage exists for each flow.
+3. Keep AntD `Form.Item` compatibility until the page-level forms are migrated, because the current validation and submit behavior depends on it.
+4. Replace page-level AntD layout (`Row`, `Col`, `Space`) with MUI layout primitives only where the responsive behavior can be verified in Storybook and app runtime.
+
+## WCAG 2.2 checks to keep with each migration
+
+- Every interactive control must be a native control or expose the correct role, tab behavior, and Enter/Space/Escape/Arrow handling for its pattern.
+- Focus must remain visible.
+- Controls need stable accessible names, states, and error text wiring.
+- Status cannot rely on color alone.
+- Mobile viewports must not clip labels, table actions, modal buttons, or editor toolbars.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "build:check": "npm run build && node scripts/bundleCheck.mjs",
     "serve": "vite preview",
     "storybook": "storybook dev -p 6006",
+    "typecheck:storybook": "tsc --noEmit --project tsconfig.storybook.json",
+    "prebuild-storybook": "npm run typecheck:storybook",
     "build-storybook": "storybook build",
     "test": "vitest run",
     "lint": "yarn run lint:css && yarn run lint:js && yarn run lint:formatting",

--- a/src/components/FormPluginEditor/FormPluginEditor.stories.tsx
+++ b/src/components/FormPluginEditor/FormPluginEditor.stories.tsx
@@ -2,6 +2,22 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Form } from 'antd';
 import FormPluginEditor from './FormPluginEditor';
 
+type FormInitialValues = Record<string, unknown>;
+type FormPluginEditorParameters = {
+    formInitialValues?: FormInitialValues;
+};
+type FormPluginEditorStory = StoryObj<typeof meta> & {
+    parameters?: StoryObj<typeof meta>['parameters'] & FormPluginEditorParameters;
+};
+
+const defaultFormInitialValues: FormInitialValues = {
+    legalText:
+        '<p>Willkommen bei <strong>ORISO</strong>.</p><p>Bitte beachten Sie unsere <em>Datenschutzhinweise</em>.</p>',
+};
+
+const getFormInitialValues = (parameters: FormPluginEditorParameters): FormInitialValues =>
+    parameters.formInitialValues ?? defaultFormInitialValues;
+
 // Renders the TipTap rich-text editor in isolation (toolbar + HTML content +
 // placeholder insertion). Doubles as the React 19 smoke test for the editor.
 const meta = {
@@ -12,12 +28,7 @@ const meta = {
         (Story, context) => (
             <Form
                 style={{ maxWidth: 720 }}
-                initialValues={
-                    context.parameters.formInitialValues ?? {
-                        legalText:
-                            '<p>Willkommen bei <strong>ORISO</strong>.</p><p>Bitte beachten Sie unsere <em>Datenschutzhinweise</em>.</p>',
-                    }
-                }
+                initialValues={getFormInitialValues(context.parameters)}
             >
                 <Story />
             </Form>
@@ -26,7 +37,7 @@ const meta = {
 } satisfies Meta<typeof FormPluginEditor>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = FormPluginEditorStory;
 
 export const Default: Story = {
     args: {

--- a/src/components/FormPluginEditor/FormPluginEditor.stories.tsx
+++ b/src/components/FormPluginEditor/FormPluginEditor.stories.tsx
@@ -9,13 +9,15 @@ const meta = {
     component: FormPluginEditor,
     parameters: { layout: 'padded' },
     decorators: [
-        (Story) => (
+        (Story, context) => (
             <Form
                 style={{ maxWidth: 720 }}
-                initialValues={{
-                    legalText:
-                        '<p>Willkommen bei <strong>ORISO</strong>.</p><p>Bitte beachten Sie unsere <em>Datenschutzhinweise</em>.</p>',
-                }}
+                initialValues={
+                    context.parameters.formInitialValues ?? {
+                        legalText:
+                            '<p>Willkommen bei <strong>ORISO</strong>.</p><p>Bitte beachten Sie unsere <em>Datenschutzhinweise</em>.</p>',
+                    }
+                }
             >
                 <Story />
             </Form>
@@ -59,11 +61,5 @@ export const Empty: Story = {
         placeholder: 'Rechtstext eingeben …',
         itemProps: { label: 'Rechtstext' },
     },
-    decorators: [
-        (Story) => (
-            <Form style={{ maxWidth: 720 }}>
-                <Story />
-            </Form>
-        ),
-    ],
+    parameters: { formInitialValues: {} },
 };

--- a/tsconfig.storybook.json
+++ b/tsconfig.storybook.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "types": ["vite/client", "vite-plugin-svgr/client", "node", "react", "react-dom"],
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "index.d.ts",
+    "vite-env.d.ts",
+    ".storybook/**/*.ts",
+    ".storybook/**/*.tsx",
+    "src/**/*.stories.ts",
+    "src/**/*.stories.tsx"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Add a dedicated `tsconfig.storybook.json` for Admin Storybook 10.4 / Vite.
- Run `npm run typecheck:storybook` automatically before `npm run build-storybook`.
- Fix `FormPluginEditor` stories so Storybook no longer renders nested `<form>` elements.
- Document the current Admin MUI 9 baseline and the remaining AntD migration inventory.

## Functional explanation
Admin `origin/dev` already contains the React 19, Vite 8, Cypress 15, Storybook 10, and MUI 9 modernization baseline. This PR does not re-merge the older conflicting modernization branches. Instead, it adds a small verification gate on top of current `dev`, fixes the real browser Storybook warning found locally, and records where AntD still remains so the MUI 9 migration can be split into reviewable follow-up changes.

## Local verification
- `npm ci` - passed
- `npm run typecheck:storybook` - passed
- `npm run build-storybook` - passed with existing chunk-size warning
- `npm run test` - 73 files, 275 tests passed
- `npm run build` - passed with existing Prettier/lint warnings and bundle warnings
- `npx cypress verify` - Cypress 15.18.0 verified locally
- `git diff --check` - passed

## Browser/manual QA evidence
- Local Storybook dev server: `http://localhost:6007/`
- Storybook index: 20 stories found
- Playwright/real-browser smoke: 20 stories loaded in desktop viewport, 20 stories loaded in mobile viewport
- Browser result: 0 render failures, 0 page/console errors after fixing the nested Form story
- Docs/Controls shell sampled through the Storybook manager
- `/mcp` endpoint is reachable as a long-running stream; direct fetch times out by design when treated as a normal HTTP document

## Known follow-ups
- Full AntD removal is intentionally not part of this PR because remaining usage spans layout, forms, tables, modals, legal settings, and page-level flows.
- Follow-up MUI migration should start with shared buttons, alerts, simple fields/selects, cards, modals, and table primitives where Storybook/browser coverage exists.
- Pre-Dev/live validation is still pending and should happen only after merge/deploy.

Refs #229, #230, OpenResilienceInitiative/ORISO-Frontend#353.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storybook examples for the form editor now support custom starting values per story.
  * The empty-state example now opens with no prefilled content, making the placeholder visible.

* **Bug Fixes**
  * Improved consistency in how the form editor preview initializes across different story configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->