### PR TITLE
fix(admin): surface agency-assignment errors instead of silent success

### DIFF
--- a/src/api/agency/putAgenciesForCounselor.ts
+++ b/src/api/agency/putAgenciesForCounselor.ts
@@ -18,7 +18,9 @@ export const putAgenciesForCounselor = (counselorId: string, agencyIds: string[]
         url: `${counselorEndpoint}/${counselorId}/agencies`,
         method: FETCH_METHODS.PUT,
         skipAuth: false,
-        responseHandling: [FETCH_ERRORS.CATCH_ALL],
+        // Reject with the raw Response (no generic toast) so the caller can surface the
+        // backend's specific message — e.g. "topic ids [10] are not covered by ... agencies".
+        responseHandling: [FETCH_ERRORS.BAD_REQUEST_WITH_RESPONSE, FETCH_ERRORS.CATCH_ALL_SILENT],
         bodyData: JSON.stringify(agencies),
     });
 };

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -44,6 +44,7 @@
     "message.success.auth.resetPassword": "Passwort erfolgreich zurückgesetzt! Wenn diese E-Mail vorhanden ist, erhalten Sie einen Link zum zurücksetzen!",
     "message.warning.cancelRequest": "Der Vorgang wurde abgebrochen.",
     "message.error.default": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es später noch einmal.",
+    "message.error.topicsNotCoveredByAgencies": "Folgende Themen werden von keiner ausgewählten Beratungsstelle abgedeckt: {{topics}}. Bitte eine passende Beratungsstelle auswählen oder die Themen entfernen.",
     "message.error.unexpected": "Der Vorgang wurde abgebrochen.",
     "message.error.auth.login": "Login fehlgeschlagen. Bitte überprüfen Sie Benutzernamen/E-Mail und Passwort.",
     "message.error.auth.adminOnly": "Dieses Konto kann nicht auf die Verwaltung zugreifen. Bitte verwenden Sie ein Admin-Konto.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -36,6 +36,7 @@
     "message.error.ROLE_NOT_FOUND": "The required user role is missing from the system and could not be assigned. Please contact your administrator.",
     "message.error.NUMBER_OF_LICENSES_EXCEEDED": "You have reached the maximum number of consultants. Contact your admin to add more users or remove inactive consultants.",
     "message.error.default": "Something went wrong. Please try again later.",
+    "message.error.topicsNotCoveredByAgencies": "The following topics are not covered by any selected counselling agency: {{topics}}. Please select a matching agency or remove the topics.",
     "profile.title": "Profile",
     "profile.title.text": "Your profile information",
     "settings.title": "Settings",

--- a/src/pages/users/Edit/index.tsx
+++ b/src/pages/users/Edit/index.tsx
@@ -27,6 +27,7 @@ import { parseUserAuthInfo } from '../../../utils/parseUserAuthInfo';
 import { searchTenantData } from '../../../api/tenant/searchTenantData';
 import { getSingleTenantData } from '../../../api/tenant/getSingleTenantData';
 import { extractApiErrorMessage } from '../../../utils/extractApiErrorMessage';
+import { findUncoveredTopics } from '../../../utils/topicAgencyCoverage';
 import { useTenantTopics } from '../../../hooks/useTenantTopics';
 import { useCounselorById } from '../../../hooks/useCounselorById';
 import { GrantConsultantIdentityModal } from '../../../components/GrantConsultantIdentityModal';
@@ -231,7 +232,36 @@ export const UserEditOrAdd = () => {
         },
     });
 
-    const onSave = useCallback((data) => mutate(data), []);
+    // Mirror the backend ADR-003 rule (ConsultantTopicAgencyCompatibilityValidator):
+    // every selected topic must be offered by at least one selected agency. Catching this
+    // here means we name the mismatch instead of relying on the assignment request, which
+    // the backend used to swallow silently.
+    const onSave = useCallback(
+        (data) => {
+            if (isConsultantForm) {
+                const uncoveredTopics = findUncoveredTopics(
+                    data.agencies ?? [],
+                    data.topicIds ?? [],
+                    filteredAgencies || [],
+                );
+                if (uncoveredTopics.length > 0) {
+                    form.setFields([
+                        {
+                            name: 'topicIds',
+                            errors: [
+                                t('message.error.topicsNotCoveredByAgencies', {
+                                    topics: uncoveredTopics.map(({ label }) => label).join(', '),
+                                }),
+                            ],
+                        },
+                    ]);
+                    return;
+                }
+            }
+            mutate(data);
+        },
+        [isConsultantForm, filteredAgencies, form, mutate, t],
+    );
     const onCancel = useCallback(() => navigate(`/admin/users/${typeOfUsers}`), []);
     const isAbsentEnabled = useWatch('absent', form);
     // Superadmins pick the tenant in the form; other admins carry it in their token.

--- a/src/utils/topicAgencyCoverage.test.ts
+++ b/src/utils/topicAgencyCoverage.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { findUncoveredTopics } from './topicAgencyCoverage';
+
+const agencies = [
+    { id: 272, topics: [{ id: 10 }, { id: 3 }] },
+    { id: 273, topics: [{ id: 7 }] },
+    { id: 274, topics: [] as Array<{ id: number }> },
+];
+
+describe('findUncoveredTopics (ADR-003 topic/agency coverage)', () => {
+    it('returns no mismatch when no topic is selected', () => {
+        expect(findUncoveredTopics([{ value: '272', label: 'A' }], [], agencies)).toEqual([]);
+    });
+
+    it('returns no mismatch when every topic is covered by a selected agency', () => {
+        const result = findUncoveredTopics(
+            [{ value: '272', label: 'Agency 272' }],
+            [
+                { value: '10', label: 'Eltern und Familie' },
+                { value: '3', label: 'U25' },
+            ],
+            agencies,
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('flags a topic not offered by any selected agency (the demo case)', () => {
+        const result = findUncoveredTopics(
+            [{ value: '273', label: 'Agency 273' }],
+            [{ value: '10', label: 'Eltern und Familie' }],
+            agencies,
+        );
+        expect(result.map((t) => t.value)).toEqual(['10']);
+    });
+
+    it('ignores topics offered by an agency that is not selected', () => {
+        const result = findUncoveredTopics(
+            [{ value: '274', label: 'Empty agency' }],
+            [{ value: '7', label: 'HIV' }],
+            agencies,
+        );
+        expect(result.map((t) => t.value)).toEqual(['7']);
+    });
+
+    it('treats every topic as uncovered when no agency is selected', () => {
+        const result = findUncoveredTopics([], [{ value: '10', label: 'Eltern und Familie' }], agencies);
+        expect(result.map((t) => t.value)).toEqual(['10']);
+    });
+
+    it('coerces mixed string/number ids consistently', () => {
+        const result = findUncoveredTopics(
+            [{ value: '272', label: 'Agency 272' }],
+            [{ value: '10', label: 'ten' }],
+            [{ id: '272', topics: [{ id: '10' }] }],
+        );
+        expect(result).toEqual([]);
+    });
+});

--- a/src/utils/topicAgencyCoverage.ts
+++ b/src/utils/topicAgencyCoverage.ts
@@ -1,0 +1,29 @@
+import { Option } from '../components/SelectFormField';
+
+interface AgencyWithTopics {
+    id: number | string;
+    topics?: Array<{ id: number | string }>;
+}
+
+/**
+ * Mirrors the backend ADR-003 rule (ConsultantTopicAgencyCompatibilityValidator): a consultant
+ * topic is only valid if at least one of the selected agencies offers it. Returns the selected
+ * topics that no selected agency covers, so the caller can name the mismatch before submitting.
+ */
+export const findUncoveredTopics = (
+    selectedAgencies: Option[],
+    selectedTopics: Option[],
+    agencies: AgencyWithTopics[],
+): Option[] => {
+    if (!selectedTopics?.length) {
+        return [];
+    }
+    const selectedAgencyIds = new Set((selectedAgencies || []).map(({ value }) => String(value)));
+    const coveredTopicIds = new Set(
+        (agencies || [])
+            .filter((agency) => selectedAgencyIds.has(String(agency.id)))
+            .flatMap((agency) => agency.topics || [])
+            .map((topic) => String(topic.id)),
+    );
+    return selectedTopics.filter(({ value }) => !coveredTopicIds.has(String(value)));
+};


### PR DESCRIPTION
## Problem

When creating/editing a consultant, a **rejected agency assignment was invisible**: the backend swallowed validation failures (returned `200`) and the frontend used a generic catch-all toast at best. During the Caritas demo on 2026-07-08 the admin picked topic *Eltern und Familie* (id 10) and an agency that offered no such topic — the UI reported success while nothing was persisted.

## Changes

1. **Client-side coverage check** — mirrors the backend ADR-003 rule (`ConsultantTopicAgencyCompatibilityValidator`): every selected topic must be offered by at least one selected agency. On mismatch we set an **antd field error on the topics field naming the offending topics** and block submit, so the user fixes it before any request is sent. Logic is extracted into a pure, unit-tested util `utils/topicAgencyCoverage.ts`.
2. **`putAgenciesForCounselor`** now rejects with the raw `Response` (`BAD_REQUEST_WITH_RESPONSE` + `CATCH_ALL_SILENT`) instead of firing a generic `CATCH_ALL` toast. The consultant mutation's existing `onError` → `extractApiErrorMessage` then surfaces the backend's **specific** message (e.g. `topic ids [10] are not covered by ... agencies [272]`) for anything that slips past the client-side check.
3. New i18n key `message.error.topicsNotCoveredByAgencies` (de/en).

## Scope note

Agency-**admin** assignment (`putAgenciesForAgencyAdmin`) is intentionally left non-blocking: `CreateAdminAgencyRelationDTO` carries no topics, so it never hits the topic validator, and the account is created before the (secondary) agency step. It already shows a warning toast on failure via the existing `agencyAssignmentFailed` flag.

## Verification

- `tsc --noEmit`, `eslint`, `prettier --check` — all clean.
- `vitest run src/utils/topicAgencyCoverage.test.ts` — 6/6 green (covers the demo mismatch, full coverage, unselected-agency, no-agency, and mixed string/number id cases).
- Driving the full form flow needs a logged-in dev session (DNS/CA + Keycloak), so it was not exercised in a browser; the coverage logic is pure and unit-tested instead.

## Related

- Backend counterpart: OpenResilienceInitiative/ORISO-UserService#343 (stops swallowing the error, returns 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)