### PR TITLE
test(agency-list): lock in graceful degradation on a failed agencies load (#240)

### DIFF
--- a/src/pages/Agency/List/index.test.tsx
+++ b/src/pages/Agency/List/index.test.tsx
@@ -114,7 +114,7 @@ vi.mock('../../../components/ResizableTable', () => ({
         return (
             <div>
                 {loading && <div data-testid="table-loading" />}
-                {dataSource.length === 0 && <div data-testid="table-empty">{locale?.emptyText}</div>}
+                {!loading && dataSource.length === 0 && <div data-testid="table-empty">{locale?.emptyText}</div>}
                 {dataSource.map((record: any) => (
                     <div key={record.id}>
                         <div data-testid={`topics-${record.id}`}>{topicColumn.render(record.topics, record)}</div>

--- a/src/pages/Agency/List/index.test.tsx
+++ b/src/pages/Agency/List/index.test.tsx
@@ -8,6 +8,9 @@ const mocks = vi.hoisted(() => ({
     agencies: [] as any[],
     navigate: vi.fn(),
     refetch: vi.fn(),
+    // Query state overrides for the agencies list (default: loaded successfully).
+    isLoading: false,
+    isError: false,
 }));
 
 const translations: Record<string, string> = {
@@ -32,6 +35,7 @@ const translations: Record<string, string> = {
     status: 'Status',
     new: 'New',
     'tenants.list.empty': 'No data available',
+    'message.error.default': 'Something went wrong. Please try again.',
 };
 
 const t = (key: string) => translations[key] || key;
@@ -103,12 +107,14 @@ vi.mock('../../../components/SearchInput/SearchInput', () => ({
 }));
 
 vi.mock('../../../components/ResizableTable', () => ({
-    ResizeTable: ({ columns, dataSource }: any) => {
+    ResizeTable: ({ columns, dataSource, loading, locale }: any) => {
         const topicColumn = columns.find((column: any) => column.key === 'topics');
         const actionColumn = columns.find((column: any) => column.key === 'edit');
 
         return (
             <div>
+                {loading && <div data-testid="table-loading" />}
+                {dataSource.length === 0 && <div data-testid="table-empty">{locale?.emptyText}</div>}
                 {dataSource.map((record: any) => (
                     <div key={record.id}>
                         <div data-testid={`topics-${record.id}`}>{topicColumn.render(record.topics, record)}</div>
@@ -122,8 +128,9 @@ vi.mock('../../../components/ResizableTable', () => ({
 
 vi.mock('../../../hooks/useAgencysData', () => ({
     useAgenciesData: () => ({
-        data: { total: mocks.agencies.length, data: mocks.agencies },
-        isLoading: false,
+        data: mocks.isError ? undefined : { total: mocks.agencies.length, data: mocks.agencies },
+        isLoading: mocks.isLoading,
+        isError: mocks.isError,
         refetch: mocks.refetch,
     }),
 }));
@@ -183,6 +190,8 @@ const buildAgency = (topics: Array<{ id: number | null; name: string }>) =>
 describe('AgencyList topic rendering', () => {
     beforeEach(() => {
         mocks.agencies = [];
+        mocks.isLoading = false;
+        mocks.isError = false;
         mocks.navigate.mockReset();
         mocks.refetch.mockReset();
     });
@@ -239,5 +248,27 @@ describe('AgencyList topic rendering', () => {
         render(<AgencyList />);
 
         expect(screen.getByText('No topics assigned')).toBeInTheDocument();
+    });
+
+    // #240: a failed agencies load must degrade to an error message, never hang
+    // on the spinner. The query uses retry:false and fetchData's 30s timeout, so
+    // isLoading resolves to false and isError drives a visible message.
+    it('shows an error message and stops loading when the agencies query fails', () => {
+        mocks.isError = true;
+        mocks.isLoading = false;
+
+        render(<AgencyList />);
+
+        expect(screen.queryByTestId('table-loading')).not.toBeInTheDocument();
+        expect(screen.getByTestId('table-empty')).toHaveTextContent('Something went wrong. Please try again.');
+    });
+
+    it('shows the neutral empty text (not the error) when the load succeeds with no agencies', () => {
+        mocks.isError = false;
+        mocks.agencies = [];
+
+        render(<AgencyList />);
+
+        expect(screen.getByTestId('table-empty')).toHaveTextContent('No data available');
     });
 });


### PR DESCRIPTION
## Context
#240 reports the agency list at `/admin/agency` spinning forever. The page already reads `isError`/`isLoading` from `useAgenciesData` and shows an error `emptyText`, and the query uses `retry: false`. The one way the spinner could hang indefinitely was a request that never settles — now prevented by fetchData's 30s default timeout (#143): after at most 30s the query resolves to `isError`, `isLoading` becomes false, and the error message shows.

## What
- Regression test: a failed agencies load shows the error message and is **not** in the loading state.
- Test: a successful empty load shows the neutral empty text, not the error.
- The `ResizeTable` test mock now renders `loading` + `locale.emptyText` so these states are assertable (previously it only rendered rows).

Full suite: 496/496; eslint + prettier clean.

## Scope
This nails the **frontend symptom** (no more infinite spinner — it degrades to a visible error). If the list is still empty on `admin.oriso.org`, the **root cause is backend** (agencies API returning 500 / not responding — cf. the UserService agency-admin self-call config drift) and should be reproduced against the live service separately. Leaving #240 open for that root-cause confirmation rather than closing on the frontend guard alone.

Part of #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)