### PR TITLE
feat(agency): single-select topic picker (ADR-003 #3)

### DIFF
--- a/src/api/agency/addAgencyData.test.ts
+++ b/src/api/agency/addAgencyData.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, it } from 'vitest';
-import { resolveAgencyTenantId } from './addAgencyData';
+import { buildAgencyDataRequestBody, resolveAgencyTenantId } from './addAgencyData';
+
+describe('buildAgencyDataRequestBody — ADR-003 single-select topic', () => {
+    const parse = (consultingTypeId: string | number, formData: Record<string, any>) =>
+        JSON.parse(buildAgencyDataRequestBody(consultingTypeId, formData, 1));
+
+    it('sends the single-select Option as a one-element topicIds array', () => {
+        // Would crash on the old `topics?.map` (an Option object has no .map) — this is the guard.
+        const body = parse(1, { name: 'A', topicIds: { value: '7', label: 'Debt counselling' } });
+        expect(body.topicIds).toEqual(['7']);
+    });
+
+    it('omits topicIds entirely when the picker was cleared', () => {
+        const body = parse(1, { name: 'A', topicIds: undefined });
+        expect(body).not.toHaveProperty('topicIds');
+    });
+
+    it('still accepts the legacy array shape', () => {
+        const body = parse(1, { name: 'A', topicIds: [{ value: '3' }, { value: '9' }] });
+        expect(body.topicIds).toEqual(['3', '9']);
+    });
+});
 
 describe('resolveAgencyTenantId', () => {
     it('prefers the explicitly selected tenant from the agency form', () => {

--- a/src/api/agency/addAgencyData.ts
+++ b/src/api/agency/addAgencyData.ts
@@ -5,16 +5,15 @@ import updateAgencyPostCodeRange from './updateAgencyPostCodeRange';
 import getConsultingType4Tenant from '../consultingtype/getConsultingType4Tenant';
 import { parseUserAuthInfo } from '../../utils/parseUserAuthInfo';
 import { assignAgencyToConsultants } from './assignAgencyToConsultants';
+import { normalizeTopicIds } from './normalizeTopicIds';
 
-function buildAgencyDataRequestBody(
+export function buildAgencyDataRequestBody(
     consultingTypeResponseId: string | number,
     formData: Record<string, any>,
     tenantId: number,
 ) {
-    const topics = formData?.topicIds || formData?.topics;
-    const topicIds = topics
-        ?.map((topic) => (typeof topic === 'string' ? topic : topic?.value || topic?.id))
-        .filter((id) => id != null && !Number.isNaN(Number(id)));
+    // ADR-003: single-select topic picker — normalise the Option/array/id shapes to string[].
+    const topicIds = normalizeTopicIds(formData?.topicIds ?? formData?.topics);
     const requestBody: any = withLegacyDioceseId({
         name: formData.name,
         description: formData.description ? formData.description : '',

--- a/src/api/agency/normalizeTopicIds.test.ts
+++ b/src/api/agency/normalizeTopicIds.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeTopicIds } from './normalizeTopicIds';
+
+describe('normalizeTopicIds (ADR-003 single-select topic picker)', () => {
+    it('unwraps a single labelInValue Option to a one-element string[]', () => {
+        expect(normalizeTopicIds({ value: '7', label: 'Debt counselling' })).toEqual(['7']);
+    });
+
+    it('treats a cleared field (undefined/null) as no topic', () => {
+        expect(normalizeTopicIds(undefined)).toEqual([]);
+        expect(normalizeTopicIds(null)).toEqual([]);
+    });
+
+    it('unwraps a legacy Option[] (former multi-select shape)', () => {
+        expect(
+            normalizeTopicIds([
+                { value: '3', label: 'A' },
+                { value: '9', label: 'B' },
+            ]),
+        ).toEqual(['3', '9']);
+    });
+
+    it('reads ids from the backend topic shape { id }', () => {
+        expect(normalizeTopicIds({ id: 42, name: 'Pregnancy' } as any)).toEqual(['42']);
+        expect(normalizeTopicIds([{ id: 1 }, { id: 2 }] as any)).toEqual(['1', '2']);
+    });
+
+    it('accepts raw ids as string, number, or string[]', () => {
+        expect(normalizeTopicIds('5')).toEqual(['5']);
+        expect(normalizeTopicIds(8 as any)).toEqual(['8']);
+        expect(normalizeTopicIds(['5', '6'])).toEqual(['5', '6']);
+    });
+
+    it('is idempotent on an already-normalised string[]', () => {
+        expect(normalizeTopicIds(['11'])).toEqual(['11']);
+    });
+
+    it('drops null, empty, and non-numeric entries', () => {
+        expect(normalizeTopicIds([null, { value: '' }, { value: 'abc' }, { value: '4' }] as any)).toEqual(['4']);
+    });
+
+    it('handles the empty array (explicitly cleared) as no topic', () => {
+        expect(normalizeTopicIds([])).toEqual([]);
+    });
+});

--- a/src/api/agency/normalizeTopicIds.ts
+++ b/src/api/agency/normalizeTopicIds.ts
@@ -1,0 +1,36 @@
+/**
+ * ADR-003: an agency maps to at most one topic (department = unique agency × topic), so the Admin
+ * topic picker is single-select. Depending on the code path the topic value can arrive in several
+ * shapes, and this normalises all of them to the `string[]` (length 0/1) the agency API expects:
+ *
+ * - a single labelInValue Option `{ value }` — the single-select form field
+ * - a legacy array of Options `[{ value }]` — the former multi-select shape
+ * - the backend topic shape `{ id }` / `[{ id }]`
+ * - a raw id `string | number` or `string[]`
+ * - `undefined` / `null` (field never set or cleared) → `[]`
+ *
+ * Non-numeric ids are dropped. The function is idempotent, so it is safe to run again on an
+ * already-normalised `string[]`.
+ */
+type TopicLike = string | number | { value?: string | number; id?: string | number } | null | undefined;
+
+const toArray = (value: TopicLike | TopicLike[]): TopicLike[] => {
+    if (Array.isArray(value)) {
+        return value;
+    }
+    return value == null ? [] : [value];
+};
+
+export const normalizeTopicIds = (value: TopicLike | TopicLike[]): string[] =>
+    toArray(value)
+        .map((item) => {
+            if (item == null) {
+                return null;
+            }
+            if (typeof item === 'string' || typeof item === 'number') {
+                return item;
+            }
+            return item.value ?? item.id ?? null;
+        })
+        .filter((id): id is string | number => id != null && `${id}`.trim() !== '' && !Number.isNaN(Number(id)))
+        .map((id) => String(id));

--- a/src/api/agency/updateAgencyData.test.ts
+++ b/src/api/agency/updateAgencyData.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ fetchData: vi.fn() }));
+
+vi.mock('../fetchData', async () => {
+    const actual = await vi.importActual<typeof import('../fetchData')>('../fetchData');
+    return { ...actual, fetchData: mocks.fetchData };
+});
+vi.mock('./updateAgencyType', () => ({ default: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./updateAgencyPostCodeRange', () => ({ default: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../consultingtype/getConsultingType4Tenant', () => ({ default: vi.fn().mockResolvedValue('1') }));
+
+import { updateAgencyData } from './updateAgencyData';
+
+const agencyModel: any = { id: '55', consultingType: '1' };
+
+const sentBody = () => JSON.parse(mocks.fetchData.mock.calls[0][0].bodyData);
+
+describe('updateAgencyData — ADR-003 single-select topic', () => {
+    beforeEach(() => {
+        mocks.fetchData.mockReset();
+        mocks.fetchData.mockResolvedValue({ _embedded: {} });
+    });
+
+    it('sends the single-select Option as a one-element topicIds array', async () => {
+        await updateAgencyData(agencyModel, {
+            ...agencyModel,
+            topicIds: { value: '7', label: 'Debt counselling' },
+        } as any);
+        expect(sentBody().topicIds).toEqual(['7']);
+    });
+
+    it('sends an empty topicIds array when the picker was cleared', async () => {
+        // Regression guard: with the old `|| topics` fallback a cleared [] fell back to the
+        // backend topics and could not be cleared. `?? topics` + normalize keeps it empty.
+        await updateAgencyData(agencyModel, { ...agencyModel, topicIds: [] } as any);
+        expect(sentBody().topicIds).toEqual([]);
+    });
+
+    it('still accepts the legacy Option[] shape', async () => {
+        await updateAgencyData(agencyModel, {
+            ...agencyModel,
+            topicIds: [{ value: '3' }, { value: '9' }],
+        } as any);
+        expect(sentBody().topicIds).toEqual(['3', '9']);
+    });
+});

--- a/src/api/agency/updateAgencyData.ts
+++ b/src/api/agency/updateAgencyData.ts
@@ -23,11 +23,14 @@ export const updateAgencyData = async (agencyModel: AgencyData, formInput: Agenc
     const consultingTypeId =
         formInput.consultingType !== null ? parseInt(formInput.consultingType, 10) : await getConsultingType4Tenant();
 
-    const topics = formInput?.topicIds || formInput?.topics;
+    // ADR-003: topicIds may arrive as a single-select Option, a legacy Option[]/string[], or the
+    // backend `topics` shape — normalise all of them to an array before extracting the ids.
+    const rawTopics = formInput?.topicIds ?? formInput?.topics;
+    const topicsArray = Array.isArray(rawTopics) ? rawTopics : rawTopics == null ? [] : [rawTopics];
 
-    const topicIds = topics
-        ?.map((topic) => (typeof topic === 'string' ? topic : topic?.id))
-        .filter((id) => !Number.isNaN(Number(id)));
+    const topicIds = topicsArray
+        .map((topic) => (typeof topic === 'string' ? topic : topic?.value ?? topic?.id))
+        .filter((id) => id != null && !Number.isNaN(Number(id)));
 
     const agencyDataRequestBody = withLegacyDioceseId({
         name: formInput.name,

--- a/src/api/agency/updateAgencyData.ts
+++ b/src/api/agency/updateAgencyData.ts
@@ -5,6 +5,7 @@ import { AgencyData } from '../../types/agency';
 import updateAgencyType from './updateAgencyType';
 import getConsultingType4Tenant from '../consultingtype/getConsultingType4Tenant';
 import updateAgencyPostCodeRange from './updateAgencyPostCodeRange';
+import { normalizeTopicIds } from './normalizeTopicIds';
 
 /**
  * update agency
@@ -24,13 +25,8 @@ export const updateAgencyData = async (agencyModel: AgencyData, formInput: Agenc
         formInput.consultingType !== null ? parseInt(formInput.consultingType, 10) : await getConsultingType4Tenant();
 
     // ADR-003: topicIds may arrive as a single-select Option, a legacy Option[]/string[], or the
-    // backend `topics` shape — normalise all of them to an array before extracting the ids.
-    const rawTopics = formInput?.topicIds ?? formInput?.topics;
-    const topicsArray = Array.isArray(rawTopics) ? rawTopics : rawTopics == null ? [] : [rawTopics];
-
-    const topicIds = topicsArray
-        .map((topic) => (typeof topic === 'string' ? topic : topic?.value ?? topic?.id))
-        .filter((id) => id != null && !Number.isNaN(Number(id)));
+    // backend `topics` shape — normalise all of them to the string[] the API expects.
+    const topicIds = normalizeTopicIds(formInput?.topicIds ?? formInput?.topics);
 
     const agencyDataRequestBody = withLegacyDioceseId({
         name: formInput.name,

--- a/src/pages/Agency/Edit/components/AgencySettings/index.tsx
+++ b/src/pages/Agency/Edit/components/AgencySettings/index.tsx
@@ -24,7 +24,6 @@ interface AgencySettingsProps {
 export const AgencySettings = ({ isEditMode, asFields }: AgencySettingsProps) => {
     const [t] = useTranslation();
 
-    const topicIds = Form.useWatch<Option[]>('topicIds') || [];
     const genders = Form.useWatch<Option[]>(['demographics', 'genders']) || [];
     const counsellingRelations = Form.useWatch<Option[]>('counsellingRelations') || [];
 
@@ -33,7 +32,6 @@ export const AgencySettings = ({ isEditMode, asFields }: AgencySettingsProps) =>
     const { isEnabled: isReleaseToggleEnabled } = useReleasesToggle();
     const [tenantsData, setTenantsData] = useState([]);
     const { data: topics, isLoading: isLoadingTopics } = useTenantTopics(true);
-    const topicsForList = topics?.filter(({ id }) => !topicIds.find(({ value }) => value === `${id}`));
     const gendersForList = Object.values(Gender).filter((name) => !genders.find(({ value }) => value === `${name}`));
     const counsellingRelationsForList = Object.values(CounsellingRelation).filter(
         (relation) => !counsellingRelations.find(({ value }) => value === `${relation}`),
@@ -63,14 +61,15 @@ export const AgencySettings = ({ isEditMode, asFields }: AgencySettingsProps) =>
             )}
 
             {topics?.length > 0 && (
+                // ADR-003: a department is the unique (agency × topic) pairing, so an agency maps to
+                // at most one topic — single-select replaces the former multi-select.
                 <SelectFormField
                     label="topics.title"
                     name="topicIds"
                     labelInValue
-                    isMulti
                     allowClear
                     placeholder="plsSelect"
-                    options={convertToOptions(topicsForList, 'name', 'id')}
+                    options={convertToOptions(topics, 'name', 'id')}
                 />
             )}
 

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import ErrorOutlinedIcon from '@mui/icons-material/ErrorOutlined';
 import { PostCodeRange } from '../../../api/agency/getAgencyPostCodeRange';
+import { normalizeTopicIds } from '../../../api/agency/normalizeTopicIds';
 import routePathNames from '../../../appConfig';
 import { Page } from '../../../components/Page';
 import { CardDeck } from '../../../components/CardDeck';
@@ -43,19 +44,6 @@ type AgencySettingsSection = 'general' | 'legal' | 'functionalities';
 interface AgencyPageEditProps {
     section?: AgencySettingsSection;
 }
-
-// ADR-003: the topic picker is single-select, so the form field holds a single labelInValue
-// Option (or undefined when cleared). Normalise that — or a legacy array — to the string[] of
-// length 0/1 the agency API expects.
-const toTopicIdArray = (value: unknown): string[] => {
-    const options = Array.isArray(value) ? value : value == null ? [] : [value];
-    return options
-        .map((option) =>
-            option && typeof option === 'object' && 'value' in option ? (option as { value: unknown }).value : option,
-        )
-        .filter((id): id is string | number => id != null)
-        .map((id) => String(id));
-};
 
 const getEntityId = (value: unknown) => {
     if (typeof value === 'number' || typeof value === 'string') {
@@ -170,7 +158,7 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
                               genders: mergedFormData.demographics.genders.map(({ value }) => value),
                           }
                         : mergedFormData.demographics,
-                topicIds: toTopicIdArray(mergedFormData.topicIds),
+                topicIds: normalizeTopicIds(mergedFormData.topicIds),
                 offline: !mergedFormData.online,
                 counsellingRelations: mergedFormData.counsellingRelations?.map(
                     (relation) => relation.value || relation,

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -44,6 +44,19 @@ interface AgencyPageEditProps {
     section?: AgencySettingsSection;
 }
 
+// ADR-003: the topic picker is single-select, so the form field holds a single labelInValue
+// Option (or undefined when cleared). Normalise that — or a legacy array — to the string[] of
+// length 0/1 the agency API expects.
+const toTopicIdArray = (value: unknown): string[] => {
+    const options = Array.isArray(value) ? value : value == null ? [] : [value];
+    return options
+        .map((option) =>
+            option && typeof option === 'object' && 'value' in option ? (option as { value: unknown }).value : option,
+        )
+        .filter((id): id is string | number => id != null)
+        .map((id) => String(id));
+};
+
 const getEntityId = (value: unknown) => {
     if (typeof value === 'number' || typeof value === 'string') {
         return String(value);
@@ -128,7 +141,7 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
         ...counsellingRelationsInitialValues,
         postCodeRangesActive: !hasOnlyDefaultRangeDefined(postCodes || []),
         online: agencyData?.id ? !agencyData?.offline : false,
-        topicIds: convertToOptions(agencyData?.topics, 'name', 'id', true),
+        topicIds: convertToOptions(agencyData?.topics, 'name', 'id', true)[0],
         tenantId: agencyTenantId,
     };
 
@@ -157,7 +170,7 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
                               genders: mergedFormData.demographics.genders.map(({ value }) => value),
                           }
                         : mergedFormData.demographics,
-                topicIds: mergedFormData.topicIds?.map(({ value }) => value),
+                topicIds: toTopicIdArray(mergedFormData.topicIds),
                 offline: !mergedFormData.online,
                 counsellingRelations: mergedFormData.counsellingRelations?.map(
                     (relation) => relation.value || relation,

--- a/src/types/agency.d.ts
+++ b/src/types/agency.d.ts
@@ -24,7 +24,9 @@ export interface AgencyData {
     city: string;
     counsellingRelations: CounsellingRelation[];
     topics: TopicData[];
-    topicIds: Array<{ value: string; label: string }> | string[];
+    // ADR-003: single-select topic picker — the form field holds a single labelInValue Option
+    // (or undefined when cleared); legacy array shapes stay accepted for backwards compatibility.
+    topicIds?: { value: string; label: string } | Array<{ value: string; label: string }> | string[];
     consultantIds?: Array<{ value: string; label: string }> | string[];
     consultantAssignmentFailed?: boolean;
     demographics?: AgencyDemographicsData;


### PR DESCRIPTION
## Why
ADR-003 makes a **department** the unique `(agency × topic)` pairing. The backend half is already on `dev` — `UNIQUE(agency_id, topic_id)` + dedup migration (changeset `0023`), inline `content_dpp`/`content_imprint` with a `draft|published` lifecycle, admin publish/read API, and the public `DepartmentLegalService`. The remaining open acceptance item of #203 was the **Admin single-select topic picker** (was multi-select). The 2026-06-26 attempt (`02435c3`) was never merged and `dev` diverged, so this re-applies the change fresh onto current `dev`.

## What
- **AgencySettings**: drop `isMulti` from the `topicIds` field; remove the array watcher + `topicsForList` filter (single-select replaces rather than appends); pass the full topic list. `allowClear` kept; selection stays optional.
- **Agency Edit**: LOAD takes the first/only `Option` (labelInValue single mode stores one Option, not an array); SUBMIT normalises via `toTopicIdArray` to the `string[]` of length 0/1 the agency API expects.
- **updateAgencyData**: normalise `topicIds` (single Option | Option[] | string[] | undefined) before extracting ids.
- **agency.d.ts**: retype `topicIds`.

Consultant/user topic pickers are unchanged (separate concern).

## Acceptance (ADR-003 / #203)
- [x] Cannot link the same topic twice to one agency *(backend `UNIQUE` on dev)*
- [x] Each department resolves a single imprint/DPP incl. draft state *(backend on dev)*
- [x] Admin enforces single-select *(this PR)*

## Testing
- `tsc --noEmit` clean
- `vitest` Agency Edit + List suites pass (6); full suite 439/440 (the 1 failure is a pre-existing flaky 5s timeout in an unrelated `DataProcessingAgreementCard` test — passes 17/17 in isolation)

Refs ADR-003, part of epic #205, closes the picker item of #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Topic selection in agency settings now supports a simpler single-select experience while still accepting older formats.
  * Agency topic IDs are now normalized consistently before saving, improving compatibility across different input shapes.

* **Bug Fixes**
  * Fixed cases where cleared or legacy topic values could be sent incorrectly.
  * Improved handling of empty, invalid, or mixed topic inputs so saved data stays consistent.

* **Tests**
  * Added coverage for topic normalization and agency save/update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->