### PR TITLE
fix(auth): cover PR 261 review gaps

### DIFF
--- a/src/api/auth/getAccessToken.test.ts
+++ b/src/api/auth/getAccessToken.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FETCH_ERRORS, FetchErrorWithOptions } from '../fetchData';
+import getAccessToken from './getAccessToken';
+
+describe('getAccessToken', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('returns token data for a successful login response', async () => {
+        const loginData = {
+            access_token: 'access-token',
+            expires_in: 300,
+            refresh_token: 'refresh-token',
+            refresh_expires_in: 600,
+        };
+        const fetchMock = vi.fn().mockResolvedValue({
+            status: 200,
+            json: () => Promise.resolve(loginData),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(getAccessToken({ username: 'admin@example.com', password: 'correct' })).resolves.toEqual(
+            loginData,
+        );
+    });
+
+    it('keeps bad credentials as UNAUTHORIZED after the email fallback was tried', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ status: 401 });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(getAccessToken({ username: 'admin@example.com', password: 'wrong' })).rejects.toThrow(
+            FETCH_ERRORS.UNAUTHORIZED,
+        );
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('preserves OTP challenge details for bad requests', async () => {
+        const otpResponse = { otpType: 'APP' };
+        const fetchMock = vi.fn().mockResolvedValue({
+            status: 400,
+            json: () => Promise.resolve(otpResponse),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(getAccessToken({ username: 'admin@example.com', password: 'correct' })).rejects.toMatchObject(
+            new FetchErrorWithOptions(FETCH_ERRORS.BAD_REQUEST, { data: otpResponse }),
+        );
+    });
+
+    it('reports an unreachable auth server as TIMEOUT so the login form can show the network message', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+        await expect(getAccessToken({ username: 'admin@example.com', password: 'correct' })).rejects.toThrow(
+            FETCH_ERRORS.TIMEOUT,
+        );
+    });
+
+    it('reports unexpected auth server responses as TIMEOUT instead of blaming credentials', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 503 }));
+
+        await expect(getAccessToken({ username: 'admin@example.com', password: 'correct' })).rejects.toThrow(
+            FETCH_ERRORS.TIMEOUT,
+        );
+    });
+});

--- a/src/api/auth/getAccessToken.ts
+++ b/src/api/auth/getAccessToken.ts
@@ -55,11 +55,11 @@ const getKeycloakAccessToken = (loginProps: {
                         reject(new Error(FETCH_ERRORS.UNAUTHORIZED));
                     }
                 } else {
-                    reject(new Error('keycloakLogin'));
+                    reject(new Error(FETCH_ERRORS.TIMEOUT));
                 }
             })
             .catch(() => {
-                reject(new Error('keycloakLogin'));
+                reject(new Error(FETCH_ERRORS.TIMEOUT));
             });
     });
 

--- a/src/components/ErrorBoundary/index.test.tsx
+++ b/src/components/ErrorBoundary/index.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Link, MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { ErrorBoundary } from './index';
 
 vi.mock('i18next', () => ({
@@ -11,6 +12,23 @@ const Bomb = ({ shouldThrow }: { shouldThrow: boolean }) => {
         throw new Error('boom');
     }
     return <div>page content</div>;
+};
+
+const RoutedPageBoundaryHarness = () => {
+    const location = useLocation();
+
+    return (
+        <>
+            <nav>Admin navigation</nav>
+            <Link to="/admin/healthy">Healthy page</Link>
+            <ErrorBoundary scope="page" resetKeys={[location.pathname]}>
+                <Routes>
+                    <Route path="/admin/broken" element={<Bomb shouldThrow />} />
+                    <Route path="/admin/healthy" element={<Bomb shouldThrow={false} />} />
+                </Routes>
+            </ErrorBoundary>
+        </>
+    );
 };
 
 describe('ErrorBoundary', () => {
@@ -78,5 +96,22 @@ describe('ErrorBoundary', () => {
         );
 
         expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('keeps layout navigation mounted and resets the page fallback after route navigation', () => {
+        render(
+            <MemoryRouter initialEntries={['/admin/broken']}>
+                <RoutedPageBoundaryHarness />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('Admin navigation')).toBeInTheDocument();
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('link', { name: 'Healthy page' }));
+
+        expect(screen.getByText('Admin navigation')).toBeInTheDocument();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        expect(screen.getByText('page content')).toBeInTheDocument();
     });
 });

--- a/src/context/FeatureContext.test.tsx
+++ b/src/context/FeatureContext.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FeatureFlag } from '../enums/FeatureFlag';
 import { FeatureProvider, useFeatureContext } from './FeatureContext';
 
@@ -39,6 +39,10 @@ const FeatureConsumer = () => {
 };
 
 describe('FeatureContext', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('maps tenant and public tenant settings to feature flags', () => {
         render(
             <FeatureProvider tenantData={tenantData} publicTenantData={publicTenantData}>
@@ -63,5 +67,22 @@ describe('FeatureContext', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Toggle developer' }));
 
         expect(screen.getByLabelText('developer')).toHaveTextContent('true');
+    });
+
+    it('degrades to all flags off outside the provider without noisy error logging', () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        render(<FeatureConsumer />);
+
+        expect(screen.getByLabelText('appointments')).toHaveTextContent('false');
+        expect(screen.getByLabelText('topics')).toHaveTextContent('false');
+        expect(screen.getByLabelText('registration-topics')).toHaveTextContent('false');
+        expect(screen.getByLabelText('group-chat')).toHaveTextContent('false');
+        expect(screen.getByLabelText('developer')).toHaveTextContent('false');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Toggle developer' }));
+
+        expect(screen.getByLabelText('developer')).toHaveTextContent('false');
+        expect(consoleError).not.toHaveBeenCalled();
     });
 });

--- a/src/context/FeatureContext.tsx
+++ b/src/context/FeatureContext.tsx
@@ -4,6 +4,8 @@ import { IFeature } from '../types/feature';
 import { TenantData } from '../types/tenant';
 
 const FeatureContext = createContext<[IFeature[], (features: IFeature[]) => void]>(null);
+const NO_FEATURES: IFeature[] = [];
+const ignoreFeatureUpdates = () => undefined;
 
 interface FeatureProviderProps {
     children: ReactNode;
@@ -55,14 +57,9 @@ const FeatureProvider = ({ children, tenantData, publicTenantData }: FeatureProv
 function useFeatureContext() {
     const contextValue = useContext(FeatureContext);
 
-    if (!contextValue) {
-        // eslint-disable-next-line no-console
-        console.error('useFeatureContext used outside of FeatureProvider; all feature flags read as disabled.');
-    }
-
     // Degrade to "all flags off" instead of crashing the tree when the
     // provider is missing (e.g. on public pages).
-    const [features, setFeatures] = contextValue ?? [[] as IFeature[], () => undefined];
+    const [features, setFeatures] = contextValue ?? [NO_FEATURES, ignoreFeatureUpdates];
 
     const isEnabled = useCallback(
         (name: FeatureFlag) => {

--- a/src/hooks/useLoginMutation.hook.test.tsx
+++ b/src/hooks/useLoginMutation.hook.test.tsx
@@ -157,6 +157,25 @@ describe('useLoginMutation', () => {
         expect(mocks.setTokens).not.toHaveBeenCalled();
     });
 
+    it('reports an unreachable auth server before the tenant access check as TIMEOUT', async () => {
+        const user = userEvent.setup();
+        mocks.getAccessToken.mockRejectedValue(new Error('TIMEOUT'));
+        renderLoginMutation();
+
+        await user.click(screen.getByRole('button', { name: 'Login' }));
+
+        await waitFor(() => {
+            expect(mocks.onError).toHaveBeenCalledWith(
+                new Error('TIMEOUT'),
+                { username: 'admin@example.com', password: 'correct-password', otp: '123456' },
+                undefined,
+                expect.anything(),
+            );
+        });
+        expect(mocks.fetchData).not.toHaveBeenCalled();
+        expect(mocks.setTokens).not.toHaveBeenCalled();
+    });
+
     it('reports a denied tenant access check as TENANT_ACCESS_DENIED', async () => {
         const user = userEvent.setup();
         mocks.fetchData.mockRejectedValue(new Error('API call error: 401 Unauthorized'));


### PR DESCRIPTION
## Problem

Follow-up for review gaps found after PR #261: auth-server failures could still look like credential errors, and two graceful-degradation paths needed stronger tests.

Closes #279. Follow-up to #261.

## Changes

- Map initial auth-token server/fetch failures to the existing network error path instead of `keycloakLogin`
- Add direct `getAccessToken` tests for success, bad credentials, OTP challenge, fetch failure, and unexpected server responses
- Add `useLoginMutation` coverage for auth-server failure before tenant access is checked
- Add routed page-boundary coverage proving layout navigation remains mounted and fallback resets after route navigation
- Make `useFeatureContext` fallback quiet and cover outside-provider behavior

## Verification

- `npm run test -- src/api/auth/getAccessToken.test.ts src/hooks/useLoginMutation.hook.test.tsx src/components/ErrorBoundary/index.test.tsx src/context/FeatureContext.test.tsx`
- `npx tsc --noEmit`
- `npx eslint src/api/auth/getAccessToken.ts src/api/auth/getAccessToken.test.ts src/hooks/useLoginMutation.hook.test.tsx src/context/FeatureContext.tsx src/context/FeatureContext.test.tsx src/components/ErrorBoundary/index.test.tsx --max-warnings=0`
- `npx prettier --check src/api/auth/getAccessToken.ts src/api/auth/getAccessToken.test.ts src/hooks/useLoginMutation.hook.test.tsx src/context/FeatureContext.tsx src/context/FeatureContext.test.tsx src/components/ErrorBoundary/index.test.tsx`
- `git diff --check`
