### PR TITLE
feat(admin): bridge M3/OrisoScheme tokens into the antd ConfigProvider theme

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ConfigProvider } from 'antd';
 import de_DE from 'antd/es/locale/de_DE';
+import { buildAdminAntdTheme } from '../src/theme/antdM3Theme';
 
 // Global Admin styling: antd v5 reset + app less/overrides. Mirrors src/App.tsx.
 import 'antd/dist/reset.css';
@@ -26,10 +27,7 @@ const preview: Preview = {
     decorators: [
         (Story) => (
             <QueryClientProvider client={queryClient}>
-                <ConfigProvider
-                    locale={de_DE}
-                    theme={{ token: { colorPrimary: '#273270', colorLink: '#273270', borderRadius: 4 } }}
-                >
+                <ConfigProvider locale={de_DE} theme={buildAdminAntdTheme()}>
                     <MemoryRouter>
                         <Story />
                     </MemoryRouter>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,7 @@ import { apiServerSettings } from './api/settings/apiServerSettings';
 import { Initialization } from './components/Layout/Initialization';
 import { AccessDenied } from './pages/ErrorPages/AccessDenied';
 import { DEFAULT_LANGUAGE, normalizeLanguage } from './utils/language';
+import { buildAdminAntdTheme } from './theme/antdM3Theme';
 
 interface LangMap {
     [key: string]: Locale;
@@ -73,10 +74,7 @@ const LanguageAwareConfigProvider = ({ children }: { children: JSX.Element }) =>
     }, []);
 
     return (
-        <ConfigProvider
-            locale={myLanguages[language]}
-            theme={{ token: { colorPrimary: '#273270', colorLink: '#273270', borderRadius: 4 } }}
-        >
+        <ConfigProvider locale={myLanguages[language]} theme={buildAdminAntdTheme()}>
             {children}
         </ConfigProvider>
     );

--- a/src/theme/AdminThemeBridge.stories.tsx
+++ b/src/theme/AdminThemeBridge.stories.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button, Card, ConfigProvider, Input, Select, Space, Switch, Table, Tag, Tabs, type ThemeConfig } from 'antd';
+
+import { buildAdminAntdTheme } from './antdM3Theme';
+
+/**
+ * Side-by-side proof that the M3 token bridge recolours every antd component
+ * from the source palette, without touching any component. Left column uses the
+ * legacy hard-coded blue theme; right column uses {@link buildAdminAntdTheme}.
+ */
+const LEGACY_BLUE_THEME: ThemeConfig = {
+    token: { colorPrimary: '#273270', colorLink: '#273270', borderRadius: 4 },
+};
+
+const selectOptions = [
+    { value: 'illness', label: 'Illness' },
+    { value: 'advice', label: 'Advice needed' },
+    { value: 'legal', label: 'Legal violation' },
+];
+
+const tableColumns = [
+    { title: 'Agency', dataIndex: 'name', key: 'name' },
+    { title: 'Status', dataIndex: 'status', key: 'status', render: (v: string) => <Tag color="processing">{v}</Tag> },
+];
+
+const tableData = [
+    { key: '1', name: 'Nearby 1:1', status: 'active' },
+    { key: '2', name: 'Live 1.1', status: 'draft' },
+];
+
+const Sampler = () => (
+    <Space direction="vertical" size="middle" style={{ width: 280 }}>
+        <Space>
+            <Button type="primary">Speichern</Button>
+            <Button>Abbrechen</Button>
+        </Space>
+        <Select defaultValue="illness" options={selectOptions} style={{ width: '100%' }} />
+        <Input placeholder="Suche…" />
+        <Space>
+            <Switch defaultChecked />
+            <Tag color="error">Legal violation</Tag>
+            <Tag>Holiday</Tag>
+        </Space>
+        <Tabs
+            items={[
+                { key: 'a', label: 'Erscheinungsbild' },
+                { key: 'b', label: 'Rechtliches' },
+                { key: 'c', label: 'Berechtigungen' },
+            ]}
+        />
+        <Card size="small" title="Case takeover">
+            <Table columns={tableColumns} dataSource={tableData} pagination={false} size="small" />
+        </Card>
+    </Space>
+);
+
+const Column = ({ title, theme }: { title: string; theme: ThemeConfig }) => (
+    <div style={{ flex: '0 0 auto' }}>
+        <h3 style={{ font: "500 14px/20px 'Inter', sans-serif", marginBottom: 12 }}>{title}</h3>
+        <ConfigProvider theme={theme}>
+            <div style={{ padding: 16, background: '#fcf9f9', borderRadius: 16 }}>
+                <Sampler />
+            </div>
+        </ConfigProvider>
+    </div>
+);
+
+const meta: Meta = {
+    title: 'Foundations/Admin Theme Bridge',
+    parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+export const BeforeAfter: StoryObj = {
+    render: () => (
+        <div style={{ display: 'flex', gap: 48, padding: 32, alignItems: 'flex-start' }}>
+            <Column title="Vorher — hard-coded blue (#273270)" theme={LEGACY_BLUE_THEME} />
+            <Column title="Nachher — M3 bridge (#A5000A)" theme={buildAdminAntdTheme()} />
+        </div>
+    ),
+};

--- a/src/theme/antdM3Theme.ts
+++ b/src/theme/antdM3Theme.ts
@@ -1,0 +1,74 @@
+import { theme as antdTheme, type ThemeConfig } from 'antd';
+
+import { computeOrisoPalette, type OrisoSchemeName } from '../utils/theme/orisoScheme';
+import type { TenantSeeds } from '../utils/themeSeeds';
+
+/**
+ * Bridges the M3/OrisoScheme design tokens into antd's ConfigProvider theme.
+ *
+ * Historically antd was themed with three hard-coded values (`colorPrimary
+ * #273270`, `colorLink #273270`, `borderRadius 4`) that had nothing to do with
+ * the Material-3 palette used by the SCSS modules, the MUI surfaces and the
+ * Figma design. That is why antd components rendered blue while the rest of the
+ * admin was muted-red M3. This module derives a full antd token set from the
+ * same `computeOrisoPalette` source so every antd component inherits the M3
+ * colours, radii and typography without any per-component restyling.
+ */
+
+// M3 body/medium is the admin's default text size; Inter is the M3 body face,
+// Roboto the title face (see Figma variable defs).
+const M3_FONT_FAMILY = "'Inter', 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";
+
+// M3 corner radii. Cards/sheets use the large radius, controls the base one.
+const M3_RADIUS = 8;
+const M3_RADIUS_LG = 16;
+const M3_RADIUS_SM = 4;
+
+// M3 control size (also satisfies the WCAG 2.2 "target size" minimum far more
+// comfortably than antd's default 32px control height).
+const M3_CONTROL_HEIGHT = 40;
+
+export interface AdminAntdThemeOptions {
+    seeds?: TenantSeeds;
+    scheme?: OrisoSchemeName;
+}
+
+/**
+ * Build the antd {@link ThemeConfig} for the admin panel from the M3 palette.
+ *
+ * @param options.seeds  Tenant colour seeds; defaults to the platform seed
+ *                        (`#A5000A`) when omitted.
+ * @param options.scheme `'light'` (default) or `'inverted'` for the dark surface.
+ */
+export const buildAdminAntdTheme = ({ seeds, scheme = 'light' }: AdminAntdThemeOptions = {}): ThemeConfig => {
+    const { tokens } = computeOrisoPalette(seeds ?? {}, scheme);
+    const t = (name: string, fallback: string) => tokens[name] ?? fallback;
+
+    return {
+        algorithm: scheme === 'inverted' ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
+        token: {
+            // Brand + semantic colours, straight from the M3 scheme.
+            colorPrimary: t('--m3-primary', '#a5000a'),
+            colorLink: t('--m3-primary', '#a5000a'),
+            colorInfo: t('--m3-primary', '#a5000a'),
+            colorError: t('--m3-error', '#b1005e'),
+            colorWarning: t('--m3-warning', '#410001'),
+            // Surfaces + text.
+            colorTextBase: t('--m3-on-surface', '#1a1c1e'),
+            colorBgBase: t('--m3-surface', '#fcf9f9'),
+            colorBgContainer: t('--m3-surface-container-low', '#f7f3f4'),
+            colorBgElevated: t('--m3-surface-container', '#f0edee'),
+            colorBorder: t('--m3-outline-variant', '#c4c7c8'),
+            colorBorderSecondary: t('--m3-outline-variant', '#c4c7c8'),
+            // M3 shape scale.
+            borderRadius: M3_RADIUS,
+            borderRadiusLG: M3_RADIUS_LG,
+            borderRadiusSM: M3_RADIUS_SM,
+            // M3 typography.
+            fontFamily: M3_FONT_FAMILY,
+            fontSize: 14,
+            // M3 sizing (+ WCAG 2.2 target size headroom).
+            controlHeight: M3_CONTROL_HEIGHT,
+        },
+    };
+};


### PR DESCRIPTION
## Why
The admin's look-and-feel is inconsistent: antd's `ConfigProvider` was themed with three hard-coded values — `colorPrimary`/`colorLink` `#273270` (blue) and `borderRadius: 4` — in both `src/index.tsx` and `.storybook/preview.tsx`. That is disconnected from the Material-3 / OrisoScheme system already used by the SCSS modules, the MUI surfaces and the Figma design, so every antd component (form fields, selects, tables, buttons, tabs) rendered generic blue while the rest of the admin is muted-red M3.

## What
- **`src/theme/antdM3Theme.ts` → `buildAdminAntdTheme()`**: derives a full antd token set (brand + semantic colours, surfaces/text, M3 shape scale, Inter/Roboto typography, 40px control height) from the same `computeOrisoPalette` source of truth. No per-component restyling — the token bridge propagates M3 to every antd component automatically.
- Wired into the app `ConfigProvider` (`src/index.tsx`) and the Storybook decorator (`.storybook/preview.tsx`), replacing the duplicated hard-coded blue.
- **`Foundations/Admin Theme Bridge`** story rendering the same components side by side under the legacy blue theme vs the M3 bridge, as a visual proof.

## Notes
- The 40px control height also gives comfortable **WCAG 2.2 target-size** headroom.
- One known limit: a few legacy global overrides still use `!important` (e.g. `.ant-btn-primary` in `form.less` pins the primary button to `#1f1f1f`), so those specific components don't yet pick up the bridge. Removing those overrides is a sensible follow-up.
- Next steps this enables: M3 component-level polish, micro-animations via antd motion tokens, and the eventual antd v6 upgrade (kept separate).

## Verified
Storybook before/after story renders as expected; `tsc` typecheck clean; Prettier clean.

## Affected repos
- ORISO-Admin (frontend only)
