### PR TITLE
ci: publish separate Storybook Docker image on dev/main

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -10,6 +10,10 @@ inputs:
     github_token:
         required: true
         type: string
+    dockerfile:
+        required: false
+        type: string
+        default: Dockerfile
 
 runs:
     using: 'composite'
@@ -39,6 +43,7 @@ runs:
           uses: docker/build-push-action@v7
           with:
               context: .
+              file: ${{ inputs.dockerfile }}
               push: ${{ inputs.push_to_ghcr }}
               tags: ${{ steps.meta.outputs.tags }}
               labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci-storybook-main.yml
+++ b/.github/workflows/ci-storybook-main.yml
@@ -1,0 +1,31 @@
+name: CI - Storybook Main
+
+on:
+    push:
+        branches:
+            - main
+            - dev
+
+env:
+    REGISTRY: ghcr.io
+    ORG: openresilienceinitiative
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Create and Publish Storybook Docker image
+              uses: ./.github/actions/docker-build-push
+              with:
+                  push_to_ghcr: true
+                  image_name: oriso-admin-storybook
+                  dockerfile: Dockerfile.storybook
+                  github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-storybook-pull-request.yml
+++ b/.github/workflows/ci-storybook-pull-request.yml
@@ -1,0 +1,24 @@
+name: CI - Storybook Pull Request
+
+on:
+    pull_request:
+
+env:
+    REGISTRY: ghcr.io
+    ORG: openresilienceinitiative
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Create Storybook Docker image
+              uses: ./.github/actions/docker-build-push
+              with:
+                  push_to_ghcr: false
+                  image_name: oriso-admin-storybook
+                  dockerfile: Dockerfile.storybook
+                  github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile.storybook
+++ b/Dockerfile.storybook
@@ -1,0 +1,44 @@
+ARG NODE_VERSION=22.12.0
+ARG PORT=80
+
+# Build stage
+FROM node:$NODE_VERSION AS storybookbuild
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+COPY .npmrc ./
+
+# --ignore-scripts blocks arbitrary dependency postinstall scripts
+# (supply-chain hardening), mirroring the CI node-build action.
+RUN npm ci --ignore-scripts
+
+# Copy source code
+COPY . .
+
+# Build Storybook static files (prebuild-storybook runs the SB typecheck)
+RUN npm run build-storybook
+
+# Production stage - serve static files
+FROM nginx:alpine
+
+ARG PORT=80
+
+# Copy Storybook build output to nginx html directory
+COPY --from=storybookbuild /app/storybook-static /usr/share/nginx/html
+
+# Copy nginx configuration
+RUN echo "server { \
+    listen ${PORT}; \
+    server_name _; \
+    root /usr/share/nginx/html; \
+    index index.html; \
+    location / { \
+        try_files \$uri \$uri/ /index.html; \
+    } \
+}" > /etc/nginx/conf.d/default.conf
+
+EXPOSE ${PORT}
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary

Ports the ORISO-Frontend Storybook CI recipe to ORISO-Admin so a **separate** Storybook Docker image is built and published when merged into `dev`/`main`, mirroring how the Frontend repo publishes `oriso-storybook`.

On push to `dev`/`main`, publishes `ghcr.io/openresilienceinitiative/oriso-admin-storybook` (tagged `dev`/`latest` + a SHA tag). On PRs, the image is built without pushing so a broken Storybook Dockerfile is caught before merge.

## Changes

- **`Dockerfile.storybook`** (new) — adapted from Frontend: Node 22.12.0 (vs 18), `npm ci --ignore-scripts` to match the supply-chain hardening in the CI node-build action; builds Storybook (incl. the `prebuild-storybook` typecheck) and serves `storybook-static/` via `nginx:alpine`.
- **`.github/workflows/ci-storybook-main.yml`** (new) — push to `main`/`dev` → build + push image to GHCR.
- **`.github/workflows/ci-storybook-pull-request.yml`** (new) — PRs → build image without pushing.
- **`.github/actions/docker-build-push/action.yml`** — added the optional `dockerfile` input that Admin's copy was missing (defaults to `Dockerfile`; existing `oriso-admin` workflows unaffected).

## Notes / deliberate differences from Frontend

- No `ci-storybook-feature-branch.yml` — Admin's existing `ci-feature-branch.yml` already runs `npm run build-storybook` on every feature push.
- New workflows don't repeat lint/test/build — `ci-main.yml` / `ci-pull-request.yml` already cover that on the same triggers, and the Docker build typechecks Storybook in-container.

## Verification

`npm run build-storybook` completes successfully locally with Node 22. Docker isn't installed on the dev machine, so the image build gets its first real run via this PR's Storybook PR workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)