### PR TITLE
test(fetchData): lock in the 30s default request timeout (AD-H07)

### DIFF
--- a/src/api/fetchData.test.ts
+++ b/src/api/fetchData.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 // Node env: fetch/Request/AbortController all come from the same realm, avoiding
 // the jsdom-vs-undici "signal is not an AbortSignal" mismatch. No DOM is needed here.
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // fetchData statically pulls in antd / i18next / appConfig / auth side effects.
 // Stub them so the unit stays focused on the self-healing 401 retry flow and we
@@ -55,6 +55,13 @@ describe('fetchData – self-healing 401 retry (logout-on-create fix)', () => {
         getAccessTokenForRequests.mockReset();
         getAccessTokenForRequests.mockReturnValue('access-token');
         appConfigMock.csrfWhitelistHeader = 'X-CSRF-Token';
+    });
+
+    // Guarantee cleanup even if an assertion throws mid-test, so fake timers and
+    // the stubbed fetch never leak into the next test.
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
     });
 
     it('refreshes the token and retries once on 401, then succeeds without logging out', async () => {
@@ -186,8 +193,6 @@ describe('fetchData – self-healing 401 retry (logout-on-create fix)', () => {
         expect(settled).toBe(false);
         await vi.advanceTimersByTimeAsync(1);
         await assertion;
-
-        vi.useRealTimers();
     });
 
     it('honours an explicit shorter timeout', async () => {
@@ -214,7 +219,5 @@ describe('fetchData – self-healing 401 retry (logout-on-create fix)', () => {
 
         await vi.advanceTimersByTimeAsync(5_000);
         await assertion;
-
-        vi.useRealTimers();
     });
 });

--- a/src/api/fetchData.test.ts
+++ b/src/api/fetchData.test.ts
@@ -151,4 +151,70 @@ describe('fetchData – self-healing 401 retry (logout-on-create fix)', () => {
 
         expect(location.href).toBe('/admin/access-denied');
     });
+
+    // AD-H07 / #143: every request must eventually fail instead of hanging forever.
+    it('aborts a hanging request after the 30s default timeout and rejects with TIMEOUT', async () => {
+        vi.useFakeTimers();
+        // A fetch that never settles on its own but honours the abort signal —
+        // exactly a stalled backend / dead connection.
+        const fetchMock = vi.fn(
+            (request: Request) =>
+                new Promise((_resolve, reject) => {
+                    request.signal.addEventListener('abort', () => {
+                        const abortError = new Error('aborted');
+                        abortError.name = 'AbortError';
+                        reject(abortError);
+                    });
+                }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const pending = fetchData({
+            url: 'https://api.test/service/settings',
+            method: FETCH_METHODS.GET,
+            skipAuth: true,
+        });
+        const assertion = expect(pending).rejects.toThrow(FETCH_ERRORS.TIMEOUT);
+
+        // Just before 30s the request is still in flight — the default has not
+        // fired early. It only aborts once the 30s window elapses.
+        let settled = false;
+        pending.catch(() => {
+            settled = true;
+        });
+        await vi.advanceTimersByTimeAsync(29_999);
+        expect(settled).toBe(false);
+        await vi.advanceTimersByTimeAsync(1);
+        await assertion;
+
+        vi.useRealTimers();
+    });
+
+    it('honours an explicit shorter timeout', async () => {
+        vi.useFakeTimers();
+        const fetchMock = vi.fn(
+            (request: Request) =>
+                new Promise((_resolve, reject) => {
+                    request.signal.addEventListener('abort', () => {
+                        const abortError = new Error('aborted');
+                        abortError.name = 'AbortError';
+                        reject(abortError);
+                    });
+                }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const pending = fetchData({
+            url: 'https://api.test/service/settings',
+            method: FETCH_METHODS.GET,
+            skipAuth: true,
+            timeout: 5_000,
+        });
+        const assertion = expect(pending).rejects.toThrow(FETCH_ERRORS.TIMEOUT);
+
+        await vi.advanceTimersByTimeAsync(5_000);
+        await assertion;
+
+        vi.useRealTimers();
+    });
 });


### PR DESCRIPTION
## Context
Issue #143 (AD-H07) asked for a default timeout so requests can't hang forever. The default (`props.timeout ?? 30_000`) was already added in commit 2b04e9f — but it had **no test**, so a future refactor could silently drop it.

## What
Adds two regression tests to `fetchData.test.ts`:
- a request without an explicit timeout stays in flight through 29 999 ms and only aborts (→ `TIMEOUT`) once the 30s window elapses
- an explicit shorter timeout is honoured

Verified the default-timeout test goes **red** when the `?? 30_000` default is removed, so it genuinely guards the behaviour.

Full suite green; eslint + prettier clean.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)