### PR TITLE
feat(m3-editor): single-row toolbar + fullscreen as a real modal dialog (Figma 1-49824 / 1007-27636)

### DIFF
--- a/src/components/AdminSegmentedTabs/AdminSegmentedTabs.module.scss
+++ b/src/components/AdminSegmentedTabs/AdminSegmentedTabs.module.scss
@@ -73,16 +73,18 @@
     }
 }
 
+/* Selected segment uses the tenant-themeable M3 primary (Figma 1-49824:
+   dark red on the default ORISO scheme), not a hardcoded navy. */
 .itemActive,
 .itemActive:first-child,
 .itemActive:last-child {
-    background: #141c25;
+    background: var(--m3-primary, #141c25);
     border-radius: 38px;
-    color: #ffffff;
+    color: var(--m3-on-primary, #ffffff);
 
     &:hover {
-        background: #141c25;
-        color: #ffffff;
+        background: var(--m3-primary, #141c25);
+        color: var(--m3-on-primary, #ffffff);
     }
 }
 

--- a/src/components/AdminSegmentedTabs/AdminSegmentedTabs.stories.tsx
+++ b/src/components/AdminSegmentedTabs/AdminSegmentedTabs.stories.tsx
@@ -37,3 +37,18 @@ export const AppearanceActive: Story = {
         activeId: 'appearance',
     },
 };
+
+// The button row never wraps: on narrow containers it stays on one line and
+// scrolls horizontally (hidden scrollbar), per Figma 1-49824.
+export const NarrowOverflowScroll: Story = {
+    args: {
+        activeId: 'legal',
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: 375 }}>
+                <Story />
+            </div>
+        ),
+    ],
+};

--- a/src/components/AdminSegmentedTabs/AdminSegmentedTabs.stories.tsx
+++ b/src/components/AdminSegmentedTabs/AdminSegmentedTabs.stories.tsx
@@ -13,6 +13,10 @@ const meta = {
     component: AdminSegmentedTabs,
     parameters: {
         layout: 'padded',
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/design/QfsgojtHQzBjbzU3Im9Cet/Admin.ORISO?node-id=1-49824',
+        },
     },
     args: {
         ariaLabel: 'Einstellungen',

--- a/src/components/FormPluginEditor/M3RichTextEditor.module.scss
+++ b/src/components/FormPluginEditor/M3RichTextEditor.module.scss
@@ -25,12 +25,55 @@ $m3-state-active: rgba(39, 50, 112, 0.12);
     color: $m3-on-surface;
     font-family: 'Inter Variable', Inter, Arial, sans-serif;
 
-    &.maximized {
-        position: fixed;
-        inset: 24px;
-        z-index: 1100;
+    // Inside the fullscreen dialog (Figma 1007-27636) the card fills the
+    // viewport minus the scrim margins and the editor surface grows to fit.
+    &.inDialog {
+        height: calc(100vh - 128px);
         max-width: none;
-        height: auto;
+
+        .editorWrap {
+            display: flex;
+            min-height: 0;
+            flex: 1;
+            flex-direction: column;
+        }
+
+        .editor {
+            flex: 1;
+            overflow-y: auto;
+        }
+    }
+}
+
+// Fullscreen dialog layout: centered card + round close icon-button beside
+// the top right corner (Figma "Dialog": flex, gap 20px).
+.dialogLayout {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+}
+
+.dialogClose {
+    display: inline-flex;
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 0;
+    background: $m3-on-surface-variant;
+    border-radius: 50%;
+    color: #fff;
+    cursor: pointer;
+
+    &:hover {
+        background: $m3-on-surface;
+    }
+
+    &:focus-visible {
+        outline: 2px solid $m3-on-surface;
+        outline-offset: 2px;
     }
 }
 
@@ -108,17 +151,27 @@ $m3-state-active: rgba(39, 50, 112, 0.12);
     border: 0;
 }
 
-// Toolbar
+// Toolbar — a single row that scrolls horizontally instead of wrapping
+// (Figma 1-49824 / 1007-27636: the button row always stays on one line).
 .toolbar {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 4px;
     align-items: center;
     padding: 8px 16px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
 }
 
 .toolGroup {
     display: flex;
+    flex-shrink: 0;
     gap: 2px;
     align-items: center;
 }
@@ -126,6 +179,7 @@ $m3-state-active: rgba(39, 50, 112, 0.12);
 .vDivider {
     width: 1px;
     height: 24px;
+    flex-shrink: 0;
     margin: 0 4px;
     background: $m3-divider;
 }

--- a/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+// eslint-disable-next-line import/no-unresolved -- SB10 subpath export, invisible to the eslint import resolver
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { M3RichTextEditor } from './M3RichTextEditor';
 
 // MUI Material 3 "Tip Tap Editor Module" (Figma Admin.ORISO 1:34903).
@@ -56,5 +58,29 @@ export const GDPR: Story = {
         value: '',
         languages: [{ value: 'de', label: 'Deutsch' }],
         language: 'de',
+    },
+};
+
+// Fullscreen mode as a real modal dialog (Figma 1007-27636): white 80% scrim
+// with backdrop blur, centered card, round close button at the top right.
+export const FullscreenDialog: Story = {
+    render: (args) => <ControlledEditor {...args} />,
+    args: {
+        title: 'Auftragsdaten Verabeitungsvertrag',
+        placeholder: 'Fügen Sie hier den Auftragsverarbeitungsvertrag ein.',
+        value: '',
+        languages: [{ value: 'de', label: 'Deutsch' }],
+        language: 'de',
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await userEvent.click(canvas.getByRole('button', { name: /Fenster maximieren/i }));
+
+        // The antd Modal portals to document.body, outside the canvas element.
+        const body = within(canvasElement.ownerDocument.body);
+        await waitFor(() => {
+            expect(body.getByRole('dialog')).toBeInTheDocument();
+            expect(body.getByRole('button', { name: 'Vollbild schließen' })).toBeInTheDocument();
+        });
     },
 };

--- a/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
@@ -8,7 +8,13 @@ import { M3RichTextEditor } from './M3RichTextEditor';
 const meta = {
     title: 'Organisms/M3 Rich Text Editor',
     component: M3RichTextEditor,
-    parameters: { layout: 'centered' },
+    parameters: {
+        layout: 'centered',
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/design/QfsgojtHQzBjbzU3Im9Cet/Admin.ORISO?node-id=1-34903',
+        },
+    },
     // The red footer actions only render when handlers are wired — stub them so
     // the stories show the complete Figma design.
     args: {
@@ -65,6 +71,12 @@ export const GDPR: Story = {
 // with backdrop blur, centered card, round close button at the top right.
 export const FullscreenDialog: Story = {
     render: (args) => <ControlledEditor {...args} />,
+    parameters: {
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/design/QfsgojtHQzBjbzU3Im9Cet/Admin.ORISO?node-id=1007-27636',
+        },
+    },
     args: {
         title: 'Auftragsdaten Verabeitungsvertrag',
         placeholder: 'Fügen Sie hier den Auftragsverarbeitungsvertrag ein.',

--- a/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { M3RichTextEditor } from './M3RichTextEditor';
+
+describe('M3RichTextEditor accessibility', () => {
+    it('exposes the TipTap contenteditable as a textbox named after the card title', async () => {
+        render(<M3RichTextEditor title="Datenschutz" />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('textbox', { name: 'Datenschutz' })).toBeInTheDocument();
+        });
+    });
+
+    it('falls back to the default title as accessible name', async () => {
+        render(<M3RichTextEditor />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('textbox', { name: 'Impressum' })).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
@@ -1,6 +1,38 @@
 import { describe, expect, it } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { M3RichTextEditor } from './M3RichTextEditor';
+
+describe('M3RichTextEditor fullscreen dialog', () => {
+    it('opens a modal dialog on maximize and closes it via the close button', async () => {
+        const user = userEvent.setup();
+        render(<M3RichTextEditor title="Datenschutz" />);
+
+        await user.click(await screen.findByRole('button', { name: /legal\.m3Editor\.maximize/ }));
+
+        expect(await screen.findByRole('dialog')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: /legal\.m3Editor\.closeDialog/ }));
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    it('closes the dialog with Escape', async () => {
+        const user = userEvent.setup();
+        render(<M3RichTextEditor title="Datenschutz" />);
+
+        await user.click(await screen.findByRole('button', { name: /legal\.m3Editor\.maximize/ }));
+        const dialog = await screen.findByRole('dialog');
+
+        // jsdom leaves focus on <body>; antd listens on the modal wrap, so
+        // dispatch Escape on the dialog itself.
+        fireEvent.keyDown(dialog, { key: 'Escape', keyCode: 27 });
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+});
 
 describe('M3RichTextEditor accessibility', () => {
     it('exposes the TipTap contenteditable as a textbox named after the card title', async () => {

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -9,8 +9,9 @@ import Subscript from '@tiptap/extension-subscript';
 import Superscript from '@tiptap/extension-superscript';
 import TextAlign from '@tiptap/extension-text-align';
 import Placeholder from '@tiptap/extension-placeholder';
-import { Dropdown } from 'antd';
+import { Dropdown, Modal } from 'antd';
 import {
+    Close,
     Undo,
     Redo,
     Title,
@@ -396,8 +397,8 @@ export const M3RichTextEditor = ({
     const currentLang = languages.find((l) => l.value === language) ?? languages[0];
     const html = () => (editorSlot || editor.isEmpty ? '' : editor.getHTML());
 
-    return (
-        <div className={`${styles.module} ${maximized ? styles.maximized : ''}`} data-testid="m3-editor">
+    const card = (
+        <div className={`${styles.module} ${maximized ? styles.inDialog : ''}`} data-testid="m3-editor">
             <div className={styles.header}>
                 <IconComponent className={styles.headerIcon} />
                 <h2 className={styles.title}>{title}</h2>
@@ -497,6 +498,41 @@ export const M3RichTextEditor = ({
             {belowSlot}
         </div>
     );
+
+    // Fullscreen mode is a real modal dialog (Figma 1007-27636): white 80%
+    // scrim with backdrop blur, centered card, round close button beside the
+    // top right corner. antd Modal provides focus trap + Escape handling.
+    if (maximized) {
+        return (
+            <Modal
+                open
+                closable={false}
+                footer={null}
+                centered
+                width="min(1512px, calc(100vw - 96px))"
+                onCancel={() => setMaximized(false)}
+                styles={{
+                    mask: { background: 'rgba(255, 255, 255, 0.8)', backdropFilter: 'blur(4px)' },
+                    content: { padding: 0, background: 'transparent', boxShadow: 'none' },
+                }}
+                aria-label={title}
+            >
+                <div className={styles.dialogLayout}>
+                    {card}
+                    <button
+                        type="button"
+                        className={styles.dialogClose}
+                        aria-label={t('legal.m3Editor.closeDialog')}
+                        onClick={() => setMaximized(false)}
+                    >
+                        <Close />
+                    </button>
+                </div>
+            </Modal>
+        );
+    }
+
+    return card;
 };
 
 export default M3RichTextEditor;

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -367,12 +367,20 @@ export const M3RichTextEditor = ({
         ],
         content: value,
         editable: !readOnly,
+        // The ProseMirror contenteditable exposes role="textbox" (browser-only) but
+        // no accessible name (axe: aria-input-field-name, WCAG 4.1.2) — pin the role
+        // and label it with the card title.
+        editorProps: { attributes: { 'aria-label': title, role: 'textbox' } },
         onUpdate: ({ editor: e }) => onChange?.(e.isEmpty ? '' : e.getHTML()),
     });
 
     useEffect(() => {
         editor?.setEditable(!readOnly);
     }, [editor, readOnly]);
+
+    useEffect(() => {
+        editor?.setOptions({ editorProps: { attributes: { 'aria-label': title, role: 'textbox' } } });
+    }, [editor, title]);
 
     useEffect(() => {
         if (!editor) return;

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -588,6 +588,7 @@
     "tenants.legal.version.current": "(aktuell)",
     "legal.m3Editor.maximize": "Fenster maximieren",
     "legal.m3Editor.minimize": "Fenster verkleinern",
+    "legal.m3Editor.closeDialog": "Vollbild schließen",
     "legal.m3Editor.versionLabel": "Aktuelle Version",
     "legal.m3Editor.versionLatest": "Aktuelle Version (Entwurf)",
     "legal.m3Editor.versionPublished": "Veröffentlichte Version",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1014,6 +1014,7 @@
     "tenants.legal.version.current": "(current)",
     "legal.m3Editor.maximize": "Maximize window",
     "legal.m3Editor.minimize": "Minimize window",
+    "legal.m3Editor.closeDialog": "Close fullscreen",
     "legal.m3Editor.versionLabel": "Latest version",
     "legal.m3Editor.versionLatest": "Current version (draft)",
     "legal.m3Editor.versionPublished": "Published version",


### PR DESCRIPTION
> **Stacked on #253** — merge #253 first; until then this diff includes #253's commit.

## Why
Two deltas against the Figma design of the settings/legal section:
1. The editor toolbar (button row) wrapped onto two lines on narrow cards — the design (node 1-49824) keeps it on **one line**.
2. "Maximize window" only toggled a fixed-position CSS class — the design (node 1007-27636) specifies fullscreen as a **precomposed modal dialog**: white 80% scrim with backdrop blur, centered card, round close icon-button.

## What
- **Toolbar**: `flex-wrap: nowrap` + horizontal scroll with hidden scrollbar (`M3RichTextEditor.module.scss`); tool groups and dividers are `flex-shrink: 0`. The row never wraps, matching Figma.
- **Fullscreen dialog**: maximize now renders the card inside an antd `Modal` — mask `rgba(255,255,255,0.8)` + `backdrop-filter: blur(4px)`, centered, width `min(1512px, 100vw - 96px)`, card grows to `calc(100vh - 128px)` with the editor surface flexing. Round close button (40px, `aria-label`) beside the top-right corner; Escape + focus trap come from antd. New i18n key `legal.m3Editor.closeDialog` (de/en).
- **AdminSegmentedTabs** (the connected button group from node 1-49824): the selected segment now uses `var(--m3-primary)` / `var(--m3-on-primary)` instead of hardcoded navy `#141c25` — dark red on the default ORISO scheme and tenant-themeable, consistent with the antd M3 token bridge (#250). The single-line + horizontal-scroll behavior of this row already existed and is now covered by a story.
- **Stories**: `FullscreenDialog` (play function opens the modal and asserts the dialog + close button) and `NarrowOverflowScroll` (375px container shows the no-wrap horizontal scroll).
- **Tests**: modal opens on maximize, closes via close button and via Escape (jsdom note: Escape is dispatched on the dialog element since antd listens on the modal wrap).

## Verification
- `vitest`: 25/25 green across FormPluginEditor + AdminSegmentedTabs; `tsc --noEmit` clean; prettier + eslint zero-warning gate clean on changed files
- Storybook (real browser): toolbar computes `flex-wrap: nowrap`, `overflow-x: auto`, and is actually scrollable (scrollWidth 842 > clientWidth 800); opening maximize yields `role=dialog`, mask `rgba(255, 255, 255, 0.8)` with `blur(4px)`, and the labelled close button

## Notes for review
- The antd Modal element itself carries no accessible name (antd doesn't pass `aria-label` through); the axe WCAG 2.2 AA rule set from #252 does not flag this (`aria-dialog-name` is a best-practice rule). Can be revisited if we want it.
- Design source: Figma Admin.ORISO nodes `1-49824` (desktop default) and `1007-27636` (fullscreen dialog); specs read via Figma Dev Mode (connected button group: gap 2px, radius 48px; dialog: white 80% scrim + blur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #266