### PR TITLE
feat(m3-editor): standard anchor navigation (heading anchors + horizontal jump menu + link-to-anchor bubble)

### DIFF
--- a/src/components/AdminSegmentedTabs/AdminSegmentedTabs.module.scss
+++ b/src/components/AdminSegmentedTabs/AdminSegmentedTabs.module.scss
@@ -73,16 +73,18 @@
     }
 }
 
+/* Selected segment uses the tenant-themeable M3 primary (Figma 1-49824:
+   dark red on the default ORISO scheme), not a hardcoded navy. */
 .itemActive,
 .itemActive:first-child,
 .itemActive:last-child {
-    background: #141c25;
+    background: var(--m3-primary, #141c25);
     border-radius: 38px;
-    color: #ffffff;
+    color: var(--m3-on-primary, #ffffff);
 
     &:hover {
-        background: #141c25;
-        color: #ffffff;
+        background: var(--m3-primary, #141c25);
+        color: var(--m3-on-primary, #ffffff);
     }
 }
 

--- a/src/components/AdminSegmentedTabs/AdminSegmentedTabs.stories.tsx
+++ b/src/components/AdminSegmentedTabs/AdminSegmentedTabs.stories.tsx
@@ -37,3 +37,18 @@ export const AppearanceActive: Story = {
         activeId: 'appearance',
     },
 };
+
+// The button row never wraps: on narrow containers it stays on one line and
+// scrolls horizontally (hidden scrollbar), per Figma 1-49824.
+export const NarrowOverflowScroll: Story = {
+    args: {
+        activeId: 'legal',
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: 375 }}>
+                <Story />
+            </div>
+        ),
+    ],
+};

--- a/src/components/AdminSegmentedTabs/AdminSegmentedTabs.stories.tsx
+++ b/src/components/AdminSegmentedTabs/AdminSegmentedTabs.stories.tsx
@@ -13,6 +13,10 @@ const meta = {
     component: AdminSegmentedTabs,
     parameters: {
         layout: 'padded',
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/design/QfsgojtHQzBjbzU3Im9Cet/Admin.ORISO?node-id=1-49824',
+        },
     },
     args: {
         ariaLabel: 'Einstellungen',

--- a/src/components/FormPluginEditor/AnchorChips.tsx
+++ b/src/components/FormPluginEditor/AnchorChips.tsx
@@ -11,6 +11,8 @@ export type AnchorChipsProps = {
     onSelect: (anchorId: string) => void;
     onRemove?: (anchorId: string) => void;
     ariaLabel?: string;
+    /** Extra class for host-specific styling (e.g. the M3 editor's module class). */
+    className?: string;
 };
 
 // Horizontal, scrollable row of anchor chips rendered above the editor
@@ -22,11 +24,16 @@ const AnchorChips = ({
     onSelect,
     onRemove,
     ariaLabel,
+    className,
 }: AnchorChipsProps) => {
     if (!anchors.length) return null;
 
     return (
-        <div className="RichEditor-anchorNav" role="navigation" aria-label={ariaLabel}>
+        <div
+            className={className ? `RichEditor-anchorNav ${className}` : 'RichEditor-anchorNav'}
+            role="navigation"
+            aria-label={ariaLabel}
+        >
             {anchors.map((anchor) => {
                 const active = anchor.id === activeId;
                 return (

--- a/src/components/FormPluginEditor/M3RichTextEditor.anchors.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.anchors.test.tsx
@@ -1,0 +1,169 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { M3RichTextEditor } from './M3RichTextEditor';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}));
+
+const scrollIntoViewMock = vi.fn();
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })),
+    });
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+});
+
+const content =
+    '<h2 id="intro">Intro</h2><p>Hello <a href="#details">jump to details</a></p>' +
+    '<h2 id="details">Details</h2><p>World</p>';
+
+const chipSelector = '[data-anchor-chip]';
+
+describe('M3RichTextEditor — anchor navigation (edit mode, default ON)', () => {
+    it('renders a horizontal chip row with one removable chip per anchored heading', async () => {
+        const { container } = render(<M3RichTextEditor value={content} />);
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(2));
+        expect(screen.getByRole('navigation', { name: 'Section anchors' })).toBeInTheDocument();
+        expect(container.querySelectorAll('.RichEditor-anchorNav .ant-tag-close-icon')).toHaveLength(2);
+    });
+
+    it('scrolls the heading into view when a chip is clicked', async () => {
+        scrollIntoViewMock.mockClear();
+        const { container } = render(<M3RichTextEditor value={content} />);
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(2));
+        fireEvent.click(container.querySelector('[data-anchor-chip="details"]')!);
+        expect(scrollIntoViewMock).toHaveBeenCalled();
+    });
+
+    it('removes an anchor via the chip "x" and strips the id from the emitted HTML', async () => {
+        const onChange = vi.fn();
+        const { container } = render(<M3RichTextEditor value={content} onChange={onChange} />);
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(2));
+
+        fireEvent.click(container.querySelector('[data-anchor-chip="intro"] .ant-tag-close-icon')!);
+
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(1));
+        const lastHtml = onChange.mock.calls[onChange.mock.calls.length - 1][0] as string;
+        expect(lastHtml).not.toContain('id="intro"');
+        expect(lastHtml).toContain('data-anchor-removed="true"');
+        expect(lastHtml).toContain('id="details"');
+    });
+
+    it('stamps readable slug ids onto legacy content and emits them via onChange (data contract)', async () => {
+        const onChange = vi.fn();
+        const { container } = render(
+            <M3RichTextEditor value="<h2>Geltungsbereich</h2><p>Text</p>" onChange={onChange} />,
+        );
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(1));
+        await waitFor(() => expect(onChange).toHaveBeenCalled());
+        const lastHtml = onChange.mock.calls[onChange.mock.calls.length - 1][0] as string;
+        expect(lastHtml).toContain('id="geltungsbereich"');
+    });
+
+    it('keeps duplicate heading texts unique with a numeric suffix', async () => {
+        const onChange = vi.fn();
+        const { container } = render(
+            <M3RichTextEditor value="<h2>Kapitel</h2><p>a</p><h2>Kapitel</h2><p>b</p>" onChange={onChange} />,
+        );
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(2));
+        const ids = [...container.querySelectorAll(chipSelector)].map((el) => el.getAttribute('data-anchor-chip'));
+        expect(ids).toEqual(['kapitel', 'kapitel-2']);
+    });
+
+    it('renders no chip row for content without headings (empty state)', async () => {
+        const { container } = render(<M3RichTextEditor value="<p>Nur Fließtext.</p>" />);
+        await waitFor(() => expect(container.querySelector('[data-testid="m3-editor"] p')).toBeTruthy());
+        expect(container.querySelector(chipSelector)).toBeNull();
+    });
+
+    it('renders no chip row when anchors are disabled via prop', async () => {
+        const { container } = render(<M3RichTextEditor value={content} enableAnchors={false} />);
+        await waitFor(() => expect(container.querySelector('[data-testid="m3-editor"] h2')).toBeTruthy());
+        expect(container.querySelector(chipSelector)).toBeNull();
+    });
+
+    it('renders no internal chip row when an editorSlot owns the content', async () => {
+        const { container } = render(<M3RichTextEditor value={content} editorSlot={<div>slot editor</div>} />);
+        await screen.findByText('slot editor');
+        expect(container.querySelector(chipSelector)).toBeNull();
+    });
+});
+
+describe('M3RichTextEditor — anchor navigation (read-only)', () => {
+    it('shows chips without "x" and marks the clicked chip with a checkmark', async () => {
+        const { container } = render(<M3RichTextEditor value={content} readOnly />);
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(2));
+        expect(container.querySelectorAll('.ant-tag-close-icon')).toHaveLength(0);
+
+        fireEvent.click(container.querySelector('[data-anchor-chip="details"]')!);
+
+        await waitFor(() =>
+            expect(container.querySelector('[data-anchor-chip="details"] .anticon-check')).toBeTruthy(),
+        );
+    });
+
+    it('does not invent anchors for headings without ids (content stays untouched)', async () => {
+        const { container } = render(<M3RichTextEditor value="<h2>Ohne Anker</h2><p>Text</p>" readOnly />);
+        await waitFor(() => expect(container.querySelector('[data-testid="m3-editor"] h2')).toBeTruthy());
+        expect(container.querySelector(chipSelector)).toBeNull();
+    });
+
+    it('intercepts in-text #anchor links: scrolls instead of navigating', async () => {
+        scrollIntoViewMock.mockClear();
+        const { container } = render(<M3RichTextEditor value={content} readOnly />);
+        await waitFor(() =>
+            expect(container.querySelector('[data-testid="m3-editor"] a[href="#details"]')).toBeTruthy(),
+        );
+
+        fireEvent.click(container.querySelector('[data-testid="m3-editor"] a[href="#details"]')!);
+
+        expect(scrollIntoViewMock).toHaveBeenCalled();
+    });
+});
+
+describe('M3RichTextEditor — anchor HTML round-trip (contract)', () => {
+    it('re-rendering emitted HTML yields the same anchors (ids survive the value/getHTML round-trip)', async () => {
+        const onChange = vi.fn();
+        const first = render(<M3RichTextEditor value="<h2>Geltungsbereich</h2><p>Text</p>" onChange={onChange} />);
+        await waitFor(() => expect(onChange).toHaveBeenCalled());
+        const emitted = onChange.mock.calls[onChange.mock.calls.length - 1][0] as string;
+        first.unmount();
+
+        const { container } = render(<M3RichTextEditor value={emitted} readOnly />);
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(1));
+        expect(container.querySelector('[data-anchor-chip="geltungsbereich"]')).toBeTruthy();
+    });
+
+    it('a removed anchor stays removed after the round-trip (no re-assignment)', async () => {
+        const removedHtml =
+            '<h2 data-anchor-removed="true">Intro</h2><p>Hello</p><h2 id="details">Details</h2><p>World</p>';
+        const { container } = render(<M3RichTextEditor value={removedHtml} />);
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(1));
+        expect(container.querySelector('[data-anchor-chip="details"]')).toBeTruthy();
+        expect(container.querySelector('[data-anchor-chip="intro"]')).toBeNull();
+    });
+});
+
+describe('M3RichTextEditor — anchors inside the fullscreen dialog', () => {
+    it('keeps the anchor row available when maximized into the modal', async () => {
+        const { container } = render(<M3RichTextEditor value={content} />);
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(2));
+
+        fireEvent.click(screen.getByRole('button', { name: /legal\.m3Editor\.maximize/ }));
+
+        const dialog = await screen.findByRole('dialog');
+        await waitFor(() => expect(dialog.querySelectorAll(chipSelector)).toHaveLength(2));
+    });
+});

--- a/src/components/FormPluginEditor/M3RichTextEditor.module.scss
+++ b/src/components/FormPluginEditor/M3RichTextEditor.module.scss
@@ -25,12 +25,55 @@ $m3-state-active: rgba(39, 50, 112, 0.12);
     color: $m3-on-surface;
     font-family: 'Inter Variable', Inter, Arial, sans-serif;
 
-    &.maximized {
-        position: fixed;
-        inset: 24px;
-        z-index: 1100;
+    // Inside the fullscreen dialog (Figma 1007-27636) the card fills the
+    // viewport minus the scrim margins and the editor surface grows to fit.
+    &.inDialog {
+        height: calc(100vh - 128px);
         max-width: none;
-        height: auto;
+
+        .editorWrap {
+            display: flex;
+            min-height: 0;
+            flex: 1;
+            flex-direction: column;
+        }
+
+        .editor {
+            flex: 1;
+            overflow-y: auto;
+        }
+    }
+}
+
+// Fullscreen dialog layout: centered card + round close icon-button beside
+// the top right corner (Figma "Dialog": flex, gap 20px).
+.dialogLayout {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+}
+
+.dialogClose {
+    display: inline-flex;
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 0;
+    background: $m3-on-surface-variant;
+    border-radius: 50%;
+    color: #fff;
+    cursor: pointer;
+
+    &:hover {
+        background: $m3-on-surface;
+    }
+
+    &:focus-visible {
+        outline: 2px solid $m3-on-surface;
+        outline-offset: 2px;
     }
 }
 
@@ -108,17 +151,27 @@ $m3-state-active: rgba(39, 50, 112, 0.12);
     border: 0;
 }
 
-// Toolbar
+// Toolbar — a single row that scrolls horizontally instead of wrapping
+// (Figma 1-49824 / 1007-27636: the button row always stays on one line).
 .toolbar {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 4px;
     align-items: center;
     padding: 8px 16px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
 }
 
 .toolGroup {
     display: flex;
+    flex-shrink: 0;
     gap: 2px;
     align-items: center;
 }
@@ -126,6 +179,7 @@ $m3-state-active: rgba(39, 50, 112, 0.12);
 .vDivider {
     width: 1px;
     height: 24px;
+    flex-shrink: 0;
     margin: 0 4px;
     background: $m3-divider;
 }

--- a/src/components/FormPluginEditor/M3RichTextEditor.module.scss
+++ b/src/components/FormPluginEditor/M3RichTextEditor.module.scss
@@ -246,6 +246,43 @@ $m3-state-active: rgba(39, 50, 112, 0.12);
 }
 
 // Editor surface
+// Anchor navigation — horizontal chip row above the editor surface. Same
+// single-line + hidden-scrollbar pattern as the toolbar; base layout comes
+// from the global .RichEditor-anchorNav rules, this only adds M3 chrome.
+.anchorNav {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 4px;
+    align-items: center;
+    padding: 0 16px 8px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+
+    :global(.ant-tag) {
+        margin-inline-end: 0;
+        flex: 0 0 auto;
+        cursor: pointer;
+    }
+}
+
+.anchorBubbleHost {
+    display: contents;
+}
+
+.anchorBubble {
+    padding: 4px;
+    background: #fff;
+    border: 1px solid $m3-outline-variant;
+    border-radius: 10px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
 .editorWrap {
     padding: 0 16px;
 }

--- a/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
@@ -67,6 +67,76 @@ export const GDPR: Story = {
     },
 };
 
+const anchoredContent =
+    '<h2>Geltungsbereich</h2><p>Dieser Vertrag regelt die Auftragsverarbeitung. ' +
+    'Siehe auch den Abschnitt <a href="#pflichten-des-auftragnehmers">Pflichten</a>.</p>' +
+    '<h2>Pflichten des Auftragnehmers</h2><p>Weisungsbindung, Vertraulichkeit, TOMs.</p>' +
+    '<h2>Unterauftragsverhältnisse</h2><p>Nur mit vorheriger Genehmigung.</p>';
+
+// Standard anchor navigation: headings get persistent ids, the horizontal
+// chip row above the editor jumps to them, selected text can be linked to an
+// anchor via the bubble menu.
+export const WithAnchorNavigation: Story = {
+    render: (args) => <ControlledEditor {...args} />,
+    args: {
+        title: 'Auftragsdaten Verabeitungsvertrag',
+        value: anchoredContent,
+        languages: [{ value: 'de', label: 'Deutsch' }],
+        language: 'de',
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await waitFor(() => {
+            expect(canvas.getByRole('navigation')).toBeInTheDocument();
+            expect(canvas.getAllByText('Geltungsbereich').length).toBeGreaterThan(0);
+        });
+    },
+};
+
+// Narrow container: the anchor chip row stays on ONE line and scrolls
+// horizontally, same pattern as the toolbar and the segmented tabs.
+export const AnchorRowNarrowOverflow: Story = {
+    render: (args) => <ControlledEditor {...args} />,
+    args: {
+        title: 'Datenschutz',
+        value: anchoredContent,
+        languages: [{ value: 'de', label: 'Deutsch' }],
+        language: 'de',
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: 375 }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+// Read-only: chips have no "x", clicking one marks it with a checkmark, and
+// in-text #anchor links scroll inside the card instead of navigating.
+export const ReadOnlyWithAnchors: Story = {
+    render: (args) => <ControlledEditor {...args} />,
+    args: {
+        title: 'Auftragsdaten Verabeitungsvertrag',
+        value: anchoredContent,
+        readOnly: true,
+        languages: [{ value: 'de', label: 'Deutsch' }],
+        language: 'de',
+    },
+};
+
+// Opt-out state: no anchor row, headings stay untouched.
+export const AnchorsDisabled: Story = {
+    render: (args) => <ControlledEditor {...args} />,
+    args: {
+        title: 'Impressum',
+        value: anchoredContent,
+        enableAnchors: false,
+        languages: [{ value: 'de', label: 'Deutsch' }],
+        language: 'de',
+    },
+};
+
 // Fullscreen mode as a real modal dialog (Figma 1007-27636): white 80% scrim
 // with backdrop blur, centered card, round close button at the top right.
 export const FullscreenDialog: Story = {

--- a/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+// eslint-disable-next-line import/no-unresolved -- SB10 subpath export, invisible to the eslint import resolver
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { M3RichTextEditor } from './M3RichTextEditor';
 
 // MUI Material 3 "Tip Tap Editor Module" (Figma Admin.ORISO 1:34903).
@@ -56,5 +58,29 @@ export const GDPR: Story = {
         value: '',
         languages: [{ value: 'de', label: 'Deutsch' }],
         language: 'de',
+    },
+};
+
+// Fullscreen mode as a real modal dialog (Figma 1007-27636): white 80% scrim
+// with backdrop blur, centered card, round close button at the top right.
+export const FullscreenDialog: Story = {
+    render: (args) => <ControlledEditor {...args} />,
+    args: {
+        title: 'Auftragsdaten Verabeitungsvertrag',
+        placeholder: 'Fügen Sie hier den Auftragsverarbeitungsvertrag ein.',
+        value: '',
+        languages: [{ value: 'de', label: 'Deutsch' }],
+        language: 'de',
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await userEvent.click(canvas.getByRole('button', { name: /Fenster maximieren/i }));
+
+        // The antd Modal portals to document.body, outside the canvas element.
+        const body = within(canvasElement.ownerDocument.body);
+        await waitFor(() => {
+            expect(body.getByRole('dialog')).toBeInTheDocument();
+            expect(body.getByRole('button', { name: 'Vollbild schließen' })).toBeInTheDocument();
+        });
     },
 };

--- a/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
@@ -8,7 +8,13 @@ import { M3RichTextEditor } from './M3RichTextEditor';
 const meta = {
     title: 'Organisms/M3 Rich Text Editor',
     component: M3RichTextEditor,
-    parameters: { layout: 'centered' },
+    parameters: {
+        layout: 'centered',
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/design/QfsgojtHQzBjbzU3Im9Cet/Admin.ORISO?node-id=1-34903',
+        },
+    },
     // The red footer actions only render when handlers are wired — stub them so
     // the stories show the complete Figma design.
     args: {
@@ -65,6 +71,12 @@ export const GDPR: Story = {
 // with backdrop blur, centered card, round close button at the top right.
 export const FullscreenDialog: Story = {
     render: (args) => <ControlledEditor {...args} />,
+    parameters: {
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/design/QfsgojtHQzBjbzU3Im9Cet/Admin.ORISO?node-id=1007-27636',
+        },
+    },
     args: {
         title: 'Auftragsdaten Verabeitungsvertrag',
         placeholder: 'Fügen Sie hier den Auftragsverarbeitungsvertrag ein.',

--- a/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { M3RichTextEditor } from './M3RichTextEditor';
+
+describe('M3RichTextEditor accessibility', () => {
+    it('exposes the TipTap contenteditable as a textbox named after the card title', async () => {
+        render(<M3RichTextEditor title="Datenschutz" />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('textbox', { name: 'Datenschutz' })).toBeInTheDocument();
+        });
+    });
+
+    it('falls back to the default title as accessible name', async () => {
+        render(<M3RichTextEditor />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('textbox', { name: 'Impressum' })).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
@@ -1,6 +1,38 @@
 import { describe, expect, it } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { M3RichTextEditor } from './M3RichTextEditor';
+
+describe('M3RichTextEditor fullscreen dialog', () => {
+    it('opens a modal dialog on maximize and closes it via the close button', async () => {
+        const user = userEvent.setup();
+        render(<M3RichTextEditor title="Datenschutz" />);
+
+        await user.click(await screen.findByRole('button', { name: /legal\.m3Editor\.maximize/ }));
+
+        expect(await screen.findByRole('dialog')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: /legal\.m3Editor\.closeDialog/ }));
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    it('closes the dialog with Escape', async () => {
+        const user = userEvent.setup();
+        render(<M3RichTextEditor title="Datenschutz" />);
+
+        await user.click(await screen.findByRole('button', { name: /legal\.m3Editor\.maximize/ }));
+        const dialog = await screen.findByRole('dialog');
+
+        // jsdom leaves focus on <body>; antd listens on the modal wrap, so
+        // dispatch Escape on the dialog itself.
+        fireEvent.keyDown(dialog, { key: 'Escape', keyCode: 27 });
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+});
 
 describe('M3RichTextEditor accessibility', () => {
     it('exposes the TipTap contenteditable as a textbox named after the card title', async () => {

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useEditor, EditorContent, Editor } from '@tiptap/react';
+import { useEditor, EditorContent, Editor, BubbleMenu } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Link from '@tiptap/extension-link';
@@ -9,7 +9,7 @@ import Subscript from '@tiptap/extension-subscript';
 import Superscript from '@tiptap/extension-superscript';
 import TextAlign from '@tiptap/extension-text-align';
 import Placeholder from '@tiptap/extension-placeholder';
-import { Dropdown, Modal } from 'antd';
+import { Dropdown, Modal, Select } from 'antd';
 import {
     Close,
     Undo,
@@ -42,6 +42,9 @@ import {
     Fingerprint,
 } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
+import { HeadingAnchors } from './headingAnchors';
+import AnchorChips from './AnchorChips';
+import { useHeadingAnchorNav } from './useHeadingAnchorNav';
 import styles from './M3RichTextEditor.module.scss';
 
 export type M3RichTextEditorProps = {
@@ -71,6 +74,14 @@ export type M3RichTextEditorProps = {
     editorSlot?: React.ReactNode;
     /** Rendered below the action footer (e.g. version history, modals). */
     belowSlot?: React.ReactNode;
+    /**
+     * Anchor navigation (standard, ON by default): headings get persistent
+     * `id`s, a horizontal chip row above the editor jumps to them, and
+     * selected text can be linked to an anchor via the bubble menu. Only
+     * applies to the built-in editor (an `editorSlot` owns its own anchors).
+     * Must not change during the editor's lifetime.
+     */
+    enableAnchors?: boolean;
     onPublish?: (html: string) => void;
     onSaveDraft?: (html: string) => void;
 };
@@ -348,11 +359,15 @@ export const M3RichTextEditor = ({
     aboveEditorSlot,
     editorSlot,
     belowSlot,
+    enableAnchors = true,
     onPublish,
     onSaveDraft,
 }: M3RichTextEditorProps) => {
     const { t } = useTranslation();
     const [maximized, setMaximized] = useState(false);
+    // Anchors only make sense for the built-in editor; an editorSlot brings
+    // its own TiptapEditor with its own anchor row.
+    const anchorsEnabled = enableAnchors && !editorSlot;
 
     const editor = useEditor({
         extensions: [
@@ -365,6 +380,7 @@ export const M3RichTextEditor = ({
             Superscript,
             TextAlign.configure({ types: ['heading', 'paragraph'] }),
             Placeholder.configure({ placeholder }),
+            ...(anchorsEnabled ? [HeadingAnchors] : []),
         ],
         content: value,
         editable: !readOnly,
@@ -382,6 +398,10 @@ export const M3RichTextEditor = ({
     useEffect(() => {
         editor?.setOptions({ editorProps: { attributes: { 'aria-label': title, role: 'textbox' } } });
     }, [editor, title]);
+
+    // Shared anchor-navigation behavior — same hook as the form-bound TiptapEditor.
+    const { anchors, anchorsRef, activeAnchorId, scrollToAnchor, removeAnchor, handleContentClickCapture } =
+        useHeadingAnchorNav(editor, { enabled: anchorsEnabled, editable: !readOnly });
 
     useEffect(() => {
         if (!editor) return;
@@ -433,11 +453,58 @@ export const M3RichTextEditor = ({
 
             {aboveEditorSlot}
 
+            {anchorsEnabled && (
+                <AnchorChips
+                    className={styles.anchorNav}
+                    anchors={anchors}
+                    activeId={activeAnchorId}
+                    editable={!readOnly}
+                    onSelect={scrollToAnchor}
+                    onRemove={removeAnchor}
+                    ariaLabel={t('editor.plugin.anchor.nav.label', 'Section anchors')}
+                />
+            )}
+
             {editorSlot ?? (
-                <div className={styles.editorWrap}>
+                <div className={styles.editorWrap} onClickCapture={handleContentClickCapture}>
                     <div className={styles.editor}>
                         <EditorContent editor={editor} />
                     </div>
+                </div>
+            )}
+
+            {anchorsEnabled && !readOnly && (
+                // Stable host div: the BubbleMenu plugin detaches its element
+                // from the React tree (tippy re-parents it), so it must not be
+                // a direct sibling that React repositions or removes.
+                <div className={styles.anchorBubbleHost}>
+                    <BubbleMenu
+                        editor={editor}
+                        pluginKey="anchorLinkBubble"
+                        updateDelay={150}
+                        tippyOptions={{ placement: 'top', maxWidth: 'none' }}
+                        shouldShow={({ state }) => !state.selection.empty && anchorsRef.current.length > 0}
+                    >
+                        <div className={styles.anchorBubble}>
+                            <Select
+                                size="small"
+                                placeholder={t('editor.plugin.anchor.link.placeholder', 'Link to section')}
+                                value={null}
+                                popupMatchSelectWidth={false}
+                                style={{ minWidth: 180 }}
+                                options={anchors.map((anchor) => ({ value: anchor.id, label: anchor.text }))}
+                                getPopupContainer={(trigger) => trigger.parentElement || document.body}
+                                onSelect={(anchorId: string) =>
+                                    editor
+                                        .chain()
+                                        .focus()
+                                        .extendMarkRange('link')
+                                        .setLink({ href: `#${anchorId}` })
+                                        .run()
+                                }
+                            />
+                        </div>
+                    </BubbleMenu>
                 </div>
             )}
 

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -9,8 +9,9 @@ import Subscript from '@tiptap/extension-subscript';
 import Superscript from '@tiptap/extension-superscript';
 import TextAlign from '@tiptap/extension-text-align';
 import Placeholder from '@tiptap/extension-placeholder';
-import { Dropdown } from 'antd';
+import { Dropdown, Modal } from 'antd';
 import {
+    Close,
     Undo,
     Redo,
     Title,
@@ -396,8 +397,8 @@ export const M3RichTextEditor = ({
     const currentLang = languages.find((l) => l.value === language) ?? languages[0];
     const html = () => (editorSlot || editor.isEmpty ? '' : editor.getHTML());
 
-    return (
-        <div className={`${styles.module} ${maximized ? styles.maximized : ''}`} data-testid="m3-editor">
+    const card = (
+        <div className={`${styles.module} ${maximized ? styles.inDialog : ''}`} data-testid="m3-editor">
             <div className={styles.header}>
                 <IconComponent className={styles.headerIcon} />
                 <h2 className={styles.title}>{title}</h2>
@@ -497,6 +498,41 @@ export const M3RichTextEditor = ({
             {belowSlot}
         </div>
     );
+
+    // Fullscreen mode is a real modal dialog (Figma 1007-27636): white 80%
+    // scrim with backdrop blur, centered card, round close button beside the
+    // top right corner. antd Modal provides focus trap + Escape handling.
+    if (maximized) {
+        return (
+            <Modal
+                open
+                closable={false}
+                footer={null}
+                centered
+                width="min(1512px, calc(100vw - 96px))"
+                onCancel={() => setMaximized(false)}
+                styles={{
+                    mask: { background: 'rgba(255, 255, 255, 0.8)', backdropFilter: 'blur(4px)' },
+                    content: { padding: 0, background: 'transparent', boxShadow: 'none' },
+                }}
+                aria-label={title}
+            >
+                <div className={styles.dialogLayout}>
+                    {card}
+                    <button
+                        type="button"
+                        className={styles.dialogClose}
+                        aria-label={t('legal.m3Editor.closeDialog')}
+                        onClick={() => setMaximized(false)}
+                    >
+                        <Close />
+                    </button>
+                </div>
+            </Modal>
+        );
+    }
+
+    return card;
 };
 
 export default M3RichTextEditor;

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -367,12 +367,20 @@ export const M3RichTextEditor = ({
         ],
         content: value,
         editable: !readOnly,
+        // The ProseMirror contenteditable exposes role="textbox" (browser-only) but
+        // no accessible name (axe: aria-input-field-name, WCAG 4.1.2) — pin the role
+        // and label it with the card title.
+        editorProps: { attributes: { 'aria-label': title, role: 'textbox' } },
         onUpdate: ({ editor: e }) => onChange?.(e.isEmpty ? '' : e.getHTML()),
     });
 
     useEffect(() => {
         editor?.setEditable(!readOnly);
     }, [editor, readOnly]);
+
+    useEffect(() => {
+        editor?.setOptions({ editorProps: { attributes: { 'aria-label': title, role: 'textbox' } } });
+    }, [editor, title]);
 
     useEffect(() => {
         if (!editor) return;

--- a/src/components/FormPluginEditor/TiptapEditor.tsx
+++ b/src/components/FormPluginEditor/TiptapEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useEditor, EditorContent, Editor, BubbleMenu } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
@@ -16,8 +16,9 @@ import {
 } from '@mui/icons-material';
 import { Button, ConfigProvider, Select } from 'antd';
 import { useTranslation } from 'react-i18next';
-import { HeadingAnchors, HeadingAnchor, collectAnchors } from './headingAnchors';
+import { HeadingAnchors } from './headingAnchors';
 import AnchorChips from './AnchorChips';
+import { useHeadingAnchorNav } from './useHeadingAnchorNav';
 
 // TipTap replacement for the former draft-js editor. Same data contract:
 // `value` is an HTML string in, `onChange` emits an HTML string out. Template
@@ -43,9 +44,6 @@ export type TiptapEditorProps = {
 };
 
 const isEmptyHtml = (html: string) => html === '' || html === '<p></p>';
-
-const escapeCssId = (id: string) =>
-    typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(id) : id.replace(/["\\]/g, '\\$&');
 
 const ToolbarButton = ({
     active,
@@ -216,13 +214,6 @@ const TiptapEditor = ({
     const placeholderRef = useRef(placeholder);
     placeholderRef.current = placeholder;
 
-    const [anchors, setAnchors] = useState<HeadingAnchor[]>([]);
-    const [activeAnchorId, setActiveAnchorId] = useState<string | null>(null);
-    // BubbleMenu's shouldShow is registered once, so it reads the current
-    // anchor list through this ref.
-    const anchorsRef = useRef(anchors);
-    anchorsRef.current = anchors;
-
     const editor = useEditor({
         extensions: [
             StarterKit,
@@ -263,73 +254,10 @@ const TiptapEditor = ({
         if (editor) editor.view.dispatch(editor.state.tr);
     }, [placeholder, editor]);
 
-    // Anchors: stamp ids onto legacy content when editable (persisted via the
-    // form's onChange on save) and keep the chip list in sync with the doc.
-    // The 'transaction' event also covers external setContent calls, which do
-    // not emit 'update'.
-    useEffect(() => {
-        if (!editor || !enableAnchors) return undefined;
-        if (editor.isEditable) editor.commands.ensureHeadingAnchors();
-        const refresh = () => setAnchors(collectAnchors(editor.state.doc));
-        refresh();
-        editor.on('transaction', refresh);
-        return () => {
-            editor.off('transaction', refresh);
-        };
-    }, [editor, enableAnchors, disabled]);
-
-    // Read-only scroll spy: mark the anchor whose heading is currently at the
-    // top of the (scrolled) editor content as active.
-    useEffect(() => {
-        if (!editor || !enableAnchors || !disabled) return undefined;
-        let frame = 0;
-        const onScroll = () => {
-            if (frame) return;
-            frame = window.requestAnimationFrame(() => {
-                frame = 0;
-                const root = editor.view.dom as HTMLElement;
-                const rootTop = root.getBoundingClientRect().top;
-                let current: string | null = null;
-                anchorsRef.current.forEach((anchor) => {
-                    const el = root.querySelector(`[id="${escapeCssId(anchor.id)}"]`);
-                    if (el && el.getBoundingClientRect().top - rootTop <= 32) current = anchor.id;
-                });
-                if (current) setActiveAnchorId(current);
-            });
-        };
-        document.addEventListener('scroll', onScroll, { capture: true, passive: true });
-        return () => {
-            document.removeEventListener('scroll', onScroll, true);
-            if (frame) window.cancelAnimationFrame(frame);
-        };
-    }, [editor, enableAnchors, disabled]);
-
-    const scrollToAnchor = (anchorId: string) => {
-        if (!editor) return;
-        const target = editor.view.dom.querySelector(`[id="${escapeCssId(anchorId)}"]`);
-        // Instant (non-smooth) scrolling: smooth programmatic scrolling is a
-        // silent no-op in several embedded/headless browsers.
-        target?.scrollIntoView({ block: 'start' });
-        setActiveAnchorId(anchorId);
-    };
-
-    const removeAnchor = (anchorId: string) => {
-        if (!editor) return;
-        editor.commands.removeHeadingAnchor(anchorId);
-        if (activeAnchorId === anchorId) setActiveAnchorId(null);
-    };
-
-    // In the read-only viewer, clicking an in-text `#anchor` link scrolls to
-    // the heading inside the editor instead of navigating the window.
-    const handleContentClickCapture = (event: React.MouseEvent) => {
-        if (!enableAnchors || !disabled) return;
-        const element = event.target as HTMLElement;
-        const link = element.closest?.('a[href^="#"]');
-        if (!link) return;
-        event.preventDefault();
-        event.stopPropagation();
-        scrollToAnchor((link.getAttribute('href') || '').slice(1));
-    };
+    // Shared anchor-navigation behavior (chips, scroll spy, jump/remove,
+    // read-only link-click capture) — same hook as the M3RichTextEditor.
+    const { anchors, anchorsRef, activeAnchorId, scrollToAnchor, removeAnchor, handleContentClickCapture } =
+        useHeadingAnchorNav(editor, { enabled: enableAnchors, editable: !disabled });
 
     if (!editor) return null;
 

--- a/src/components/FormPluginEditor/useHeadingAnchorNav.ts
+++ b/src/components/FormPluginEditor/useHeadingAnchorNav.ts
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from 'react';
+import type { Editor } from '@tiptap/react';
+import { collectAnchors, HeadingAnchor } from './headingAnchors';
+
+// CSS.escape is not available in every embedded browser we target.
+export const escapeCssId = (id: string) =>
+    typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(id) : id.replace(/["\\]/g, '\\$&');
+
+export type HeadingAnchorNav = {
+    /** Current anchor list (source for the chip row). */
+    anchors: HeadingAnchor[];
+    /** Same list through a ref, for callbacks registered once (BubbleMenu shouldShow). */
+    anchorsRef: React.MutableRefObject<HeadingAnchor[]>;
+    /** The anchor last jumped to / currently at the top while scrolling read-only. */
+    activeAnchorId: string | null;
+    scrollToAnchor: (anchorId: string) => void;
+    removeAnchor: (anchorId: string) => void;
+    /** Read-only mode: capture clicks on in-text `#anchor` links and scroll instead of navigating. */
+    handleContentClickCapture: (event: React.MouseEvent) => void;
+};
+
+/**
+ * Shared anchor-navigation behavior for both TipTap editors (form-bound
+ * TiptapEditor and the standalone M3RichTextEditor): keeps the anchor list in
+ * sync with the document, stamps ids onto legacy content while editable, runs
+ * a scroll spy in read-only mode, and provides jump/remove/link-click
+ * handlers. The editor must have the HeadingAnchors extension registered.
+ */
+export const useHeadingAnchorNav = (
+    editor: Editor | null,
+    { enabled, editable }: { enabled: boolean; editable: boolean },
+): HeadingAnchorNav => {
+    const [anchors, setAnchors] = useState<HeadingAnchor[]>([]);
+    const [activeAnchorId, setActiveAnchorId] = useState<string | null>(null);
+    const anchorsRef = useRef(anchors);
+    anchorsRef.current = anchors;
+
+    // Stamp ids onto legacy content when editable (persisted via onChange on
+    // save) and keep the chip list in sync with the doc. The 'transaction'
+    // event also covers external setContent calls, which do not emit 'update'.
+    useEffect(() => {
+        if (!editor || !enabled) return undefined;
+        if (editor.isEditable) editor.commands.ensureHeadingAnchors();
+        const refresh = () => setAnchors(collectAnchors(editor.state.doc));
+        refresh();
+        editor.on('transaction', refresh);
+        return () => {
+            editor.off('transaction', refresh);
+        };
+    }, [editor, enabled, editable]);
+
+    // Read-only scroll spy: mark the anchor whose heading is currently at the
+    // top of the (scrolled) editor content as active.
+    useEffect(() => {
+        if (!editor || !enabled || editable) return undefined;
+        let frame = 0;
+        const onScroll = () => {
+            if (frame) return;
+            frame = window.requestAnimationFrame(() => {
+                frame = 0;
+                const root = editor.view.dom as HTMLElement;
+                const rootTop = root.getBoundingClientRect().top;
+                let current: string | null = null;
+                anchorsRef.current.forEach((anchor) => {
+                    const el = root.querySelector(`[id="${escapeCssId(anchor.id)}"]`);
+                    if (el && el.getBoundingClientRect().top - rootTop <= 32) current = anchor.id;
+                });
+                if (current) setActiveAnchorId(current);
+            });
+        };
+        document.addEventListener('scroll', onScroll, { capture: true, passive: true });
+        return () => {
+            document.removeEventListener('scroll', onScroll, true);
+            if (frame) window.cancelAnimationFrame(frame);
+        };
+    }, [editor, enabled, editable]);
+
+    const scrollToAnchor = (anchorId: string) => {
+        if (!editor) return;
+        const target = editor.view.dom.querySelector(`[id="${escapeCssId(anchorId)}"]`);
+        // Instant (non-smooth) scrolling: smooth programmatic scrolling is a
+        // silent no-op in several embedded/headless browsers.
+        target?.scrollIntoView({ block: 'start' });
+        setActiveAnchorId(anchorId);
+    };
+
+    const removeAnchor = (anchorId: string) => {
+        if (!editor) return;
+        editor.commands.removeHeadingAnchor(anchorId);
+        setActiveAnchorId((current) => (current === anchorId ? null : current));
+    };
+
+    const handleContentClickCapture = (event: React.MouseEvent) => {
+        if (!enabled || editable) return;
+        const element = event.target as HTMLElement;
+        const link = element.closest?.('a[href^="#"]');
+        if (!link) return;
+        event.preventDefault();
+        event.stopPropagation();
+        scrollToAnchor((link.getAttribute('href') || '').slice(1));
+    };
+
+    return { anchors, anchorsRef, activeAnchorId, scrollToAnchor, removeAnchor, handleContentClickCapture };
+};
+
+export default useHeadingAnchorNav;

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -588,6 +588,7 @@
     "tenants.legal.version.current": "(aktuell)",
     "legal.m3Editor.maximize": "Fenster maximieren",
     "legal.m3Editor.minimize": "Fenster verkleinern",
+    "legal.m3Editor.closeDialog": "Vollbild schließen",
     "legal.m3Editor.versionLabel": "Aktuelle Version",
     "legal.m3Editor.versionLatest": "Aktuelle Version (Entwurf)",
     "legal.m3Editor.versionPublished": "Veröffentlichte Version",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1014,6 +1014,7 @@
     "tenants.legal.version.current": "(current)",
     "legal.m3Editor.maximize": "Maximize window",
     "legal.m3Editor.minimize": "Minimize window",
+    "legal.m3Editor.closeDialog": "Close fullscreen",
     "legal.m3Editor.versionLabel": "Latest version",
     "legal.m3Editor.versionLatest": "Current version (draft)",
     "legal.m3Editor.versionPublished": "Published version",


### PR DESCRIPTION
> **Stacked on #254** (which is stacked on #253) — merge those first; until then this diff includes their commits.

## Why
Anchor navigation existed only in the form-bound `TiptapEditor` (legal cards, #234/#246). It is now a **standard feature of the `M3RichTextEditor`** so every long text gets jump marks and a horizontal section menu — as requested, without new dependencies.

## Approach — deliberate deviation from the proposed extensions
`@tiptap/extension-unique-id` and `@tiptap/extension-table-of-contents` were evaluated and rejected for documented reasons (see the note in `headingAnchors.ts`): UniqueID instantly re-assigns ids that a user removed, and the ToC extension lists headings regardless of anchor state. The repo's own `HeadingAnchors` extension already implements the exact semantics (readable slugs, persistent removal, duplicate suffixing) — reused instead of duplicated. The BubbleMenu + Link part follows the proposal 1:1.

## What
- **New `useHeadingAnchorNav` hook** — the anchor behavior extracted from `TiptapEditor` (anchor list sync, legacy-content stamping, read-only scroll spy, jump/remove, #link click interception). `TiptapEditor` now consumes the hook (net deletion there); both editors share one implementation.
- **`M3RichTextEditor`**: new `enableAnchors` prop (default **true**); `HeadingAnchors` extension; `AnchorChips` row between toolbar and editor — **single line, hidden horizontal scrollbar** (same pattern as the toolbar/segmented tabs); BubbleMenu with an anchor `Select` on text selection (edit mode); scroll spy + link interception (read-only). Skipped when an `editorSlot` owns the content.
- `AnchorChips` accepts a `className` for the M3 chrome.

## Test coverage (all module states)
14 new tests in `M3RichTextEditor.anchors.test.tsx`:
- **Unit/Integration (edit)**: chip row renders per anchored heading (removable), chip click scrolls, removal strips the id + persists `data-anchor-removed`, legacy content gets slug ids, duplicate headings get `-2` suffixes
- **States**: empty content (no row), `enableAnchors={false}`, `editorSlot` (no internal row), read-only (no "x", checkmark on jump, no id invention), fullscreen dialog keeps the anchor row
- **Contract**: HTML round-trip — emitted HTML re-rendered yields identical anchors; a removed anchor stays removed (no re-assignment)
- Existing 21 `TiptapEditor` anchor tests green against the extracted hook (refactor safety net)

Full suite: **493/493**, `tsc --noEmit` clean, eslint zero-warning + prettier clean.

## Browser verification (Storybook)
- `WithAnchorNavigation`: 3 chips with slug ids, headings carry ids, chip click activates, BubbleMenu with "Link to section" select appears on selection (screenshot in session)
- `AnchorRowNarrowOverflow` at 375px: `flex-wrap: nowrap`, `overflow-x: auto`, actually scrollable (scrollWidth 510 > clientWidth 375)
- New stories: `WithAnchorNavigation`, `AnchorRowNarrowOverflow`, `ReadOnlyWithAnchors`, `AnchorsDisabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #267