### PR TITLE
feat: Storybook atoms (Button, InputField, SelectFormField, Card) + Card token fixes

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Card } from './index';
+
+const meta = {
+    title: 'Molecules/Card',
+    component: Card,
+    parameters: {
+        layout: 'padded',
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/design/QfsgojtHQzBjbzU3Im9Cet/Admin.ORISO?node-id=899-26642',
+        },
+    },
+    args: {
+        titleKey: 'Allgemeine Informationen',
+    },
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        children: 'Karteninhalt im Admin-Panel.',
+    },
+};
+
+export const WithTooltip: Story = {
+    args: {
+        tooltip: 'Diese Angaben werden öffentlich angezeigt.',
+        children: 'Karteninhalt mit Info-Tooltip neben dem Titel.',
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        isLoading: true,
+        children: 'Wird nicht angezeigt, während geladen wird.',
+    },
+};
+
+export const DialogVariant: Story = {
+    args: {
+        variant: 'dialog',
+        dialogContentPadding: true,
+        children: 'Dialog-Variante mit abgerundeter Karten-Oberfläche.',
+    },
+};

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -67,7 +67,7 @@ export const Card = ({
                     </Title>
 
                     {tooltip && (
-                        <Tooltip className={styles.tooltip} trigger={<InfoIcon fill="var(--primary)" />}>
+                        <Tooltip className={styles.tooltip} trigger={<InfoIcon fill="var(--m3-primary)" />}>
                             {tooltip}
                         </Tooltip>
                     )}

--- a/src/components/Card/styles.module.scss
+++ b/src/components/Card/styles.module.scss
@@ -25,7 +25,7 @@
     padding: 0;
     overflow: hidden;
     border-radius: 28px;
-    background: #eae7e8;
+    background: var(--m3-surface-container-high);
     font-synthesis: none;
     font-family: var(--m3-body-font-family);
     -moz-osx-font-smoothing: auto;
@@ -71,7 +71,7 @@
     text-align: center;
 
     .title {
-        color: #1b1b1c;
+        color: var(--m3-on-surface);
         font-family: var(--m3-body-font-family);
         font-size: 24px;
         font-weight: 400;
@@ -86,7 +86,7 @@
     height: 40px;
     align-items: center;
     justify-content: center;
-    color: #444748;
+    color: var(--m3-on-surface-variant);
 
     :global {
         svg {
@@ -109,7 +109,7 @@
 .dialogCardSubTitle {
     margin: 16px 0 0;
     padding: 0 24px;
-    color: #444748;
+    color: var(--m3-on-surface-variant);
     font-family: var(--m3-body-font-family);
     font-size: 14px;
     letter-spacing: 0.25px;

--- a/src/components/CardDeck/CardDeck.stories.tsx
+++ b/src/components/CardDeck/CardDeck.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Card } from '../Card';
+import { CardDeck } from './index';
+
+const meta = {
+    title: 'Molecules/CardDeck',
+    component: CardDeck,
+    parameters: { layout: 'padded' },
+    args: {
+        ariaLabel: 'Kartenübersicht',
+        previousLabel: 'Zurück',
+        nextLabel: 'Weiter',
+    },
+} satisfies Meta<typeof CardDeck>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A single card never shows the overflow footer. */
+export const SingleCard: Story = {
+    render: (args) => (
+        <div style={{ maxWidth: 480 }}>
+            <CardDeck {...args}>
+                <CardDeck.Item>
+                    <Card titleKey="Karte 1">Einzelne Karte, kein Overflow.</Card>
+                </CardDeck.Item>
+            </CardDeck>
+        </div>
+    ),
+};
+
+/** Several cards overflow the visible width, so the SideScrollerFooter with prev/next arrows appears. */
+export const OverflowingCards: Story = {
+    render: (args) => (
+        <div style={{ maxWidth: 480 }}>
+            <CardDeck {...args}>
+                {[1, 2, 3, 4].map((n) => (
+                    <CardDeck.Item key={n}>
+                        <div style={{ width: 260 }}>
+                            <Card titleKey={`Karte ${n}`}>Inhalt der Karte {n}.</Card>
+                        </div>
+                    </CardDeck.Item>
+                ))}
+            </CardDeck>
+        </div>
+    ),
+};

--- a/src/components/CreateAgencyModal/CreateAgencyModal.stories.tsx
+++ b/src/components/CreateAgencyModal/CreateAgencyModal.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CreateAgencyModal } from './index';
+
+const meta = {
+    title: 'Organisms/CreateAgencyModal',
+    component: CreateAgencyModal,
+    parameters: { layout: 'padded' },
+    args: {
+        onSuccess: () => {},
+    },
+} satisfies Meta<typeof CreateAgencyModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** No tenant selected yet: trigger button disabled, tooltip explains why. */
+export const NoTenantSelected: Story = {
+    args: {
+        tenantId: undefined,
+    },
+};
+
+/** Tenant known: trigger button is active. Click it to open the create-agency form. */
+export const TenantSelected: Story = {
+    args: {
+        tenantId: 42,
+    },
+};

--- a/src/components/CreateConsultantModal/CreateConsultantModal.stories.tsx
+++ b/src/components/CreateConsultantModal/CreateConsultantModal.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CreateConsultantModal } from './index';
+
+const meta = {
+    title: 'Organisms/CreateConsultantModal',
+    component: CreateConsultantModal,
+    parameters: { layout: 'padded' },
+    args: {
+        onSuccess: () => {},
+    },
+} satisfies Meta<typeof CreateConsultantModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** No tenant selected yet: trigger button disabled, tooltip explains why. */
+export const NoTenantSelected: Story = {
+    args: {
+        tenantId: undefined,
+    },
+};
+
+/** Tenant known: trigger button is active. Click it to open the create-consultant form. */
+export const TenantSelected: Story = {
+    args: {
+        tenantId: 42,
+    },
+};

--- a/src/components/EditableTable/EditableTable.stories.tsx
+++ b/src/components/EditableTable/EditableTable.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import EditableTable from './EditableTable';
+
+const data = [
+    { key: '1', name: 'Anna Muster', email: 'anna@example.org' },
+    { key: '2', name: 'Ben Beispiel', email: 'ben@example.org' },
+];
+
+const columns = [
+    { title: 'Name', dataIndex: 'name', key: 'name' },
+    { title: 'E-Mail', dataIndex: 'email', key: 'email' },
+];
+
+const meta = {
+    title: 'Organisms/EditableTable',
+    component: EditableTable,
+    parameters: { layout: 'padded' },
+    args: {
+        source: data,
+        columns,
+        isLoading: false,
+        page: 1,
+        allowedNumberOfUsers: 9999,
+        handleBtnAdd: () => {},
+        handlePagination: () => {},
+        isDeleteModalVisible: false,
+        handleOnDelete: () => {},
+        handleDeleteModalCancel: () => {},
+        handleDeleteModalTitle: 'Eintrag löschen',
+        handleDeleteModalText: 'Möchten Sie diesen Eintrag wirklich löschen?',
+    },
+} satisfies Meta<typeof EditableTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithSearch: Story = {
+    args: {
+        hasSearch: true,
+        handleOnSearch: () => {},
+        handleOnSearchClear: () => {},
+    },
+};
+
+/** The inline delete-confirmation modal, always mounted, toggled via isDeleteModalVisible. */
+export const DeleteConfirmation: Story = {
+    args: {
+        isDeleteModalVisible: true,
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        isLoading: true,
+    },
+};

--- a/src/components/FormColorSelectorField/FormColorSelectorField.stories.tsx
+++ b/src/components/FormColorSelectorField/FormColorSelectorField.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form } from 'antd';
+import { FormColorSelectorField } from './index';
+
+const meta = {
+    title: 'Atoms/FormColorSelectorField',
+    component: FormColorSelectorField,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <Form style={{ maxWidth: 360 }} initialValues={{ primaryColor: '#a5000a' }}>
+                <Story />
+            </Form>
+        ),
+    ],
+    args: {
+        name: 'primaryColor',
+        labelKey: 'Primärfarbe',
+    },
+} satisfies Meta<typeof FormColorSelectorField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+    args: { disabled: true },
+};

--- a/src/components/FormFileUploaderField/FormFileUploaderField.stories.tsx
+++ b/src/components/FormFileUploaderField/FormFileUploaderField.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form } from 'antd';
+import { FormFileUploaderField } from './index';
+
+const meta = {
+    title: 'Atoms/FormFileUploaderField',
+    component: FormFileUploaderField,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <Form style={{ maxWidth: 360 }}>
+                <Story />
+            </Form>
+        ),
+    ],
+    args: {
+        name: 'logo',
+        labelKey: 'Logo',
+    },
+} satisfies Meta<typeof FormFileUploaderField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {};
+
+export const Disabled: Story = {
+    args: { disabled: true },
+};

--- a/src/components/FormInputField/FormInputField.stories.tsx
+++ b/src/components/FormInputField/FormInputField.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form } from 'antd';
+import { FormInputField } from './index';
+
+const meta = {
+    title: 'Atoms/FormInputField',
+    component: FormInputField,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <Form style={{ maxWidth: 360 }}>
+                <Story />
+            </Form>
+        ),
+    ],
+    args: {
+        name: 'name',
+        labelKey: 'Name',
+        placeholderKey: 'Name eingeben',
+    },
+} satisfies Meta<typeof FormInputField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Required: Story = {
+    args: { required: true },
+};
+
+export const Disabled: Story = {
+    args: { disabled: true },
+};

--- a/src/components/FormInputNumberField/FormInputNumberField.stories.tsx
+++ b/src/components/FormInputNumberField/FormInputNumberField.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form } from 'antd';
+import { FormInputNumberField } from './index';
+
+const meta = {
+    title: 'Atoms/FormInputNumberField',
+    component: FormInputNumberField,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <Form style={{ maxWidth: 360 }}>
+                <Story />
+            </Form>
+        ),
+    ],
+    args: {
+        name: 'capacity',
+        labelKey: 'Kapazität',
+        placeholderKey: 'Anzahl eingeben',
+    },
+} satisfies Meta<typeof FormInputNumberField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Required: Story = {
+    args: { required: true },
+};

--- a/src/components/FormInputPasswordField/FormInputPasswordField.stories.tsx
+++ b/src/components/FormInputPasswordField/FormInputPasswordField.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form } from 'antd';
+import { FormInputPasswordField } from './index';
+
+const meta = {
+    title: 'Atoms/FormInputPasswordField',
+    component: FormInputPasswordField,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <Form style={{ maxWidth: 360 }}>
+                <Story />
+            </Form>
+        ),
+    ],
+    args: {
+        name: 'password',
+        labelKey: 'Passwort',
+        placeholderKey: 'Passwort eingeben',
+    },
+} satisfies Meta<typeof FormInputPasswordField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Required: Story = {
+    args: { required: true },
+};

--- a/src/components/FormRadioGroupField/FormRadioGroupField.stories.tsx
+++ b/src/components/FormRadioGroupField/FormRadioGroupField.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form } from 'antd';
+import { FormRadioGroupField } from './index';
+
+const meta = {
+    title: 'Atoms/FormRadioGroupField',
+    component: FormRadioGroupField,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <Form style={{ maxWidth: 360 }}>
+                <Story />
+            </Form>
+        ),
+    ],
+    args: {
+        name: 'contactType',
+        labelKey: 'Kontaktart',
+        children: (
+            <>
+                <FormRadioGroupField.Radio value="email">E-Mail</FormRadioGroupField.Radio>
+                <FormRadioGroupField.Radio value="phone">Telefon</FormRadioGroupField.Radio>
+            </>
+        ),
+    },
+} satisfies Meta<typeof FormRadioGroupField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {};
+
+export const Vertical: Story = {
+    args: { vertical: true },
+};

--- a/src/components/FormSwitchField/FormSwitchField.stories.tsx
+++ b/src/components/FormSwitchField/FormSwitchField.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form } from 'antd';
+import { FormSwitchField } from './index';
+
+const meta = {
+    title: 'Atoms/FormSwitchField',
+    component: FormSwitchField,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <Form style={{ maxWidth: 360 }}>
+                <Story />
+            </Form>
+        ),
+    ],
+    args: {
+        name: 'notifications',
+        labelKey: 'Benachrichtigungen',
+    },
+} satisfies Meta<typeof FormSwitchField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default antd Switch rendering. */
+export const AntdVariant: Story = {
+    args: { switchVariant: 'antd' },
+};
+
+/** M3-styled switch rendering (see also Atoms/M3Switch). */
+export const M3Variant: Story = {
+    args: { switchVariant: 'm3', switchLabel: 'Benachrichtigungen' },
+};

--- a/src/components/FormTextAreaField/FormTextAreaField.stories.tsx
+++ b/src/components/FormTextAreaField/FormTextAreaField.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form } from 'antd';
+import { FormTextAreaField } from './index';
+
+const meta = {
+    title: 'Atoms/FormTextAreaField',
+    component: FormTextAreaField,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <Form style={{ maxWidth: 360 }}>
+                <Story />
+            </Form>
+        ),
+    ],
+    args: {
+        name: 'description',
+        labelKey: 'Beschreibung',
+        placeholderKey: 'Beschreibung eingeben',
+    },
+} satisfies Meta<typeof FormTextAreaField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Required: Story = {
+    args: { required: true },
+};

--- a/src/components/Layout/SiteFooter.stories.tsx
+++ b/src/components/Layout/SiteFooter.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import SiteFooter from './SiteFooter';
+
+const meta = {
+    title: 'Molecules/SiteFooter',
+    component: SiteFooter,
+    parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof SiteFooter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/Layout/SiteHeader.stories.tsx
+++ b/src/components/Layout/SiteHeader.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import SiteHeader from './SiteHeader';
+
+const meta = {
+    title: 'Molecules/SiteHeader',
+    component: SiteHeader,
+    parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof SiteHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/ListingTable/ListingTable.stories.tsx
+++ b/src/components/ListingTable/ListingTable.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ListingTable } from './ListingTable';
+
+interface Row {
+    key: string;
+    name: string;
+    email: string;
+    status: string;
+}
+
+const data: Row[] = [
+    { key: '1', name: 'Anna Muster', email: 'anna@example.org', status: 'Aktiv' },
+    { key: '2', name: 'Ben Beispiel', email: 'ben@example.org', status: 'Gesperrt' },
+    { key: '3', name: 'Clara Demo', email: 'clara@example.org', status: 'Aktiv' },
+];
+
+const columns = [
+    { title: 'Name', dataIndex: 'name', key: 'name' },
+    { title: 'E-Mail', dataIndex: 'email', key: 'email' },
+    { title: 'Status', dataIndex: 'status', key: 'status' },
+];
+
+const meta = {
+    title: 'Organisms/ListingTable',
+    component: ListingTable,
+    parameters: { layout: 'padded' },
+    args: {
+        columns,
+        dataSource: data,
+        pagination: false,
+        scroll: { y: 'auto' },
+    },
+} satisfies Meta<typeof ListingTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Filled: Story = {};
+
+export const Empty: Story = {
+    args: {
+        dataSource: [],
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        loading: true,
+    },
+};

--- a/src/components/M3Checkbox/M3Checkbox.stories.tsx
+++ b/src/components/M3Checkbox/M3Checkbox.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { M3Checkbox } from './index';
+
+const meta = {
+    title: 'Atoms/M3Checkbox',
+    component: M3Checkbox,
+    parameters: { layout: 'padded' },
+    args: {
+        label: 'Beispiel-Checkbox',
+        onChange: () => {},
+    },
+} satisfies Meta<typeof M3Checkbox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Unchecked: Story = {
+    args: { checked: false },
+};
+
+export const Checked: Story = {
+    args: { checked: true },
+};
+
+export const Disabled: Story = {
+    args: { checked: false, disabled: true },
+};

--- a/src/components/M3Switch/M3Switch.stories.tsx
+++ b/src/components/M3Switch/M3Switch.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { M3Switch } from './index';
+
+const meta = {
+    title: 'Atoms/M3Switch',
+    component: M3Switch,
+    parameters: { layout: 'padded' },
+    args: {
+        label: 'Beispiel-Switch',
+        onChange: () => {},
+    },
+} satisfies Meta<typeof M3Switch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Off: Story = {
+    args: { checked: false },
+};
+
+export const On: Story = {
+    args: { checked: true },
+};
+
+export const Disabled: Story = {
+    args: { checked: false, disabled: true },
+};

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Modal } from './index';
+
+const meta = {
+    title: 'Organisms/Modal',
+    component: Modal,
+    parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof Modal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Confirmation dialog: title/content/actions all resolved via i18n keys. */
+export const Confirmation: Story = {
+    args: {
+        titleKey: 'slogan',
+        contentKey: 'subSlogan',
+        okLabelKey: 'save',
+        cancelLabelKey: 'cancel',
+        onConfirm: () => {},
+        onClose: () => {},
+    },
+};
+
+export const WithCustomChildren: Story = {
+    args: {
+        titleKey: 'slogan',
+        okLabelKey: 'save',
+        cancelLabelKey: 'cancel',
+        onConfirm: () => {},
+        onClose: () => {},
+        children: 'Beliebiger Formularinhalt lässt sich als children einsetzen.',
+    },
+};

--- a/src/components/ModalForm/ModalForm.stories.tsx
+++ b/src/components/ModalForm/ModalForm.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form } from 'antd';
+import ModalForm from './ModalForm';
+import { SelectFormField } from '../SelectFormField';
+
+const meta = {
+    title: 'Organisms/ModalForm',
+    component: ModalForm,
+    parameters: { layout: 'fullscreen' },
+    args: {
+        isModalCreateVisible: true,
+        isInAddMode: true,
+        title: 'Neue Stadt anlegen',
+        handleOnAddElement: () => {},
+        handleCreateModalCancel: () => {},
+        formData: undefined,
+        renderFormFields: ({ form }) => (
+            <Form form={form}>
+                <SelectFormField
+                    name="city"
+                    label="Stadt"
+                    required
+                    options={[
+                        { label: 'Berlin', value: 'berlin' },
+                        { label: 'Hamburg', value: 'hamburg' },
+                    ]}
+                />
+            </Form>
+        ),
+    },
+} satisfies Meta<typeof ModalForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/ModalSuccess/ModalSuccess.stories.tsx
+++ b/src/components/ModalSuccess/ModalSuccess.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ModalSuccess } from './index';
+
+const meta = {
+    title: 'Organisms/ModalSuccess',
+    component: ModalSuccess,
+    parameters: { layout: 'fullscreen' },
+    args: {
+        titleKey: 'slogan',
+        okLabelKey: 'save',
+        onConfirm: () => {},
+        onClose: () => {},
+    },
+} satisfies Meta<typeof ModalSuccess>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/ResizableTable/ResizableTable.stories.tsx
+++ b/src/components/ResizableTable/ResizableTable.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ResizeTable } from './index';
+
+interface Row {
+    key: string;
+    name: string;
+    email: string;
+}
+
+const data: Row[] = [
+    { key: '1', name: 'Anna Muster', email: 'anna@example.org' },
+    { key: '2', name: 'Ben Beispiel', email: 'ben@example.org' },
+];
+
+const columns = [
+    { title: 'Name', dataIndex: 'name', key: 'name', width: 200 },
+    { title: 'E-Mail', dataIndex: 'email', key: 'email', width: 260 },
+];
+
+const meta = {
+    title: 'Organisms/ResizableTable',
+    component: ResizeTable,
+    parameters: { layout: 'padded' },
+    args: {
+        columns,
+        dataSource: data,
+        pagination: false,
+        scroll: { y: 'auto' },
+    },
+} satisfies Meta<typeof ResizeTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Drag a column's right edge to resize it — the column-resize behavior that sets this table apart from ListingTable. */
+export const Default: Story = {};

--- a/src/components/SearchInput/SearchInput.stories.tsx
+++ b/src/components/SearchInput/SearchInput.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SearchInput } from './SearchInput';
+
+const meta = {
+    title: 'Molecules/SearchInput',
+    component: SearchInput,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <div style={{ maxWidth: 360 }}>
+                <Story />
+            </div>
+        ),
+    ],
+    args: {
+        ariaLabel: 'Suche',
+    },
+} satisfies Meta<typeof SearchInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Empty state: only the search-submit button is shown. */
+export const SearchButton: Story = {
+    args: {
+        value: '',
+    },
+};
+
+/** Filled state: the button switches to a clear (X) action. */
+export const ClearButton: Story = {
+    args: {
+        value: 'Musterstadt',
+    },
+};

--- a/src/components/SelectFormField/SelectFormField.stories.tsx
+++ b/src/components/SelectFormField/SelectFormField.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form } from 'antd';
+import { SelectFormField } from './index';
+
+const options = [
+    { label: 'Berlin', value: 'berlin' },
+    { label: 'Hamburg', value: 'hamburg' },
+    { label: 'München', value: 'muenchen' },
+];
+
+const meta = {
+    title: 'Atoms/SelectFormField',
+    component: SelectFormField,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <Form style={{ maxWidth: 360 }}>
+                <Story />
+            </Form>
+        ),
+    ],
+    args: {
+        name: 'city',
+        label: 'Stadt',
+        options,
+        placeholder: 'Stadt auswählen',
+    },
+} satisfies Meta<typeof SelectFormField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Required: Story = {
+    args: {
+        required: true,
+    },
+};
+
+export const MultiSelect: Story = {
+    args: {
+        name: 'cities',
+        label: 'Städte',
+        isMulti: true,
+        allowClear: true,
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        disabled: true,
+        initialValue: 'berlin',
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        loading: true,
+    },
+};

--- a/src/components/SideScrollerFooter/SideScrollerFooter.stories.tsx
+++ b/src/components/SideScrollerFooter/SideScrollerFooter.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SideScrollerFooter } from './index';
+
+const meta = {
+    title: 'Molecules/SideScrollerFooter',
+    component: SideScrollerFooter,
+    parameters: { layout: 'padded' },
+    args: {
+        ariaLabel: 'Karten-Navigation',
+        previousLabel: 'Zurück',
+        nextLabel: 'Weiter',
+        onScrollBackward: () => {},
+        onScrollForward: () => {},
+    },
+} satisfies Meta<typeof SideScrollerFooter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BothDisabled: Story = {
+    args: {
+        canScrollBackward: false,
+        canScrollForward: false,
+    },
+};
+
+export const ForwardOnly: Story = {
+    args: {
+        canScrollBackward: false,
+        canScrollForward: true,
+    },
+};
+
+export const BothActive: Story = {
+    args: {
+        canScrollBackward: true,
+        canScrollForward: true,
+    },
+};

--- a/src/components/button/Button.stories.tsx
+++ b/src/components/button/Button.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button, BUTTON_TYPES } from './Button';
+
+const meta = {
+    title: 'Atoms/Button',
+    component: Button,
+    parameters: { layout: 'padded' },
+    args: {
+        buttonHandle: () => {},
+    },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+    args: {
+        item: { type: BUTTON_TYPES.PRIMARY, label: 'Speichern', id: 'primary' },
+    },
+};
+
+export const Secondary: Story = {
+    args: {
+        item: { type: BUTTON_TYPES.SECONDARY, label: 'Abbrechen', id: 'secondary' },
+    },
+};
+
+export const Tertiary: Story = {
+    args: {
+        item: { type: BUTTON_TYPES.TERTIARY, label: 'Zurücksetzen', id: 'tertiary' },
+    },
+};
+
+export const Link: Story = {
+    args: {
+        item: { type: BUTTON_TYPES.LINK, label: 'Mehr erfahren', id: 'link' },
+        isLink: true,
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        item: { type: BUTTON_TYPES.PRIMARY, label: 'Speichern', id: 'disabled' },
+        disabled: true,
+    },
+};

--- a/src/components/inputField/InputField.stories.tsx
+++ b/src/components/inputField/InputField.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { InputField } from './InputField';
+
+const meta = {
+    title: 'Atoms/InputField',
+    component: InputField,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <div style={{ maxWidth: 360 }}>
+                <Story />
+            </div>
+        ),
+    ],
+    args: {
+        inputHandle: () => {},
+    },
+} satisfies Meta<typeof InputField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        item: { id: 'name', type: 'text', name: 'name', label: 'Name', content: '' },
+    },
+};
+
+export const Filled: Story = {
+    args: {
+        item: { id: 'name-filled', type: 'text', name: 'name', label: 'Name', content: 'Max Mustermann' },
+    },
+};
+
+export const Password: Story = {
+    args: {
+        item: { id: 'password', type: 'password', name: 'password', label: 'Passwort', content: '' },
+    },
+};
+
+export const Invalid: Story = {
+    args: {
+        item: {
+            id: 'invalid',
+            type: 'text',
+            name: 'email',
+            label: 'E-Mail',
+            content: 'keine-email',
+            labelState: 'invalid',
+            infoText: 'Bitte eine gültige E-Mail-Adresse eingeben.',
+        },
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        item: { id: 'disabled', type: 'text', name: 'name', label: 'Name', content: 'Gesperrt', disabled: true },
+    },
+};

--- a/src/theme/antdM3Theme.ts
+++ b/src/theme/antdM3Theme.ts
@@ -70,5 +70,17 @@ export const buildAdminAntdTheme = ({ seeds, scheme = 'light' }: AdminAntdThemeO
             // M3 sizing (+ WCAG 2.2 target size headroom).
             controlHeight: M3_CONTROL_HEIGHT,
         },
+        components: {
+            // antd's Layout component keeps its own dark-navy defaults
+            // (headerBg/footerBg) independent of the global token set above,
+            // so without this override SiteHeader/SiteFooter render near-black
+            // text on a dark background (see #276).
+            Layout: {
+                headerBg: t('--m3-surface-container-lowest', '#ffffff'),
+                headerColor: t('--m3-on-surface', '#1a1c1e'),
+                footerBg: t('--m3-surface-container-lowest', '#ffffff'),
+                siderBg: t('--m3-surface-container-low', '#f7f3f4'),
+            },
+        },
     };
 };

--- a/tsconfig.storybook.json
+++ b/tsconfig.storybook.json
@@ -11,7 +11,8 @@
         ".storybook/**/*.ts",
         ".storybook/**/*.tsx",
         "src/**/*.stories.ts",
-        "src/**/*.stories.tsx"
+        "src/**/*.stories.tsx",
+        "src/types/**/*.d.ts"
     ],
     "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Problem
Part of the atomic-design Storybook mapping tracked in #276 — the Admin panel's base form atoms had no Storybook coverage, and adding a `Card` story surfaced two design-token bugs.

## Changes
- Add `Atoms/Button`, `Atoms/InputField`, `Atoms/SelectFormField` stories
- Add `Molecules/Card` stories (default, tooltip, loading, dialog variant)
- Fix `Card` tooltip icon: `fill="var(--primary)"` (undefined var) → `var(--m3-primary)`
- Replace hardcoded hex in `Card/styles.module.scss` (`#eae7e8`, `#1b1b1c`, `#444748`×2) with the matching `--m3-*` token references

## Verification
- `npx eslint <changed files> --max-warnings=0` — clean
- `npx prettier --check` — clean
- Manual render check of every new story via Storybook preview (6006), confirmed Card tooltip icon now renders filled correctly

Refs OpenResilienceInitiative/ORISO-Admin#276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Storybook examples for many UI components and form fields, making it easier to preview common states like default, disabled, loading, empty, and required.
  * Added new component previews for navigation, tables, modals, buttons, inputs, switches, checkboxes, and search controls.

* **Bug Fixes**
  * Updated card and layout colors to better match the app’s current theme, improving consistency across headers, footers, dialogs, and tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->