### PR TITLE
fix(agency): single-select topic picker — agency maps to one department (ADR-003)

### DIFF
--- a/src/api/agency/addAgencyData.ts
+++ b/src/api/agency/addAgencyData.ts
@@ -5,16 +5,15 @@ import updateAgencyPostCodeRange from './updateAgencyPostCodeRange';
 import getConsultingType4Tenant from '../consultingtype/getConsultingType4Tenant';
 import { parseUserAuthInfo } from '../../utils/parseUserAuthInfo';
 import { assignAgencyToConsultants } from './assignAgencyToConsultants';
+import { normalizeTopicIds } from './normalizeTopicIds';
 
 function buildAgencyDataRequestBody(
     consultingTypeResponseId: string | number,
     formData: Record<string, any>,
     tenantId: number,
 ) {
-    const topics = formData?.topicIds || formData?.topics;
-    const topicIds = topics
-        ?.map((topic) => (typeof topic === 'string' ? topic : topic?.value || topic?.id))
-        .filter((id) => id != null && !Number.isNaN(Number(id)));
+    // ADR-003: single-select topic picker — normalise the Option/array/id shapes to string[].
+    const topicIds = normalizeTopicIds(formData?.topicIds ?? formData?.topics);
     const requestBody: any = withLegacyDioceseId({
         name: formData.name,
         description: formData.description ? formData.description : '',

--- a/src/api/agency/normalizeTopicIds.test.ts
+++ b/src/api/agency/normalizeTopicIds.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeTopicIds } from './normalizeTopicIds';
+
+describe('normalizeTopicIds (ADR-003 single-select topic picker)', () => {
+    it('unwraps a single labelInValue Option to a one-element string[]', () => {
+        expect(normalizeTopicIds({ value: '7', label: 'Debt counselling' })).toEqual(['7']);
+    });
+
+    it('treats a cleared field (undefined/null) as no topic', () => {
+        expect(normalizeTopicIds(undefined)).toEqual([]);
+        expect(normalizeTopicIds(null)).toEqual([]);
+    });
+
+    it('unwraps a legacy Option[] (former multi-select shape)', () => {
+        expect(
+            normalizeTopicIds([
+                { value: '3', label: 'A' },
+                { value: '9', label: 'B' },
+            ]),
+        ).toEqual(['3', '9']);
+    });
+
+    it('reads ids from the backend topic shape { id }', () => {
+        expect(normalizeTopicIds({ id: 42, name: 'Pregnancy' } as any)).toEqual(['42']);
+        expect(normalizeTopicIds([{ id: 1 }, { id: 2 }] as any)).toEqual(['1', '2']);
+    });
+
+    it('accepts raw ids as string, number, or string[]', () => {
+        expect(normalizeTopicIds('5')).toEqual(['5']);
+        expect(normalizeTopicIds(8 as any)).toEqual(['8']);
+        expect(normalizeTopicIds(['5', '6'])).toEqual(['5', '6']);
+    });
+
+    it('is idempotent on an already-normalised string[]', () => {
+        expect(normalizeTopicIds(['11'])).toEqual(['11']);
+    });
+
+    it('drops null, empty, and non-numeric entries', () => {
+        expect(normalizeTopicIds([null, { value: '' }, { value: 'abc' }, { value: '4' }] as any)).toEqual(['4']);
+    });
+
+    it('handles the empty array (explicitly cleared) as no topic', () => {
+        expect(normalizeTopicIds([])).toEqual([]);
+    });
+
+    it('prefers value over id when an Option carries both (labelInValue Option, not a raw entity)', () => {
+        expect(normalizeTopicIds({ value: '7', id: 999 } as any)).toEqual(['7']);
+    });
+
+    it('is idempotent on a single already-normalised id passed as a bare string', () => {
+        expect(normalizeTopicIds(normalizeTopicIds({ value: '7', label: 'Debt counselling' }))).toEqual(['7']);
+    });
+});

--- a/src/api/agency/normalizeTopicIds.ts
+++ b/src/api/agency/normalizeTopicIds.ts
@@ -1,0 +1,32 @@
+/**
+ * ADR-003: an agency maps to at most one topic (department = unique agency × topic), so the Admin
+ * topic picker is single-select. Depending on the code path the topic value can arrive in several
+ * shapes, and this normalises all of them to the `string[]` (length 0/1) the agency API expects:
+ *
+ * - a single labelInValue Option `{ value }` — the single-select form field
+ * - a legacy array of Options `[{ value }]` — the former multi-select shape
+ * - the backend topic shape `{ id }` / `[{ id }]`
+ * - a raw id `string | number` or `string[]`
+ * - `undefined` / `null` (field never set or cleared) → `[]`
+ *
+ * Non-numeric ids are dropped. The function is idempotent, so it is safe to run again on an
+ * already-normalised `string[]`.
+ */
+type TopicLike = string | number | { value?: string | number; id?: string | number } | null | undefined;
+
+export const normalizeTopicIds = (value: TopicLike | TopicLike[]): string[] => {
+    const items = Array.isArray(value) ? value : value == null ? [] : [value];
+
+    return items
+        .map((item) => {
+            if (item == null) {
+                return null;
+            }
+            if (typeof item === 'string' || typeof item === 'number') {
+                return item;
+            }
+            return item.value ?? item.id ?? null;
+        })
+        .filter((id): id is string | number => id != null && `${id}`.trim() !== '' && !Number.isNaN(Number(id)))
+        .map((id) => String(id));
+};

--- a/src/api/agency/updateAgencyData.test.ts
+++ b/src/api/agency/updateAgencyData.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.mock is hoisted above imports, so the mock fn must be created via vi.hoisted.
+const { fetchData } = vi.hoisted(() => ({ fetchData: vi.fn(() => Promise.resolve({})) }));
+vi.mock('../fetchData', () => ({
+    FETCH_ERRORS: { CATCH_ALL: 'CATCH_ALL' },
+    FETCH_METHODS: { GET: 'GET', PUT: 'PUT', POST: 'POST' },
+    FETCH_SUCCESS: { CONTENT: 'CONTENT' },
+    fetchData,
+}));
+vi.mock('../../appConfig', () => ({
+    agencyEndpointBase: '/service/agencies',
+    agencyPostcodeRangeEndpointBase: '/service/agencies/postcoderange',
+}));
+
+// eslint-disable-next-line import/first
+import { updateAgencyData } from './updateAgencyData';
+// eslint-disable-next-line import/first
+import { AgencyData } from '../../types/agency';
+
+beforeEach(() => fetchData.mockClear());
+
+const baseAgencyModel = { id: '1', teamAgency: false } as unknown as AgencyData;
+const baseFormInput = {
+    id: '1',
+    teamAgency: false,
+    consultingType: '1', // non-null → skips getConsultingType4Tenant's own fetchData call
+    online: true,
+} as unknown as AgencyData;
+
+/** The `fetchData` mock also intercepts the postcode-range side-effect calls; this isolates the main PUT. */
+const findPutCall = () => fetchData.mock.calls.find(([args]: any[]) => args.method === 'PUT');
+
+describe('updateAgencyData — ADR-003 topicIds normalisation', () => {
+    it('sends a single-element topicIds array for a single-select labelInValue Option', async () => {
+        await updateAgencyData(baseAgencyModel, {
+            ...baseFormInput,
+            topicIds: { value: '7', label: 'Debt counselling' },
+        } as unknown as AgencyData);
+
+        const [putArgs] = findPutCall();
+        expect(JSON.parse(putArgs.bodyData).topicIds).toEqual(['7']);
+    });
+
+    it('sends an empty topicIds array when the field was cleared (undefined)', async () => {
+        await updateAgencyData(baseAgencyModel, {
+            ...baseFormInput,
+            topicIds: undefined,
+        } as unknown as AgencyData);
+
+        const [putArgs] = findPutCall();
+        expect(JSON.parse(putArgs.bodyData).topicIds).toEqual([]);
+    });
+
+    it('falls back to formInput.topics (backend TopicData[] shape) when topicIds is absent', async () => {
+        await updateAgencyData(baseAgencyModel, {
+            ...baseFormInput,
+            topics: [{ id: 42, name: 'Pregnancy' }],
+        } as unknown as AgencyData);
+
+        const [putArgs] = findPutCall();
+        expect(JSON.parse(putArgs.bodyData).topicIds).toEqual(['42']);
+    });
+
+    it('still accepts a legacy multi-select Option[] (pre-ADR-003 saved drafts / old clients)', async () => {
+        await updateAgencyData(baseAgencyModel, {
+            ...baseFormInput,
+            topicIds: [
+                { value: '3', label: 'A' },
+                { value: '9', label: 'B' },
+            ],
+        } as unknown as AgencyData);
+
+        const [putArgs] = findPutCall();
+        expect(JSON.parse(putArgs.bodyData).topicIds).toEqual(['3', '9']);
+    });
+});

--- a/src/api/agency/updateAgencyData.ts
+++ b/src/api/agency/updateAgencyData.ts
@@ -23,11 +23,14 @@ export const updateAgencyData = async (agencyModel: AgencyData, formInput: Agenc
     const consultingTypeId =
         formInput.consultingType !== null ? parseInt(formInput.consultingType, 10) : await getConsultingType4Tenant();
 
-    const topics = formInput?.topicIds || formInput?.topics;
+    // ADR-003: topicIds may arrive as a single-select Option, a legacy Option[]/string[], or the
+    // backend `topics` shape — normalise all of them to an array before extracting the ids.
+    const rawTopics = formInput?.topicIds ?? formInput?.topics;
+    const topicsArray = Array.isArray(rawTopics) ? rawTopics : rawTopics == null ? [] : [rawTopics];
 
-    const topicIds = topics
-        ?.map((topic) => (typeof topic === 'string' ? topic : topic?.id))
-        .filter((id) => !Number.isNaN(Number(id)));
+    const topicIds = topicsArray
+        .map((topic) => (typeof topic === 'string' ? topic : topic?.value ?? topic?.id))
+        .filter((id) => id != null && !Number.isNaN(Number(id)));
 
     const agencyDataRequestBody = withLegacyDioceseId({
         name: formInput.name,

--- a/src/api/agency/updateAgencyData.ts
+++ b/src/api/agency/updateAgencyData.ts
@@ -5,6 +5,7 @@ import { AgencyData } from '../../types/agency';
 import updateAgencyType from './updateAgencyType';
 import getConsultingType4Tenant from '../consultingtype/getConsultingType4Tenant';
 import updateAgencyPostCodeRange from './updateAgencyPostCodeRange';
+import { normalizeTopicIds } from './normalizeTopicIds';
 
 /**
  * update agency
@@ -24,13 +25,8 @@ export const updateAgencyData = async (agencyModel: AgencyData, formInput: Agenc
         formInput.consultingType !== null ? parseInt(formInput.consultingType, 10) : await getConsultingType4Tenant();
 
     // ADR-003: topicIds may arrive as a single-select Option, a legacy Option[]/string[], or the
-    // backend `topics` shape — normalise all of them to an array before extracting the ids.
-    const rawTopics = formInput?.topicIds ?? formInput?.topics;
-    const topicsArray = Array.isArray(rawTopics) ? rawTopics : rawTopics == null ? [] : [rawTopics];
-
-    const topicIds = topicsArray
-        .map((topic) => (typeof topic === 'string' ? topic : topic?.value ?? topic?.id))
-        .filter((id) => id != null && !Number.isNaN(Number(id)));
+    // backend `topics` shape — normalise all of them to the string[] the API expects.
+    const topicIds = normalizeTopicIds(formInput?.topicIds ?? formInput?.topics);
 
     const agencyDataRequestBody = withLegacyDioceseId({
         name: formInput.name,

--- a/src/pages/Agency/Edit/components/AgencySettings/index.tsx
+++ b/src/pages/Agency/Edit/components/AgencySettings/index.tsx
@@ -24,7 +24,6 @@ interface AgencySettingsProps {
 export const AgencySettings = ({ isEditMode, asFields }: AgencySettingsProps) => {
     const [t] = useTranslation();
 
-    const topicIds = Form.useWatch<Option[]>('topicIds') || [];
     const genders = Form.useWatch<Option[]>(['demographics', 'genders']) || [];
     const counsellingRelations = Form.useWatch<Option[]>('counsellingRelations') || [];
 
@@ -33,7 +32,6 @@ export const AgencySettings = ({ isEditMode, asFields }: AgencySettingsProps) =>
     const { isEnabled: isReleaseToggleEnabled } = useReleasesToggle();
     const [tenantsData, setTenantsData] = useState([]);
     const { data: topics, isLoading: isLoadingTopics } = useTenantTopics(true);
-    const topicsForList = topics?.filter(({ id }) => !topicIds.find(({ value }) => value === `${id}`));
     const gendersForList = Object.values(Gender).filter((name) => !genders.find(({ value }) => value === `${name}`));
     const counsellingRelationsForList = Object.values(CounsellingRelation).filter(
         (relation) => !counsellingRelations.find(({ value }) => value === `${relation}`),
@@ -63,14 +61,15 @@ export const AgencySettings = ({ isEditMode, asFields }: AgencySettingsProps) =>
             )}
 
             {topics?.length > 0 && (
+                // ADR-003: a department is the unique (agency × topic) pairing, so an agency maps to
+                // at most one topic — single-select replaces the former multi-select.
                 <SelectFormField
                     label="topics.title"
                     name="topicIds"
                     labelInValue
-                    isMulti
                     allowClear
                     placeholder="plsSelect"
-                    options={convertToOptions(topicsForList, 'name', 'id')}
+                    options={convertToOptions(topics, 'name', 'id')}
                 />
             )}
 

--- a/src/pages/Agency/Edit/index.test.tsx
+++ b/src/pages/Agency/Edit/index.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
     mutate: vi.fn(),
     navigate: vi.fn(),
     searchTenantData: vi.fn(),
+    useTenantTopics: vi.fn(() => ({ data: [], isLoading: false })),
 }));
 
 const translations: Record<string, string> = {
@@ -132,7 +133,7 @@ vi.mock('../../../hooks/useAgencyHasConsultants', () => ({
 }));
 
 vi.mock('../../../hooks/useTenantTopics', () => ({
-    useTenantTopics: () => ({ data: [], isLoading: false }),
+    useTenantTopics: mocks.useTenantTopics,
 }));
 
 vi.mock('../../../hooks/useConsultantsOrAdminsData', () => ({
@@ -200,5 +201,62 @@ describe('AgencyPageEdit create flow', () => {
             expect(screen.getByText('Bitte füllen Sie das markierte Feld aus.')).toBeInTheDocument();
         });
         expect(mocks.mutate).not.toHaveBeenCalled();
+    });
+});
+
+describe('AgencyPageEdit — ADR-003 single-select topic picker', () => {
+    beforeEach(() => {
+        mocks.mutate.mockReset();
+        mocks.navigate.mockReset();
+        mocks.searchTenantData.mockReset();
+        mocks.searchTenantData.mockResolvedValue({ data: [{ id: 7, name: 'Caritas Augsburg' }] });
+        mocks.useTenantTopics.mockReturnValue({
+            data: [
+                { id: 3, name: 'Schulden' },
+                { id: 5, name: 'Sucht' },
+            ],
+            isLoading: false,
+        });
+    });
+
+    afterEach(() => {
+        mocks.useTenantTopics.mockReturnValue({ data: [], isLoading: false });
+    });
+
+    it('renders the topic picker as single-select (no isMulti), not the former multi-select', async () => {
+        renderWithClient(<AgencyPageEdit />);
+
+        // The picker only renders once topics have loaded, keyed by its label.
+        const picker = (await screen.findByText('topics.title')).closest('.ant-form-item') as HTMLElement;
+        const selectRoot = picker.querySelector('.ant-select');
+
+        expect(selectRoot).not.toBeNull();
+        expect(selectRoot).toHaveClass('ant-select-single');
+        expect(selectRoot).not.toHaveClass('ant-select-multiple');
+    });
+
+    it('submits exactly one topic id, not an array, when one topic is chosen', async () => {
+        const user = userEvent.setup();
+        renderWithClient(<AgencyPageEdit />);
+
+        const tenantPicker = (await screen.findByText('Trägerzuordnung')).closest('.ant-form-item') as HTMLElement;
+        await user.click(tenantPicker.querySelector('.ant-select-selector') as HTMLElement);
+        await user.click(await screen.findByTitle('Caritas Augsburg'));
+
+        const picker = (await screen.findByText('topics.title')).closest('.ant-form-item') as HTMLElement;
+        await user.click(picker.querySelector('.ant-select-selector') as HTMLElement);
+        await user.click(await screen.findByTitle('Schulden'));
+
+        fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'Neue Beratungsstelle' } });
+        fireEvent.change(screen.getByPlaceholderText('PLZ'), { target: { value: '86161' } });
+        fireEvent.change(screen.getByPlaceholderText('Stadt'), { target: { value: 'Augsburg' } });
+
+        await user.click(screen.getByRole('button', { name: 'Speichern' }));
+
+        await waitFor(() => expect(mocks.mutate).toHaveBeenCalled());
+        const [submittedData] = mocks.mutate.mock.calls[0];
+        // A pre-ADR-003 multi-select would submit an array that keeps growing/appending on
+        // repeated edits; single-select must always submit exactly the one chosen id.
+        expect(submittedData.topicIds).toEqual(['3']);
     });
 });

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import ErrorOutlinedIcon from '@mui/icons-material/ErrorOutlined';
 import { PostCodeRange } from '../../../api/agency/getAgencyPostCodeRange';
+import { normalizeTopicIds } from '../../../api/agency/normalizeTopicIds';
 import routePathNames from '../../../appConfig';
 import { Page } from '../../../components/Page';
 import { CardDeck } from '../../../components/CardDeck';
@@ -43,19 +44,6 @@ type AgencySettingsSection = 'general' | 'legal' | 'functionalities';
 interface AgencyPageEditProps {
     section?: AgencySettingsSection;
 }
-
-// ADR-003: the topic picker is single-select, so the form field holds a single labelInValue
-// Option (or undefined when cleared). Normalise that — or a legacy array — to the string[] of
-// length 0/1 the agency API expects.
-const toTopicIdArray = (value: unknown): string[] => {
-    const options = Array.isArray(value) ? value : value == null ? [] : [value];
-    return options
-        .map((option) =>
-            option && typeof option === 'object' && 'value' in option ? (option as { value: unknown }).value : option,
-        )
-        .filter((id): id is string | number => id != null)
-        .map((id) => String(id));
-};
 
 const getEntityId = (value: unknown) => {
     if (typeof value === 'number' || typeof value === 'string') {
@@ -170,7 +158,7 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
                               genders: mergedFormData.demographics.genders.map(({ value }) => value),
                           }
                         : mergedFormData.demographics,
-                topicIds: toTopicIdArray(mergedFormData.topicIds),
+                topicIds: normalizeTopicIds(mergedFormData.topicIds),
                 offline: !mergedFormData.online,
                 counsellingRelations: mergedFormData.counsellingRelations?.map(
                     (relation) => relation.value || relation,

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -44,6 +44,19 @@ interface AgencyPageEditProps {
     section?: AgencySettingsSection;
 }
 
+// ADR-003: the topic picker is single-select, so the form field holds a single labelInValue
+// Option (or undefined when cleared). Normalise that — or a legacy array — to the string[] of
+// length 0/1 the agency API expects.
+const toTopicIdArray = (value: unknown): string[] => {
+    const options = Array.isArray(value) ? value : value == null ? [] : [value];
+    return options
+        .map((option) =>
+            option && typeof option === 'object' && 'value' in option ? (option as { value: unknown }).value : option,
+        )
+        .filter((id): id is string | number => id != null)
+        .map((id) => String(id));
+};
+
 const getEntityId = (value: unknown) => {
     if (typeof value === 'number' || typeof value === 'string') {
         return String(value);
@@ -128,7 +141,7 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
         ...counsellingRelationsInitialValues,
         postCodeRangesActive: !hasOnlyDefaultRangeDefined(postCodes || []),
         online: agencyData?.id ? !agencyData?.offline : false,
-        topicIds: convertToOptions(agencyData?.topics, 'name', 'id', true),
+        topicIds: convertToOptions(agencyData?.topics, 'name', 'id', true)[0],
         tenantId: agencyTenantId,
     };
 
@@ -157,7 +170,7 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
                               genders: mergedFormData.demographics.genders.map(({ value }) => value),
                           }
                         : mergedFormData.demographics,
-                topicIds: mergedFormData.topicIds?.map(({ value }) => value),
+                topicIds: toTopicIdArray(mergedFormData.topicIds),
                 offline: !mergedFormData.online,
                 counsellingRelations: mergedFormData.counsellingRelations?.map(
                     (relation) => relation.value || relation,

--- a/src/types/agency.d.ts
+++ b/src/types/agency.d.ts
@@ -24,7 +24,9 @@ export interface AgencyData {
     city: string;
     counsellingRelations: CounsellingRelation[];
     topics: TopicData[];
-    topicIds: Array<{ value: string; label: string }> | string[];
+    // ADR-003: single-select topic picker — the form field holds a single labelInValue Option
+    // (or undefined when cleared); legacy array shapes stay accepted for backwards compatibility.
+    topicIds?: { value: string; label: string } | Array<{ value: string; label: string }> | string[];
     consultantIds?: Array<{ value: string; label: string }> | string[];
     consultantAssignmentFailed?: boolean;
     demographics?: AgencyDemographicsData;


### PR DESCRIPTION
## Summary
ADR-003 (`0 - Docs/ADR-003-department-as-unique-agency-topic-with-imprint-dpp.md`) made a department the unique `(agency_id, topic_id)` pair and that `UNIQUE` constraint is already enforced on `dev` (AgencyService PR #90). This repo's Admin topic picker was never updated to match — it still lets an admin multi-select topics for an agency, which now fails against the backend constraint for any agency with more than one topic. This closes the last open item of ORISO-UserService#203.

- `AgencySettings`: drop `isMulti` from the topic picker; pass the full topic list instead of filtering out already-picked ones (single-select replaces rather than appends).
- Agency Edit page: load takes the first/only topic Option (`labelInValue` + single mode stores one Option, not an array); submit normalises back to the `string[]` of length 0/1 the API expects.
- New `normalizeTopicIds()` helper (`src/api/agency/normalizeTopicIds.ts`) unifies the id-extraction logic that was previously duplicated across `addAgencyData.ts`, `updateAgencyData.ts`, and the Edit page — handles a single Option, a legacy Option[]/string[] (old saved drafts), the backend `{id}` shape, and raw ids.
- Consultant/user topic pickers and `GrantConsultantIdentityModal` are unchanged — separate, multi-topic concern.

## Test plan
- [x] `normalizeTopicIds.test.ts` — 10 cases (Option, legacy array, backend shape, raw ids, idempotency, value-over-id precedence, empty/invalid entries)
- [x] `updateAgencyData.test.ts` (new — this file had zero coverage before) — asserts the PUT request body carries the normalised `topicIds` for Option / undefined / legacy-array / backend-`topics` inputs
- [x] `Agency/Edit/index.test.tsx` — new checks: the picker renders `ant-select-single` (not `ant-select-multiple`); choosing one topic submits exactly one id
- [x] `tsc --noEmit` clean
- [x] Full suite: 96 files / 456 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)