### PR TITLE
Fix PreDev admin login and agency assignment

### DIFF
--- a/src/api/agency/putAgenciesForCounselor.ts
+++ b/src/api/agency/putAgenciesForCounselor.ts
@@ -11,7 +11,7 @@ export const DEFAULT_ROLE = 'CONSULTANT_DEFAULT';
 export const putAgenciesForCounselor = (counselorId: string, agencyIds: string[]) => {
     const agencies = agencyIds.map((agencyId) => ({
         agencyId,
-        role: DEFAULT_ROLE,
+        roleSetKey: DEFAULT_ROLE,
     }));
 
     return fetchData({

--- a/src/config/runtimeConfig.test.ts
+++ b/src/config/runtimeConfig.test.ts
@@ -26,6 +26,11 @@ afterEach(() => {
     vi.unstubAllEnvs();
     vi.resetModules();
     window.__APP_CONFIG__ = {};
+    Object.assign(window, {
+        _env_: {},
+        __ENV__: {},
+        env: {},
+    });
 });
 
 describe('runtimeConfig cookie domain', () => {
@@ -47,5 +52,27 @@ describe('runtimeConfig cookie domain', () => {
         });
 
         expect(runtimeConfig.cookieDomain).toBe('.oriso-dev.site');
+    });
+
+    it('reads legacy runtime env.js globals still used by PreDev deployments', async () => {
+        vi.resetModules();
+        runtimeEnvKeys.forEach((key) => {
+            vi.stubEnv(`VITE_${key}`, '');
+            vi.stubEnv(`REACT_APP_${key}`, '');
+        });
+        window.__APP_CONFIG__ = undefined;
+        Object.assign(window, {
+            _env_: {
+                API_URL: 'https://api.oriso-dev.site',
+                KEYCLOAK_URL: 'https://auth.oriso-dev.site',
+            },
+        });
+
+        const { keycloakAuthPath, runtimeConfig } = await import('./runtimeConfig');
+
+        expect(runtimeConfig.keycloakBaseUrl).toBe('https://auth.oriso-dev.site');
+        expect(keycloakAuthPath('/protocol/openid-connect/token')).toBe(
+            'https://auth.oriso-dev.site/realms/online-beratung/protocol/openid-connect/token',
+        );
     });
 });

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -3,7 +3,7 @@ import type { AppRuntimeConfig } from '../types/runtimeConfig';
 
 // Runtime config is injected by public/env.js in production deployments.
 // eslint-disable-next-line no-underscore-dangle
-const runtime = (): AppRuntimeConfig => window.__APP_CONFIG__ ?? {};
+const runtime = (): AppRuntimeConfig => window.__APP_CONFIG__ ?? window._env_ ?? window.__ENV__ ?? window.env ?? {};
 
 const readEnvString = (key: string): string | undefined => {
     const value = import.meta.env[key as keyof ImportMetaEnv];

--- a/src/types/runtimeConfig.d.ts
+++ b/src/types/runtimeConfig.d.ts
@@ -22,6 +22,9 @@ export interface AppRuntimeConfig {
 declare global {
     interface Window {
         __APP_CONFIG__?: AppRuntimeConfig;
+        _env_?: AppRuntimeConfig;
+        __ENV__?: AppRuntimeConfig;
+        env?: AppRuntimeConfig;
     }
 }
 


### PR DESCRIPTION
## Summary

- read legacy PreDev `env.js` runtime globals when resolving the Admin Keycloak base URL
- send `roleSetKey` in consultant agency assignment payloads
- add regression coverage for the legacy runtime config shape

## Validation

- `npm test -- --run src/config/runtimeConfig.test.ts`
- `git diff --check`
- `npm run build`
- PreDev E2E: Admin login, tenant/unit creation, consultant creation, agency assignment, and visibility enablement passed with screenshots in the run artifact folder

## Notes

This PR packages the Admin fixes from the Codex PreDev E2E run. Live Chat-specific exploratory frontend changes were rolled back and are not part of this PR.
