### PR TITLE
test(admin): cover the antd M3 theme bridge and Figma case-handover controls

### DIFF
--- a/src/components/M3Checkbox/index.test.tsx
+++ b/src/components/M3Checkbox/index.test.tsx
@@ -18,6 +18,37 @@ describe('M3Checkbox', () => {
         expect(onChange).toHaveBeenCalledWith(true);
     });
 
+    it('unchecks a checked box via onChange(false)', async () => {
+        const onChange = vi.fn();
+        const user = userEvent.setup();
+        render(<M3Checkbox checked label="Activated" onChange={onChange} />);
+        await user.click(screen.getByRole('checkbox', { name: 'Activated' }));
+        expect(onChange).toHaveBeenCalledWith(false);
+    });
+
+    it('is keyboard-operable: Tab focuses it, Space and Enter toggle', async () => {
+        const onChange = vi.fn();
+        const user = userEvent.setup();
+        render(<M3Checkbox checked={false} label="Activated" onChange={onChange} />);
+
+        await user.tab();
+        expect(screen.getByRole('checkbox', { name: 'Activated' })).toHaveFocus();
+
+        await user.keyboard(' ');
+        expect(onChange).toHaveBeenNthCalledWith(1, true);
+
+        await user.keyboard('{Enter}');
+        expect(onChange).toHaveBeenNthCalledWith(2, true);
+    });
+
+    it('is removed from the tab order when disabled', async () => {
+        const user = userEvent.setup();
+        render(<M3Checkbox checked={false} disabled label="Activated" />);
+
+        await user.tab();
+        expect(screen.getByRole('checkbox', { name: 'Activated' })).not.toHaveFocus();
+    });
+
     it('does not fire onChange when disabled', async () => {
         const onChange = vi.fn();
         const user = userEvent.setup();

--- a/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/CaseHandoverCard.test.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/CaseHandoverCard.test.tsx
@@ -76,14 +76,17 @@ describe('CaseHandoverCard', () => {
         await user.click(screen.getByRole('switch', { name: 'tenants.permissions.card.activated' }));
 
         await waitFor(() => {
-            expect(mocks.mutate).toHaveBeenCalledWith([
-                expect.objectContaining({
-                    code: 'COUNSELLOR_ASKED_FOR_ADVICE',
-                    enabled: false,
-                    policyAuthority: null,
-                }),
-                expect.objectContaining({ code: 'COUNSELLOR_IS_ILL', enabled: false }),
-            ], expect.anything());
+            expect(mocks.mutate).toHaveBeenCalledWith(
+                [
+                    expect.objectContaining({
+                        code: 'COUNSELLOR_ASKED_FOR_ADVICE',
+                        enabled: false,
+                        policyAuthority: null,
+                    }),
+                    expect.objectContaining({ code: 'COUNSELLOR_IS_ILL', enabled: false }),
+                ],
+                expect.anything(),
+            );
         });
     });
 
@@ -99,16 +102,19 @@ describe('CaseHandoverCard', () => {
         );
 
         await waitFor(() => {
-            expect(mocks.mutate).toHaveBeenCalledWith([
-                expect.objectContaining({
-                    code: 'COUNSELLOR_ASKED_FOR_ADVICE',
-                    clientConsentRequired: false,
-                }),
-                expect.objectContaining({
-                    code: 'COUNSELLOR_IS_ILL',
-                    clientConsentRequired: false,
-                }),
-            ], expect.anything());
+            expect(mocks.mutate).toHaveBeenCalledWith(
+                [
+                    expect.objectContaining({
+                        code: 'COUNSELLOR_ASKED_FOR_ADVICE',
+                        clientConsentRequired: false,
+                    }),
+                    expect.objectContaining({
+                        code: 'COUNSELLOR_IS_ILL',
+                        clientConsentRequired: false,
+                    }),
+                ],
+                expect.anything(),
+            );
         });
     });
 
@@ -133,6 +139,31 @@ describe('CaseHandoverCard', () => {
         expect(
             screen.getByRole('switch', { name: 'tenants.permissions.card.caseHandover.optOutMessage' }),
         ).toBeDisabled();
+    });
+
+    it('renders the Figma enforce checkboxes disabled and unchecked without persisting anything', async () => {
+        const user = userEvent.setup();
+        render(<CaseHandoverCard />);
+
+        // One M3 checkbox per feature row (master "Activated" + opt-out message),
+        // both coming-soon previews: disabled, unchecked, keyboard-reachable tooltip wrapper.
+        const activatedCheckbox = screen.getByRole('checkbox', {
+            name: 'tenants.permissions.card.caseHandover.enforceOption: tenants.permissions.card.activated',
+        });
+        const optOutCheckbox = screen.getByRole('checkbox', {
+            name: 'tenants.permissions.card.caseHandover.enforceOption: tenants.permissions.card.caseHandover.optOutMessage',
+        });
+
+        [activatedCheckbox, optOutCheckbox].forEach((checkbox) => {
+            expect(checkbox).toBeDisabled();
+            expect(checkbox).toHaveAttribute('aria-checked', 'false');
+            // The tooltip wrapper keeps the disabled control reachable by keyboard.
+            expect(checkbox.parentElement).toHaveAttribute('tabindex', '0');
+        });
+
+        await user.click(activatedCheckbox);
+        await user.click(optOutCheckbox);
+        expect(mocks.mutate).not.toHaveBeenCalled();
     });
 
     it('rolls back the optimistic toggle when the save fails', async () => {

--- a/src/theme/antdM3Theme.test.ts
+++ b/src/theme/antdM3Theme.test.ts
@@ -1,0 +1,94 @@
+import { theme as antdTheme } from 'antd';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildAdminAntdTheme } from './antdM3Theme';
+import { computeOrisoPalette } from '../utils/theme/orisoScheme';
+
+// The bridge must stay a pure derivation of the OrisoScheme palette. To test the
+// fallback path (palette missing a token) the module is wrapped so single tests
+// can override the returned token set while all others use the real palette.
+const mocks = vi.hoisted(() => ({
+    tokensOverride: null as Record<string, string> | null,
+}));
+
+vi.mock('../utils/theme/orisoScheme', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../utils/theme/orisoScheme')>();
+    return {
+        ...actual,
+        computeOrisoPalette: (...args: Parameters<typeof actual.computeOrisoPalette>) =>
+            mocks.tokensOverride
+                ? { tokens: mocks.tokensOverride, tooPale: false }
+                : actual.computeOrisoPalette(...args),
+    };
+});
+
+describe('buildAdminAntdTheme', () => {
+    afterEach(() => {
+        mocks.tokensOverride = null;
+    });
+
+    it('derives the antd colour tokens from the M3 light palette (single source of truth)', () => {
+        const { tokens } = computeOrisoPalette({}, 'light');
+        const { token, algorithm } = buildAdminAntdTheme();
+
+        expect(algorithm).toBe(antdTheme.defaultAlgorithm);
+        // Brand + semantic colours come straight from the --m3-* token set,
+        // not from the legacy hard-coded blue (#273270).
+        expect(token?.colorPrimary).toBe(tokens['--m3-primary']);
+        expect(token?.colorPrimary).toBe('#a5000a');
+        expect(token?.colorLink).toBe(tokens['--m3-primary']);
+        expect(token?.colorInfo).toBe(tokens['--m3-primary']);
+        expect(token?.colorError).toBe(tokens['--m3-error']);
+        expect(token?.colorWarning).toBe(tokens['--m3-warning']);
+        // Surfaces, text and borders follow the M3 surface roles.
+        expect(token?.colorTextBase).toBe(tokens['--m3-on-surface']);
+        expect(token?.colorBgBase).toBe(tokens['--m3-surface']);
+        expect(token?.colorBgContainer).toBe(tokens['--m3-surface-container-low']);
+        expect(token?.colorBgElevated).toBe(tokens['--m3-surface-container']);
+        expect(token?.colorBorder).toBe(tokens['--m3-outline-variant']);
+        expect(token?.colorBorderSecondary).toBe(tokens['--m3-outline-variant']);
+    });
+
+    it('propagates tenant colour seeds into the antd primary colour', () => {
+        const { token } = buildAdminAntdTheme({ seeds: { accentDark: '#336699' } });
+
+        expect(token?.colorPrimary).toBe('#336699');
+        expect(token?.colorLink).toBe('#336699');
+    });
+
+    it('uses the dark algorithm and the inverted palette for the inverted scheme', () => {
+        const { tokens } = computeOrisoPalette({}, 'inverted');
+        const { token, algorithm } = buildAdminAntdTheme({ scheme: 'inverted' });
+
+        expect(algorithm).toBe(antdTheme.darkAlgorithm);
+        expect(token?.colorPrimary).toBe(tokens['--m3-primary']);
+        expect(token?.colorBgBase).toBe(tokens['--m3-surface']);
+        expect(token?.colorTextBase).toBe(tokens['--m3-on-surface']);
+    });
+
+    it('falls back to the baked-in M3 defaults when the palette omits a token', () => {
+        mocks.tokensOverride = {};
+
+        const { token } = buildAdminAntdTheme();
+
+        expect(token?.colorPrimary).toBe('#a5000a');
+        expect(token?.colorError).toBe('#b1005e');
+        expect(token?.colorWarning).toBe('#410001');
+        expect(token?.colorTextBase).toBe('#1a1c1e');
+        expect(token?.colorBgBase).toBe('#fcf9f9');
+        expect(token?.colorBorder).toBe('#c4c7c8');
+    });
+
+    it('applies the M3 shape, typography and control sizing regardless of scheme', () => {
+        for (const scheme of ['light', 'inverted'] as const) {
+            const { token } = buildAdminAntdTheme({ scheme });
+
+            expect(token?.borderRadius).toBe(8);
+            expect(token?.borderRadiusLG).toBe(16);
+            expect(token?.borderRadiusSM).toBe(4);
+            expect(token?.fontFamily).toMatch(/^'Inter', 'Roboto'/);
+            expect(token?.fontSize).toBe(14);
+            // 40px control height = WCAG 2.2 target-size headroom.
+            expect(token?.controlHeight).toBe(40);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Follow-up unit-test coverage for the freshly merged #248 (Case Handover card matching Figma, new `M3Checkbox`) and #250 (antd M3 token bridge). No production code changes — tests only.

- **New `src/theme/antdM3Theme.test.ts`** (#250 landed with no unit test):
  - `buildAdminAntdTheme()` derives every antd colour token from the `computeOrisoPalette` M3 token set — the single source of truth — instead of the legacy hard-coded blue (`#273270`)
  - tenant colour seeds propagate into `colorPrimary`/`colorLink`
  - the `inverted` scheme selects `antdTheme.darkAlgorithm` and the inverted palette
  - fallback path: when the palette omits a token, the baked-in M3 defaults apply
  - M3 shape (`8/16/4` radii), Inter/Roboto typography, and the 40px control height (WCAG 2.2 target-size headroom) hold for both schemes
- **Extended `src/components/M3Checkbox/index.test.tsx`**: unchecking a checked box emits `onChange(false)`; keyboard operability (Tab focuses, Space and Enter toggle); disabled removes it from the tab order. Existing tests already covered role/checked exposure, click toggling and the disabled no-op.
- **Extended `CaseHandoverCard.test.tsx`**: the two new Figma "enforce" feature-row checkboxes render disabled + unchecked, sit inside keyboard-reachable tooltip wrappers (`tabindex="0"`), and clicking them never persists anything. The pre-existing tests (master toggle, consent toggles, placeholder tab, error/rollback paths) still pass unchanged against the new markup.

Deliberately **no CardDeck tests** — #249 ships its own and would conflict.

## Test plan

- [x] `npx vitest run` — 100 files / 471 tests green (18 in the touched files)
- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --check` on the changed files — clean
- Note: `npm run lint:js` is argument-less `eslint` (v7), a no-op; running eslint on any `*.test.tsx` file (pre-existing ones included) fails with a parsing error because `tsconfig.json` excludes test files from the type-aware parser project — a pre-existing repo-wide limitation, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)