### PR TITLE
test(carddeck): lock in that items respect --card-deck-item-min-width (#259)

### DIFF
--- a/src/components/CardDeck/styles.test.ts
+++ b/src/components/CardDeck/styles.test.ts
@@ -11,4 +11,14 @@ describe('CardDeck responsive contract', () => {
         expect(cardDeckStyles).toMatch(/\.deck\s*{[^}]*overflow:\s*visible;/s);
         expect(cardDeckStyles).toMatch(/\.footer\s*{[^}]*display:\s*none;/s);
     });
+
+    // #259: items must respect --card-deck-item-min-width, not collapse to 0.
+    it('honours the configured item minimum width (capped by the responsive max)', () => {
+        const itemRule = cardDeckStyles.match(/\.item\s*{([^}]*)}/s)?.[1] ?? '';
+        expect(itemRule).toMatch(
+            /min-width:\s*min\(\s*var\(--card-deck-item-min-width,\s*320px\)\s*,\s*var\(--card-deck-item-max-width/s,
+        );
+        // The desktop item rule must not force the min-width to 0.
+        expect(itemRule).not.toMatch(/min-width:\s*0/);
+    });
 });


### PR DESCRIPTION
## Context
#259 reported that CardDeck items forced `min-width: 0` and collapsed below their configured minimum. The fix already landed in commit 5635964 — `.item` now uses `min-width: min(var(--card-deck-item-min-width, 320px), var(--card-deck-item-max-width, …))` — but there was no test guarding it.

## What
Adds a style-contract test (matching the existing responsive test's approach of asserting against the compiled SCSS source) that:
- the `.item` rule derives its `min-width` from `--card-deck-item-min-width` (capped by the responsive max)
- the desktop item rule never forces `min-width: 0`

Existing CardDeck tests stay green; production build succeeds (validation target from the issue).

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)