### PR TITLE
test(cypress): fix stale login spec selectors after MUI login-form migration (#229)

### DIFF
--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -5,29 +5,29 @@ describe('login page', () => {
 
     it('displays username and password fields', () => {
         cy.get('form').should('be.visible');
-        cy.get('#basic_username').should('be.visible');
-        cy.get('#basic_password').should('be.visible');
+        cy.get('input[autocomplete="username"]').should('be.visible');
+        cy.get('input[autocomplete="current-password"]').should('be.visible');
     });
 
     it('keeps submit disabled until username and password are filled', () => {
         cy.get('button[type="submit"]').should('be.disabled');
-        cy.get('#basic_username').type('test-user');
+        cy.get('input[autocomplete="username"]').type('test-user');
         cy.get('button[type="submit"]').should('be.disabled');
-        cy.get('#basic_password').type('test-password', { log: false });
+        cy.get('input[autocomplete="current-password"]').type('test-password', { log: false });
         cy.get('button[type="submit"]').should('not.be.disabled');
     });
 
     it('toggles password visibility from the login form', () => {
-        cy.get('#basic_password').type('test-password', { log: false });
-        cy.get('#basic_password').should('have.attr', 'type', 'password');
+        cy.get('input[autocomplete="current-password"]').type('test-password', { log: false });
+        cy.get('input[autocomplete="current-password"]').should('have.attr', 'type', 'password');
         cy.get('[data-testid="password-visibility-toggle"]').should('have.attr', 'aria-pressed', 'false');
 
         cy.get('[data-testid="password-visibility-toggle"]').click();
-        cy.get('#basic_password').should('have.attr', 'type', 'text');
+        cy.get('input[autocomplete="current-password"]').should('have.attr', 'type', 'text');
         cy.get('[data-testid="password-visibility-toggle"]').should('have.attr', 'aria-pressed', 'true');
 
         cy.get('[data-testid="password-visibility-toggle"]').click();
-        cy.get('#basic_password').should('have.attr', 'type', 'password');
+        cy.get('input[autocomplete="current-password"]').should('have.attr', 'type', 'password');
         cy.get('[data-testid="password-visibility-toggle"]').should('have.attr', 'aria-pressed', 'false');
     });
 });


### PR DESCRIPTION
## Context
Validating the Cypress upgrade (#229). Cypress 15.18 verified + runs, but the one login smoke spec still targeted the old antd field ids (`#basic_username` / `#basic_password`) which the MUI-migrated `LoginForm` no longer emits (MUI/antd produce auto-generated ids, no `name`). The spec was red against current code.

## What
- Switch to stable **semantic selectors**: `input[autocomplete="username"]` / `input[autocomplete="current-password"]` (these attributes are explicitly set on the fields and survive the id churn).
- Password-visibility toggle already uses `data-testid`, kept as-is.

## Verification (real E2E via Docker)
- Built `build/` + `docker build` → `docker run oriso-admin -p 9000:80` (nginx serves `/admin/login`, HTTP 200)
- `cypress run` against it: **3 passing, 2 pending** (the credential-gated authenticated suite skips) — was 3 failing before.
- Cypress binary `cypress verify` ✓ (15.18.0).

Part of #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)