### PR TITLE
chore(ci): run unit tests in CI + supply-chain hardening (audit items 4/6)

### DIFF
--- a/.github/actions/node-build/action.yml
+++ b/.github/actions/node-build/action.yml
@@ -16,7 +16,14 @@ runs:
 
   - name: Install dependencies
     shell: bash
-    run: npm ci
+    # --ignore-scripts blocks arbitrary dependency postinstall scripts from
+    # executing in CI (supply-chain hardening). Admin is a Vite app and does
+    # not rely on any dependency lifecycle script to build.
+    run: npm ci --ignore-scripts
+
+  - name: Run unit tests
+    shell: bash
+    run: npm test
 
   - name: Build app
     shell: bash

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -132,17 +132,33 @@ jobs:
           # piping the mutable `curl https://cursor.com/install | bash` installer
           # into a shell. That installer runs whatever code the vendor serves at
           # request time inside a job that holds a write-capable token, which is a
-          # prompt-injection / supply-chain surface. Cursor does not publish a
-          # checksum for the tarball, so the pinned immutable version URL is the
-          # integrity anchor. Bump CURSOR_CLI_VERSION deliberately to upgrade.
+          # prompt-injection / supply-chain surface.
+          #
+          # Cursor publishes no checksum for the tarball, so we anchor integrity
+          # ourselves: the download is verified against a reviewed SHA-256 pinned
+          # here per architecture before it is extracted. Any change to the bytes
+          # the versioned URL serves fails the job. Bump CURSOR_CLI_VERSION AND
+          # the matching checksum deliberately to upgrade (recompute with
+          # `curl -fSL <url> | shasum -a 256`).
           CURSOR_CLI_VERSION: "2026.07.01-41b2de7"
+          CURSOR_CLI_SHA256_X64: "c30df9f1e518bd626ec58a97528e5978bcea6e2372193a87db0d38b857dcc193"
+          CURSOR_CLI_SHA256_ARM64: "55566abfe87a9d28346d50c7dc71cfcf0dc6135df6198b4661e4d5dd68796d11"
         run: |
           set -euo pipefail
-          arch="$(uname -m)"; case "$arch" in x86_64|amd64) arch=x64;; arm64|aarch64) arch=arm64;; esac
+          arch="$(uname -m)"
+          case "$arch" in
+            x86_64|amd64) arch=x64; expected_sha="${CURSOR_CLI_SHA256_X64}";;
+            arm64|aarch64) arch=arm64; expected_sha="${CURSOR_CLI_SHA256_ARM64}";;
+            *) echo "::error::Unsupported architecture for Cursor CLI: $arch"; exit 1;;
+          esac
           install_dir="$HOME/.local/share/cursor-agent/versions/${CURSOR_CLI_VERSION}"
           mkdir -p "$install_dir" "$HOME/.local/bin"
+          tarball="$(mktemp)"
           curl -fSL "https://downloads.cursor.com/lab/${CURSOR_CLI_VERSION}/linux/${arch}/agent-cli-package.tar.gz" \
-            | tar --strip-components=1 -xzf - -C "$install_dir"
+            -o "$tarball"
+          echo "${expected_sha}  ${tarball}" | sha256sum -c -
+          tar --strip-components=1 -xzf "$tarball" -C "$install_dir"
+          rm -f "$tarball"
           ln -sf "$install_dir/cursor-agent" "$HOME/.local/bin/cursor-agent"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/cursor-agent" --version

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -127,8 +127,23 @@ jobs:
 
       - name: Install Cursor CLI
         if: steps.guard.outputs.run == 'true'
+        env:
+          # Pin the Cursor Agent CLI to an immutable versioned build instead of
+          # piping the mutable `curl https://cursor.com/install | bash` installer
+          # into a shell. That installer runs whatever code the vendor serves at
+          # request time inside a job that holds a write-capable token, which is a
+          # prompt-injection / supply-chain surface. Cursor does not publish a
+          # checksum for the tarball, so the pinned immutable version URL is the
+          # integrity anchor. Bump CURSOR_CLI_VERSION deliberately to upgrade.
+          CURSOR_CLI_VERSION: "2026.07.01-41b2de7"
         run: |
-          curl https://cursor.com/install -fsS | bash
+          set -euo pipefail
+          arch="$(uname -m)"; case "$arch" in x86_64|amd64) arch=x64;; arm64|aarch64) arch=arm64;; esac
+          install_dir="$HOME/.local/share/cursor-agent/versions/${CURSOR_CLI_VERSION}"
+          mkdir -p "$install_dir" "$HOME/.local/bin"
+          curl -fSL "https://downloads.cursor.com/lab/${CURSOR_CLI_VERSION}/linux/${arch}/agent-cli-package.tar.gz" \
+            | tar --strip-components=1 -xzf - -C "$install_dir"
+          ln -sf "$install_dir/cursor-agent" "$HOME/.local/bin/cursor-agent"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/cursor-agent" --version
 


### PR DESCRIPTION
Part of **Test Quality Audit 2026-07-04, items 4 & 6** (Admin repo group).

### Item 4 — Admin ran zero tests in CI
Admin has ~265+ unit tests (vitest) but CI ran only build + Storybook.

- Added a blocking **Run unit tests** step (`npm test` → `vitest run`) to the shared `.github/actions/node-build` composite action. This composite is used by `ci-main`, `ci-pull-request`, and `ci-feature-branch`, so tests now run (and block) in every Admin CI flow, before the Docker image is built.
- No `--passWithNoTests` is used anywhere.

**Verified locally:** `npm ci --ignore-scripts && npm test` → **87 test files, 397 tests passed** (35s).

### Item 6 — supply-chain hardening
- **Removed `curl https://cursor.com/install | bash`** from `ai-pr-review.yml`. That installer is *mutable* — it hardcodes whatever build the vendor currently serves — and it ran inside a job holding a **write-capable token** (`contents: write`, `pull-requests: write`), i.e. a prompt-injection / supply-chain surface. Replaced with a **pinned, immutable versioned tarball** download (`downloads.cursor.com/lab/${CURSOR_CLI_VERSION}/…`) + extract + symlink, reproducing exactly what the installer produced at `$HOME/.local/bin/cursor-agent`. Cursor publishes no checksum for the tarball, so the pinned immutable version URL is the integrity anchor; bump `CURSOR_CLI_VERSION` deliberately to upgrade.
- **Added `--ignore-scripts` to `npm ci`** in the node-build composite, blocking arbitrary dependency `postinstall` scripts from executing in CI. **Verified** `npm ci --ignore-scripts` installs cleanly and the full test suite passes; Admin is a Vite app and no dependency relies on a lifecycle script to build.

### Notes / observations (out of scope, not changed here)
- The pre-existing Cursor review step interpolates `github.base_ref` into a `run:` heredoc. Low risk (a branch name), but worth an eventual env-var refactor per GitHub's workflow-injection guidance.

### Collision status
No open Admin PR touches `.github/actions/node-build` or `ai-pr-review.yml` (surveyed `gh pr list`; Hassan has no open CI PR here). Isolated worktree off `origin/dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by preventing dependency postinstall scripts from running during CI installs.
  * Made the review workflow use a pinned Cursor CLI version, reducing install variability and improving consistency across runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->