### PR TITLE
feat(admin): implement Case Handover card to match Figma (937-7659)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -99,8 +99,10 @@
     --m3-surface-container: #f0edee;
     --m3-surface-container-high: #eae7e8;
     --m3-surface-container-highest: #e4e2e2;
-    /* M3 container/fixed roles (OrisoScheme, seed #A5000A), aligned with ORISO-Frontend tokens */
-    --m3-secondary-container: #e8ebee;
+    /* M3 container/fixed roles (OrisoScheme, seed #A5000A). secondary-container is
+       the mid slate (#646D78) from the runtime OrisoScheme (light) and Figma; the
+       previous #e8ebee drifted and left the light on-colour text unreadable. */
+    --m3-secondary-container: #646d78;
     --m3-on-secondary-container: #e7effc;
     --m3-primary-fixed: #ffdad5;
     --m3-tertiary-container: #ffdad6;

--- a/src/components/M3Checkbox/index.test.tsx
+++ b/src/components/M3Checkbox/index.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { M3Checkbox } from './index';
+
+describe('M3Checkbox', () => {
+    it('exposes the checkbox role and checked state', () => {
+        render(<M3Checkbox checked label="Activated" />);
+        const checkbox = screen.getByRole('checkbox', { name: 'Activated' });
+        expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('toggles via onChange when enabled', async () => {
+        const onChange = vi.fn();
+        const user = userEvent.setup();
+        render(<M3Checkbox checked={false} label="Activated" onChange={onChange} />);
+        await user.click(screen.getByRole('checkbox', { name: 'Activated' }));
+        expect(onChange).toHaveBeenCalledWith(true);
+    });
+
+    it('does not fire onChange when disabled', async () => {
+        const onChange = vi.fn();
+        const user = userEvent.setup();
+        render(<M3Checkbox checked={false} disabled label="Activated" onChange={onChange} />);
+        await user.click(screen.getByRole('checkbox', { name: 'Activated' }));
+        expect(onChange).not.toHaveBeenCalled();
+        expect(screen.getByRole('checkbox', { name: 'Activated' })).toBeDisabled();
+    });
+});

--- a/src/components/M3Checkbox/index.tsx
+++ b/src/components/M3Checkbox/index.tsx
@@ -1,0 +1,48 @@
+import classNames from 'classnames';
+import styles from './styles.module.scss';
+
+interface M3CheckboxProps {
+    checked?: boolean;
+    disabled?: boolean;
+    /** Accessible name; the visible label is rendered by the caller. */
+    label: string;
+    className?: string;
+    onChange?: (value: boolean) => void;
+}
+
+/**
+ * Material-3 checkbox (18px container inside a 40px state-layer / touch target),
+ * built to match the Figma design system alongside {@link M3Switch}. Colours are
+ * driven by the M3/OrisoScheme CSS variables so it inherits the admin theme.
+ */
+export const M3Checkbox = ({ checked = false, disabled = false, label, className, onChange }: M3CheckboxProps) => {
+    const handleToggle = () => {
+        if (disabled) {
+            return;
+        }
+
+        onChange?.(!checked);
+    };
+
+    return (
+        <button
+            type="button"
+            role="checkbox"
+            aria-checked={checked}
+            aria-label={label}
+            disabled={disabled}
+            onClick={handleToggle}
+            className={classNames(styles.checkbox, className)}
+        >
+            <span className={styles.stateLayer}>
+                <span className={classNames(styles.box, { [styles.boxChecked]: checked })}>
+                    {checked && (
+                        <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+                            <path d="M7.1 12.3 3.6 8.8l1-1 2.5 2.5 5.3-5.3 1 1z" fill="var(--m3-on-primary, #ffffff)" />
+                        </svg>
+                    )}
+                </span>
+            </span>
+        </button>
+    );
+};

--- a/src/components/M3Checkbox/styles.module.scss
+++ b/src/components/M3Checkbox/styles.module.scss
@@ -1,0 +1,48 @@
+.checkbox {
+    display: inline-flex;
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 0;
+    appearance: none;
+    background: none;
+    cursor: pointer;
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.38;
+    }
+}
+
+.stateLayer {
+    display: inline-flex;
+    width: 40px;
+    height: 40px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 100px;
+    transition: background-color 150ms ease;
+}
+
+.checkbox:not(:disabled):hover .stateLayer {
+    background: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 8%, transparent);
+}
+
+.box {
+    display: inline-flex;
+    width: 18px;
+    height: 18px;
+    box-sizing: border-box;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid var(--admin-form-muted-text, var(--m3-on-surface-variant, #444748));
+    border-radius: 2px;
+}
+
+.boxChecked {
+    border-color: var(--admin-control-selected, var(--m3-primary, #a5000a));
+    background: var(--admin-control-selected, var(--m3-primary, #a5000a));
+}

--- a/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/CaseHandoverCardView.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/CaseHandoverCardView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Skeleton, Tooltip } from 'antd';
 import { ReactComponent as CaseHandoverIcon } from '../../../../../resources/img/svg/permissions/case_handover.svg';
 import { M3Switch } from '../../../../M3Switch';
+import { M3Checkbox } from '../../../../M3Checkbox';
 import type { CaseHandoverReasonPolicy } from '../../../../../types/caseHandoverReasonPolicy';
 import {
     buildDisplayReasons,
@@ -89,15 +90,28 @@ export const CaseHandoverCardView = ({
                 <span className={cardStyles.cardIcon} aria-hidden>
                     <CaseHandoverIcon width={40} height={40} />
                 </span>
-                <h3 className={cardStyles.cardTitle}>{t('tenants.permissions.card.caseHandover.title')}</h3>
+                <h3 className={`${cardStyles.cardTitle} ${styles.cardTitleM3}`}>
+                    {t('tenants.permissions.card.caseHandover.title')}
+                </h3>
             </div>
 
             {isLoading ? (
                 <Skeleton active paragraph={{ rows: 6 }} />
             ) : (
                 <>
-                    <div className={cardStyles.masterRow}>
-                        <span className={cardStyles.masterLabel}>{t('tenants.permissions.card.activated')}</span>
+                    <div className={styles.featureRow}>
+                        <Tooltip title={comingSoon}>
+                            <span tabIndex={0}>
+                                <M3Checkbox
+                                    checked={false}
+                                    disabled
+                                    label={`${t('tenants.permissions.card.caseHandover.enforceOption')}: ${t(
+                                        'tenants.permissions.card.activated',
+                                    )}`}
+                                />
+                            </span>
+                        </Tooltip>
+                        <span className={styles.featureLabel}>{t('tenants.permissions.card.activated')}</span>
                         <M3Switch
                             checked={moduleEnabled}
                             disabled={!canEdit}
@@ -106,12 +120,21 @@ export const CaseHandoverCardView = ({
                         />
                     </div>
 
-                    <p className={`${cardStyles.cardDescription} ${styles.cardDescriptionCompact}`}>
-                        {t('tenants.permissions.card.caseHandover.description')}
-                    </p>
+                    <p className={styles.helperText}>{t('tenants.permissions.card.caseHandover.description')}</p>
 
-                    <div className={cardStyles.toggleRow}>
-                        <span className={cardStyles.toggleLabel}>
+                    <div className={styles.featureRow}>
+                        <Tooltip title={comingSoon}>
+                            <span tabIndex={0}>
+                                <M3Checkbox
+                                    checked={false}
+                                    disabled
+                                    label={`${t('tenants.permissions.card.caseHandover.enforceOption')}: ${t(
+                                        'tenants.permissions.card.caseHandover.optOutMessage',
+                                    )}`}
+                                />
+                            </span>
+                        </Tooltip>
+                        <span className={styles.featureLabel}>
                             {t('tenants.permissions.card.caseHandover.optOutMessage')}
                         </span>
                         <Tooltip title={comingSoon}>

--- a/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/styles.module.scss
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/styles.module.scss
@@ -6,14 +6,50 @@
    notification preview) than the chat-type cards, so it doesn't need the shared
    card's reserved description height. */
 
-.cardDescriptionCompact {
-    min-height: 0;
+/* M3 headline-small (Figma): 24/32, regular weight, centered. Overrides the
+   shared card title (22/700) for this card to match the design system. */
+
+.cardTitleM3 {
+    font-size: 24px;
+    font-weight: 400;
+    line-height: 32px;
+}
+
+/* Figma "Additional Features Element": checkbox + label + trailing control,
+   16px gap, vertically centered. */
+
+.featureRow {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    padding: 4px 0;
+    gap: 16px;
+}
+
+.featureLabel {
+    min-width: 0;
+    flex: 1;
+    color: var(--admin-form-field-text, var(--m3-on-surface, #1b1b1c));
+    font-size: 16px;
+    font-weight: 400;
+    letter-spacing: 0.5px;
+    line-height: 24px;
+}
+
+/* M3 body-medium helper line under the master row. */
+.helperText {
+    margin: 4px 0 12px;
+    color: var(--admin-form-muted-text, var(--m3-on-surface-variant, #444748));
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: 0.25px;
+    line-height: 20px;
 }
 
 .reasonTabs {
     display: flex;
     align-items: stretch;
-    border-bottom: 1px solid color-mix(in srgb, var(--m3-on-surface) 14%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 14%, transparent);
     margin: 4px -8px 0;
     overflow-x: auto;
     scrollbar-width: none;
@@ -29,7 +65,7 @@
     border-bottom: 3px solid transparent;
     appearance: none;
     background: none;
-    color: var(--m3-on-surface-variant, #444748);
+    color: var(--admin-form-muted-text, var(--m3-on-surface-variant, #444748));
     cursor: pointer;
     font-family: inherit;
     font-size: 14px;
@@ -38,29 +74,29 @@
     white-space: nowrap;
 
     &:hover {
-        color: var(--m3-on-surface, #1b1b1c);
+        color: var(--admin-form-field-text, var(--m3-on-surface, #1b1b1c));
     }
 }
 
 .reasonTabActive {
-    border-bottom-color: var(--m3-primary, #a5000a);
-    color: var(--m3-primary, #a5000a);
+    border-bottom-color: var(--admin-control-selected, var(--m3-primary, #a5000a));
+    color: var(--admin-control-selected, var(--m3-primary, #a5000a));
     font-weight: 600;
 }
 
 /* Placeholder reason (not backend-seeded yet): selectable to inspect, greyed out. */
 .reasonTabPlaceholder {
-    color: var(--input-disabled-color, rgb(27 27 28 / 38%));
+    color: color-mix(in srgb, var(--admin-form-muted-text, #444748) 45%, transparent);
 
     &.reasonTabActive {
-        border-bottom-color: var(--input-disabled-color, rgb(27 27 28 / 38%));
-        color: color-mix(in srgb, var(--m3-on-surface) 55%, transparent);
+        border-bottom-color: color-mix(in srgb, var(--admin-form-muted-text, #444748) 45%, transparent);
+        color: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 55%, transparent);
     }
 }
 
 .placeholderHint {
     margin: 8px 0 0;
-    color: var(--m3-on-surface-variant, #444748);
+    color: var(--admin-form-muted-text, var(--m3-on-surface-variant, #444748));
     font-size: 12px;
     letter-spacing: 0.4px;
     line-height: 16px;
@@ -91,7 +127,7 @@
     appearance: none;
     background: none;
     border-radius: 8px;
-    color: var(--m3-on-surface-variant, #444748);
+    color: var(--admin-form-muted-text, var(--m3-on-surface-variant, #444748));
     cursor: pointer;
     font-family: inherit;
     font-size: 14px;
@@ -107,17 +143,19 @@
 }
 
 .notificationField {
-    min-height: 88px;
+    min-height: 128px;
+    box-sizing: border-box;
     padding: 8px 16px 10px;
-    border-bottom: 1px solid var(--m3-on-surface-variant, #444748);
-    background: var(--m3-surface-container-low, #f6f3f3);
-    border-radius: 4px 4px 0 0;
+    border: 1px solid var(--input-border-color, var(--m3-outline, #747878));
+    background: var(--input-bg, var(--m3-surface-container-low, #f6f3f3));
+    border-radius: 4px;
+    overflow-wrap: anywhere;
 }
 
 .notificationFieldLabel {
     display: block;
     margin-bottom: 2px;
-    color: var(--m3-on-surface-variant, #444748);
+    color: var(--admin-form-muted-text, var(--m3-on-surface-variant, #444748));
     font-size: 12px;
     letter-spacing: 0.4px;
     line-height: 16px;
@@ -125,19 +163,22 @@
 
 .notificationFieldText {
     margin: 0;
-    color: var(--m3-on-surface, #1b1b1c);
+    color: var(--admin-form-field-text, var(--m3-on-surface, #1b1b1c));
     font-size: 15px;
     letter-spacing: 0.3px;
     line-height: 22px;
+    overflow-wrap: anywhere;
 }
 
 .enforceHint {
     margin: 14px 0 4px;
+
+    /* Figma M3/sys/light/on-primary-fixed (#410001), body-medium-emphasized. */
     color: var(--m3-on-primary-fixed, #410001);
-    font-size: 13px;
+    font-size: 14px;
     font-weight: 500;
     letter-spacing: 0.25px;
-    line-height: 19px;
+    line-height: 20px;
     text-align: center;
 }
 
@@ -147,7 +188,7 @@
     align-items: center;
     justify-content: flex-end;
     padding: 0 24px 0 8px;
-    border-top: 1px solid color-mix(in srgb, var(--m3-on-surface) 14%, transparent);
+    border-top: 1px solid color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 14%, transparent);
     margin: auto -32px 0;
     gap: 8px;
 }
@@ -169,7 +210,7 @@
     letter-spacing: 0.1px;
 
     &:disabled {
-        color: var(--input-disabled-color, rgb(27 27 28 / 38%));
+        color: color-mix(in srgb, var(--admin-form-muted-text, #444748) 45%, transparent);
         cursor: not-allowed;
     }
 
@@ -179,6 +220,9 @@
     }
 }
 
+/* Figma renders both footer actions in secondary (#4C555F); the primary action
+   is distinguished by its leading icon, not colour. */
+
 .footerTextButtonPrimary {
-    color: var(--m3-primary, #a5000a);
+    color: var(--m3-secondary, #4c555f);
 }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -703,6 +703,7 @@
     "tenants.permissions.card.caseHandover.enforceHint": "Ausgewählte Optionen verhindern, dass niedrigere Rollen Funktionen ausblenden können.",
     "tenants.permissions.card.caseHandover.configure": "Konfigurieren",
     "tenants.permissions.card.caseHandover.enforce": "Aktivierte Auswahl erzwingen",
+    "tenants.permissions.card.caseHandover.enforceOption": "Diese Option für niedrigere Rollen erzwingen",
     "tenants.permissions.card.caseHandover.comingSoon": "Wird mit einem späteren Update konfigurierbar.",
     "tenants.permissions.card.caseHandover.reasonsAria": "Übergabegründe",
     "tenants.permissions.card.caseHandover.languagesAria": "Sprachen der Systembenachrichtigung",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1069,6 +1069,7 @@
     "tenants.permissions.card.caseHandover.enforceHint": "Selected options prevent lower roles from hiding functions.",
     "tenants.permissions.card.caseHandover.configure": "Configure",
     "tenants.permissions.card.caseHandover.enforce": "Enforce activated selections",
+    "tenants.permissions.card.caseHandover.enforceOption": "Mark this option to enforce it for lower roles",
     "tenants.permissions.card.caseHandover.comingSoon": "Will become configurable in a later update.",
     "tenants.permissions.card.caseHandover.reasonsAria": "Handover reasons",
     "tenants.permissions.card.caseHandover.languagesAria": "System notification languages",


### PR DESCRIPTION
## Why
The Case Handover ("Fallübergabe") permissions card had drifted from the Figma design (`node-id=937-7659`). Missing controls and off-spec typography/colours made it look inconsistent with the M3 design system.

## What
Implements the card to match Figma:

- **M3 checkboxes** added to the *Activated* and *Opt-out message* rows (the enforce-selection controls). New reusable **`M3Checkbox`** component — 18px box inside a 40px M3 state layer / touch target, colours driven by the M3/OrisoScheme CSS variables, sibling to `M3Switch`. Rendered disabled with the existing "coming soon" tooltip until the enforce backend lands (disable, don't hide).
- **Feature rows** restructured to the Figma layout (checkbox + label + trailing control, 16px gap).
- **M3 typography**: headline-small title (24/32, regular), body-large feature labels, body-medium helper text.
- **Enforce hint** now uses `on-primary-fixed` (#410001); both footer actions render in secondary (#4C555F), matching the design.
- **Token fix**: `--m3-secondary-container` in `app.css` drifted to `#e8ebee`, which left the selected language chip pale with unreadable light-on-light text. Corrected to `#646D78` (the runtime OrisoScheme light value + Figma), fixing the chip and a WCAG text-contrast issue.

## Verified
- Rendered the `CaseHandoverCard` story in Storybook and compared against the Figma node — checkboxes, title, tabs, filled language chip (`#646D78` / `#E7EFFC`), enforce hint and footer all match.
- `vitest`: 16/16 pass (incl. new `M3Checkbox` tests). `tsc` typecheck clean. Stylelint 0 errors, Prettier clean.

## Scope
Card-only. The broader antd `ConfigProvider` M3 token bridge (admin-wide consistency) is intentionally kept out of this PR as a separate change.

## Affected repos
- ORISO-Admin (frontend only)

## Screenshot
Storybook render matches Figma `node-id=937-7659` (Fallübergabe card).
