### PR TITLE
Respect CardDeck item minimum width

### DIFF
--- a/src/components/CardDeck/styles.module.scss
+++ b/src/components/CardDeck/styles.module.scss
@@ -37,8 +37,8 @@
 
 .item {
     display: flex;
+    min-width: min(var(--card-deck-item-min-width, 320px), var(--card-deck-item-max-width, calc(100vw - 176px)));
     flex: 0 0 min(var(--card-deck-item-width, 392px), var(--card-deck-item-max-width, calc(100vw - 176px)));
-    min-width: 0;
     scroll-snap-align: start;
 
     > * {


### PR DESCRIPTION
## Summary

Fixes #259.

The shared CardDeck item style ignored page-level `--card-deck-item-min-width` values by forcing `min-width: 0`. This lets cards collapse below the intended width on Admin pages that configure a minimum card width.

This PR applies the configured minimum width while preserving the existing responsive maximum-width cap and mobile behavior.

## Validation

- `npm run test -- CardDeck/index.test.tsx --run --reporter=dot`
- `npm run build`
- `git diff --check`

Build completed with existing warnings from `/env.js`, `lottie-web` direct eval, and large chunks.