### PR TITLE
feat: replace admin panel switches with M3Switch

### DIFF
--- a/src/components/FormSwitchField/FormSwitchField.stories.tsx
+++ b/src/components/FormSwitchField/FormSwitchField.stories.tsx
@@ -22,12 +22,17 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** Default antd Switch rendering. */
+/** Default M3-styled switch rendering (see also Atoms/M3Switch). */
+export const Default: Story = {
+    args: { switchLabel: 'Benachrichtigungen' },
+};
+
+/** Legacy antd Switch rendering. */
 export const AntdVariant: Story = {
     args: { switchVariant: 'antd' },
 };
 
-/** M3-styled switch rendering (see also Atoms/M3Switch). */
+/** Explicit M3-styled switch rendering. */
 export const M3Variant: Story = {
     args: { switchVariant: 'm3', switchLabel: 'Benachrichtigungen' },
 };

--- a/src/components/FormSwitchField/index.tsx
+++ b/src/components/FormSwitchField/index.tsx
@@ -94,7 +94,7 @@ export const FormSwitchField = ({
     checkedKey = 'yes',
     unCheckedKey = 'no',
     switchLabel,
-    switchVariant = 'antd',
+    switchVariant = 'm3',
 }: FormSwitchFieldProps) => {
     const [t] = useTranslation();
     const message = errorMessage || t('form.errors.required');

--- a/src/pages/Profile/TwoFactorAuth/TwoFactorAuth.tsx
+++ b/src/pages/Profile/TwoFactorAuth/TwoFactorAuth.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
-import { Typography, Switch } from 'antd';
+import { Typography } from 'antd';
 import { useTranslation } from 'react-i18next';
+import { M3Switch } from '../../../components/M3Switch';
 import { FETCH_ERRORS } from '../../../api/fetchData';
 import { OVERLAY_FUNCTIONS, OverlayItem, OverlayWrapper, Overlay } from '../../../components/overlay/Overlay';
 import { BUTTON_TYPES } from '../../../components/button/Button';
@@ -414,10 +415,14 @@ const TwoFactorAuth = () => {
     return (
         <>
             <div className="twoFactorAuth__switch mb-m">
-                <Switch
-                    size="default"
-                    onChange={handleSwitchChange}
+                <M3Switch
+                    onChange={() => handleSwitchChange()}
                     checked={userData?.twoFactorAuth.isActive || false}
+                    label={
+                        userData?.twoFactorAuth.isActive
+                            ? t('twoFactorAuth.switch.active.label')
+                            : t('twoFactorAuth.switch.deactive.label')
+                    }
                 />
                 <Paragraph className="text desc">
                     {userData?.twoFactorAuth.isActive

--- a/src/pages/Topics/List/TopicList.tsx
+++ b/src/pages/Topics/List/TopicList.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Modal, Space, Switch } from 'antd';
+import { Button, Modal, Space } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import { ColumnProps } from 'antd/lib/table';
 import { InterestsOutlined } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
+import { M3Switch } from '../../../components/M3Switch';
 import { TopicData } from '../../../types/topic';
 import { Status } from '../../../types/status';
 import { TopicDeletionModal } from './TopicDeletionModal';
@@ -184,7 +185,11 @@ export const TopicList = () => {
 
                 {canShowTopicSwitch && (
                     <>
-                        <Switch checked={isTopicsFeatureActive} onClick={onTopicsSwitch} />
+                        <M3Switch
+                            checked={isTopicsFeatureActive}
+                            label={t('topics.featureToggle')}
+                            onChange={() => onTopicsSwitch()}
+                        />
                         {t('topics.featureToggle')}
                     </>
                 )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates all admin panel toggle switches to the Material 3 `M3Switch` component to align with Storybook design system atoms.

## Changes

- **FormSwitchField**: Default `switchVariant` changed from `antd` to `m3`, so all existing form toggles (tenant settings, global settings, user edit, agency registration, topics, legal, notifications, etc.) now render `M3Switch` automatically.
- **TopicList**: Replaced standalone antd `Switch` on the topics feature toggle with `M3Switch`.
- **TwoFactorAuth**: Replaced antd `Switch` on the 2FA activation toggle with `M3Switch`.
- **Storybook**: Updated `FormSwitchField` stories — M3 is now the default story; antd variant retained for legacy reference.

## Testing

- `npm run test -- --run src/components/M3Switch/index.test.tsx` — passed
- `npm run lint:js` on changed files — passed
- `npm run typecheck:storybook` — passed
- Storybook running at http://localhost:6006/
- Admin panel running at http://localhost:9000/admin

## Notes

- `PermissionsSettings` already used `M3Switch` via `CheckToggle`; no change needed there.
- `FormSwitchField` still supports `switchVariant="antd"` for any legacy use cases.
- Remaining antd `Switch` usage is limited to the legacy variant inside `FormSwitchField` and theme bridge Storybook demos.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c38f6ffe-fa59-4225-8add-6831e84fc093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c38f6ffe-fa59-4225-8add-6831e84fc093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

