### PR TITLE
fix(a11y): give the M3RichTextEditor contenteditable an accessible name

### DIFF
--- a/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { M3RichTextEditor } from './M3RichTextEditor';
+
+describe('M3RichTextEditor accessibility', () => {
+    it('exposes the TipTap contenteditable as a textbox named after the card title', async () => {
+        render(<M3RichTextEditor title="Datenschutz" />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('textbox', { name: 'Datenschutz' })).toBeInTheDocument();
+        });
+    });
+
+    it('falls back to the default title as accessible name', async () => {
+        render(<M3RichTextEditor />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('textbox', { name: 'Impressum' })).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -367,12 +367,20 @@ export const M3RichTextEditor = ({
         ],
         content: value,
         editable: !readOnly,
+        // The ProseMirror contenteditable exposes role="textbox" (browser-only) but
+        // no accessible name (axe: aria-input-field-name, WCAG 4.1.2) — pin the role
+        // and label it with the card title.
+        editorProps: { attributes: { 'aria-label': title, role: 'textbox' } },
         onUpdate: ({ editor: e }) => onChange?.(e.isEmpty ? '' : e.getHTML()),
     });
 
     useEffect(() => {
         editor?.setEditable(!readOnly);
     }, [editor, readOnly]);
+
+    useEffect(() => {
+        editor?.setOptions({ editorProps: { attributes: { 'aria-label': title, role: 'textbox' } } });
+    }, [editor, title]);
 
     useEffect(() => {
         if (!editor) return;


### PR DESCRIPTION
## Why
The new Storybook a11y gate (#252) immediately flagged a **Serious** `aria-input-field-name` violation (WCAG 4.1.2) on both `M3RichTextEditor` stories: the TipTap/ProseMirror contenteditable exposes `role=textbox` in the browser but has no accessible name, so screen readers announce an unnamed input.

## What
- Label the editor via `editorProps: { attributes: { 'aria-label': title, role: 'textbox' } }` — the accessible name is derived from the card title prop (e.g. "Datenschutz", "Impressum")
- Keep the label in sync when the `title` prop changes (`editor.setOptions` effect)
- Pin `role=textbox` explicitly: ProseMirror only sets it in real browsers, so pinning makes jsdom match browser semantics and the name testable
- New `M3RichTextEditor.test.tsx`: asserts `getByRole('textbox', { name })` for both an explicit and the default title

## Verification
- Storybook (with #252's a11y config applied locally): **GDPR story 0 violations / 19 passes, Imprint story 0 violations / 19 passes** — previously 1 Serious violation each
- `npx vitest run src/components/FormPluginEditor`: 23/23 green
- `npx tsc --noEmit` clean; prettier + eslint (zero-warning gate) clean on the changed files

## Note
Only the internal-editor path is covered. In the `editorSlot` variant (LegalText cards) the slot brings its own TiptapEditor — if that one lacks a name too, it will surface once #252 is merged and can be fixed in the slot component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #265