### PR TITLE
feat: Storybook-aligned admin UI, theme, cards, forms & legal editors

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.0.1",
+    "configurations": [
+        {
+            "name": "storybook-admin",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": ["run", "storybook", "--", "-p", "6099", "--no-open", "--ci"],
+            "port": 6099
+        }
+    ]
+}

--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,4 @@ src/vite-env.d.ts
 build
 vitest.config.ts
 vite.authBffPlugin.ts
+public/mockServiceWorker.js

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -6,7 +6,8 @@ import { mergeConfig } from 'vite';
 // at http://localhost:6006/mcp. antd v4 styling needs less { javascriptEnabled }.
 const config: StorybookConfig = {
     stories: ['../src/**/*.stories.@(ts|tsx)'],
-    addons: ['@storybook/addon-mcp', '@storybook/addon-designs'],
+    // addon-a11y runs axe (WCAG 2.2 AA) against each story in the a11y panel + test-runner.
+    addons: ['@storybook/addon-mcp', '@storybook/addon-designs', '@storybook/addon-a11y'],
     framework: { name: '@storybook/react-vite', options: {} },
     core: { disableTelemetry: true },
     // Serve public/ so MSW's generated service worker (public/mockServiceWorker.js) is reachable.

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -9,6 +9,8 @@ const config: StorybookConfig = {
     addons: ['@storybook/addon-mcp', '@storybook/addon-designs'],
     framework: { name: '@storybook/react-vite', options: {} },
     core: { disableTelemetry: true },
+    // Serve public/ so MSW's generated service worker (public/mockServiceWorker.js) is reachable.
+    staticDirs: ['../public'],
     async viteFinal(cfg) {
         // Drop app-only plugins that are noisy or meaningless inside Storybook
         // (eslint linting, runtime-env middleware, auth BFF dev proxy, bundle

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ConfigProvider } from 'antd';
 import de_DE from 'antd/es/locale/de_DE';
+import { initialize, mswLoader } from 'msw-storybook-addon';
 import { buildAdminAntdTheme } from '../src/theme/antdM3Theme';
 
 // Global Admin styling: antd v5 reset + app less/overrides. Mirrors src/App.tsx.
@@ -12,6 +13,10 @@ import '../src/styles/App.less';
 import '../src/app.css';
 // Initialise the shared i18next instance (side-effect import).
 import '../src/i18n';
+
+// Start the MSW request-mocking worker. Stories opt in with `parameters.msw.handlers`;
+// everything else passes through untouched (`onUnhandledRequest: 'bypass'`).
+initialize({ onUnhandledRequest: 'bypass' });
 
 const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -24,6 +29,7 @@ const preview: Preview = {
             storySort: { order: ['Atoms', 'Molecules', 'Organisms', '*'] },
         },
     },
+    loaders: [mswLoader],
     decorators: [
         (Story) => (
             <QueryClientProvider client={queryClient}>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -28,6 +28,10 @@ const preview: Preview = {
         options: {
             storySort: { order: ['Atoms', 'Molecules', 'Organisms', '*'] },
         },
+        // Run axe against the WCAG 2.2 AA rule set (addon-a11y panel + test-runner).
+        a11y: {
+            options: { runOnly: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'] },
+        },
     },
     loaders: [mswLoader],
     decorators: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,8 @@
         "eslint-plugin-react-hooks": "^4.3.0",
         "jsdom": "^23.2.0",
         "less": "^4.2.0",
+        "msw": "^2.15.0",
+        "msw-storybook-addon": "^2.0.7",
         "postcss": "^8.4.6",
         "postcss-less": "^6.0.0",
         "prettier": "^2.5.1",
@@ -2986,6 +2988,106 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz",
@@ -3128,6 +3230,31 @@
       "peerDependencies": {
         "@types/react": "17 || 18 || 19"
       }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "9.1.2",
@@ -3457,6 +3584,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
       "version": "0.127.0",
@@ -6497,6 +6649,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
@@ -6508,6 +6670,13 @@
       "version": "2.3.10",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
       "integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8109,6 +8278,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -10183,6 +10362,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -10199,6 +10395,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -10764,6 +10970,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -10883,6 +11099,24 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/headers-polyfill/node_modules/set-cookie-parser": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hi-base32": {
       "version": "0.5.1",
@@ -11533,6 +11767,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -13178,6 +13419,157 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.15.0.tgz",
+      "integrity": "sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw-storybook-addon": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-2.0.7.tgz",
+      "integrity": "sha512-TGmlxXy2TsaB6QcClVKRxqvay5f93xoLguHOihRFQ+gIEIyiyvcoQjkEeuOe7Y9qvddzGB1LyFomzPo9/EpnuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.0.1"
+      },
+      "peerDependencies": {
+        "msw": "^2.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/msw/node_modules/tldts": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.8"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/msw/node_modules/tldts-core": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw/node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/msw/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/multimatch": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
@@ -13206,6 +13598,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/nanoid": {
@@ -13577,6 +13979,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -13818,6 +14227,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -15746,6 +16162,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -16537,6 +16960,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -16758,6 +17191,13 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
@@ -17365,6 +17805,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/text-table": {
@@ -18085,6 +18538,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/untildify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@babel/core": "^7.17.2",
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-typescript": "^7.16.7",
+        "@storybook/addon-a11y": "^10.4.6",
         "@storybook/addon-designs": "^11.1.3",
         "@storybook/addon-mcp": "^0.6.0",
         "@storybook/react-vite": "^10.4.6",
@@ -5119,6 +5120,24 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.4.6.tgz",
+      "integrity": "sha512-XCJy+f0DFOiCgUU9knRDlLDxVFI+AAQ3/wE/NF85zB9iDPPS2DwkSN+mas3zDgHt66zhN8Cq3/UiyCDUweV9Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.4.6"
+      }
     },
     "node_modules/@storybook/addon-designs": {
       "version": "11.1.3",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,8 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "jsdom": "^23.2.0",
     "less": "^4.2.0",
+    "msw": "^2.15.0",
+    "msw-storybook-addon": "^2.0.7",
     "postcss": "^8.4.6",
     "postcss-less": "^6.0.0",
     "prettier": "^2.5.1",
@@ -148,5 +150,10 @@
   "overrides": {
     "@types/react": "$@types/react",
     "@types/react-dom": "$@types/react-dom"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@babel/core": "^7.17.2",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-typescript": "^7.16.7",
+    "@storybook/addon-a11y": "^10.4.6",
     "@storybook/addon-designs": "^11.1.3",
     "@storybook/addon-mcp": "^0.6.0",
     "@storybook/react-vite": "^10.4.6",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,361 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.15.0'
+const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Omit the body of server-sent event stream responses.
+    // Cloning such responses would prevent client-side stream cancelations
+    // from reaching the original stream (a teed stream only cancels its
+    // source once both of its branches cancel) and would buffer the
+    // entire stream into the unconsumed clone indefinitely.
+    const isEventStreamResponse = response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .startsWith('text/event-stream')
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = isEventStreamResponse ? null : response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: response.type,
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: responseClone ? responseClone.body : null,
+          },
+        },
+      },
+      responseClone && responseClone.body
+        ? [serializedRequest.body, responseClone.body]
+        : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { useUserRoles } from './hooks/useUserRoles.hook';
 import { UserRole } from './enums/UserRole';
 import { canReadCaseHandoverAdmin, canSeeSupervisorLogs } from './constants/caseHandoverAccess';
 import { useAppConfigContext } from './context/useAppConfig';
-import { useAdminInvertedTheme } from './hooks/useAdminInvertedTheme.hook';
+import { useAdminTheme } from './hooks/useAdminTheme.hook';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import {
     LazyAgencyList,
@@ -70,7 +70,7 @@ export const App = () => {
         isFetched: isPublicTenantFetched,
     } = usePublicTenantData();
     const { isLoading, data } = useTenantData();
-    useAdminInvertedTheme(publicTenantData?.theming, isPublicTenantFetched || !isPublicTenantLoading);
+    useAdminTheme(publicTenantData?.theming, isPublicTenantFetched || !isPublicTenantLoading);
     const { settings } = useAppConfigContext();
     const navigate = useNavigate();
     const location = useLocation();

--- a/src/components/Card/styles.module.scss
+++ b/src/components/Card/styles.module.scss
@@ -2,6 +2,17 @@
     height: 100%;
 }
 
+/* Default card surface. Matches the M3 gray card used consistently across the
+   admin (dialog cards, functionality cards) so there are no more white cards:
+   gray surface + subtle border + rounded corners. */
+
+.card {
+    border: 1px solid color-mix(in srgb, var(--m3-outline, #747878) 22%, transparent);
+    background: var(--admin-form-card-surface, var(--m3-surface-container-high, #eae7e8));
+    border-radius: 28px;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 30%), 0 1px 3px 1px rgb(0 0 0 / 15%);
+}
+
 .contentClassName {
     display: flex;
     height: 100%;
@@ -18,20 +29,19 @@
     --input-label-bg: var(--admin-form-field-surface);
 
     display: flex;
-    height: var(--dialog-card-height, clamp(560px, 62dvh, 640px));
-    max-height: var(--dialog-card-max-height, calc(100dvh - 320px));
-    min-height: 0;
+    overflow: visible;
+    height: auto;
+    min-height: var(--dialog-card-min-height, 400px);
     flex-direction: column;
     padding: 0;
-    overflow: hidden;
-    border-radius: 28px;
     background: var(--m3-surface-container-high);
-    font-synthesis: none;
+    border-radius: 28px;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 30%), 0 1px 3px 1px rgb(0 0 0 / 15%);
     font-family: var(--m3-body-font-family);
     -moz-osx-font-smoothing: auto;
     -webkit-font-smoothing: subpixel-antialiased;
-    box-shadow: 0 1px 2px rgb(0 0 0 / 30%), 0 1px 3px 1px rgb(0 0 0 / 15%);
-    text-rendering: optimizeLegibility;
+    font-synthesis: none;
+    text-rendering: optimizelegibility;
 }
 
 .dialogAutoHeight {
@@ -49,9 +59,9 @@
 }
 
 .dialogCardTitle {
-    justify-content: center;
-    margin-bottom: 0;
+    justify-content: flex-start;
     padding: 24px 24px 0;
+    margin-bottom: 0;
 }
 
 .titleContainer {
@@ -65,18 +75,18 @@
 
 .dialogTitleContainer {
     width: 100%;
+    flex-direction: row;
     align-items: center;
-    flex-direction: column;
-    gap: 16px;
-    text-align: center;
+    gap: 8px;
+    text-align: left;
 
     .title {
         color: var(--m3-on-surface);
         font-family: var(--m3-body-font-family);
-        font-size: 24px;
-        font-weight: 400;
-        line-height: 32px;
-        text-align: center;
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 28px;
+        text-align: left;
     }
 }
 
@@ -97,18 +107,18 @@
 }
 
 .cardSubTitle {
+    margin-top: 5px;
     margin-bottom: 20px;
     color: var(--label-color);
     font-size: 14px;
     font-weight: 400;
     line-height: 16px;
-    margin-top: 5px;
     white-space: pre-line;
 }
 
 .dialogCardSubTitle {
-    margin: 16px 0 0;
     padding: 0 24px;
+    margin: 16px 0 0;
     color: var(--m3-on-surface-variant);
     font-family: var(--m3-body-font-family);
     font-size: 14px;
@@ -125,9 +135,10 @@
 
 .dialogContainer {
     display: flex;
+    overflow: visible;
     min-height: 0;
     flex-direction: column;
-    overflow: hidden;
+    padding: 20px 24px 24px;
 
     :global {
         .ant-row:not(.ant-form-item-row) {

--- a/src/components/CardDeck/styles.module.scss
+++ b/src/components/CardDeck/styles.module.scss
@@ -10,14 +10,14 @@
     width: 100%;
     min-width: 0;
     flex: 1 1 auto;
+    padding: var(--card-deck-padding, 0 4px 8px);
+    -webkit-overflow-scrolling: touch;
     overflow-x: auto;
     overflow-y: hidden;
-    padding: var(--card-deck-padding, 0 4px 8px);
+    overscroll-behavior-x: contain;
     scroll-behavior: smooth;
     scroll-snap-type: x proximity;
     scrollbar-width: none;
-    overscroll-behavior-x: contain;
-    -webkit-overflow-scrolling: touch;
     touch-action: pan-x pan-y;
 
     &::-webkit-scrollbar {
@@ -27,11 +27,11 @@
 
 .list {
     display: flex;
-    align-items: stretch;
-    gap: var(--card-deck-gap, 24px);
     min-width: max-content;
-    margin: 0;
+    align-items: flex-start;
     padding: 0;
+    margin: 0;
+    gap: 24px;
     list-style: none;
 }
 
@@ -51,8 +51,8 @@
     z-index: 20;
     bottom: var(--card-deck-footer-bottom, 28px);
     flex: 0 0 auto;
-    margin-top: auto;
     padding: var(--card-deck-footer-padding, 0 24px);
+    margin-top: auto;
     pointer-events: none;
 
     :global(button) {
@@ -66,9 +66,9 @@
     }
 
     .deck {
-        gap: var(--card-deck-mobile-gap, 24px);
         overflow: visible;
         padding: var(--card-deck-mobile-padding, 0);
+        gap: var(--card-deck-mobile-gap, 24px);
         scroll-snap-type: none;
     }
 

--- a/src/components/CardEditable/styles.module.scss
+++ b/src/components/CardEditable/styles.module.scss
@@ -24,11 +24,8 @@
     min-height: 0;
     min-width: 0;
     flex-direction: column;
-    overflow-x: hidden;
-    overflow-y: auto;
-    overscroll-behavior: contain;
+    overflow: visible;
     padding: 20px 24px 0;
-    scrollbar-gutter: stable;
 
     :global {
         .ant-row:not(.ant-form-item-row) {

--- a/src/components/ColorSelector/ColorSelector.stories.tsx
+++ b/src/components/ColorSelector/ColorSelector.stories.tsx
@@ -1,0 +1,35 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import ColorSelector from './ColorSelector';
+
+/** Wrapper that owns the color state so the picker is interactive in the story. */
+const StatefulColorSelector = (args: ComponentProps<typeof ColorSelector>) => {
+    const [color, setColor] = useState(args.tenantColor);
+    return <ColorSelector {...args} tenantColor={color} setColorValue={(_field, value) => setColor(value)} />;
+};
+
+const meta = {
+    title: 'Molecules/ColorSelector',
+    component: ColorSelector,
+    parameters: { layout: 'padded' },
+    args: {
+        isLoading: false,
+        label: 'Primärfarbe',
+        field: 'primaryColor',
+        tenantColor: '#0a4a7a',
+        setColorValue: () => {},
+    },
+} satisfies Meta<typeof ColorSelector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Swatch + HEX readout; click the swatch to open the picker. Interactive. */
+export const Default: Story = {
+    render: (args) => <StatefulColorSelector {...args} />,
+};
+
+/** Disabled while the tenant settings are saving. */
+export const Loading: Story = {
+    args: { isLoading: true },
+};

--- a/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CopyToClipboard } from './index';
+
+const meta = {
+    title: 'Molecules/CopyToClipboard',
+    component: CopyToClipboard,
+    parameters: { layout: 'padded' },
+    args: {
+        children: 'https://beratung.example.org/agency/42',
+    },
+} satisfies Meta<typeof CopyToClipboard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Renders its text next to a copy icon; clicking copies and shows a success toast. */
+export const Default: Story = {};
+
+/** Short token — useful for IDs / slugs. */
+export const ShortValue: Story = {
+    args: { children: 'AB12-CD34' },
+};

--- a/src/components/CreateConsultantModal/index.tsx
+++ b/src/components/CreateConsultantModal/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { FETCH_ERRORS, X_REASON } from '../../api/fetchData';
 import { UnsavedChangesModal } from '../CardEditable/components/UnsavedChanges';
 import { FormInputField } from '../FormInputField';
-import { FormPasswordField } from '../FormPasswordField';
+import { FormInputPasswordField } from '../FormInputPasswordField';
 import { TypeOfUser } from '../../enums/TypeOfUser';
 import { useAddOrUpdateConsultantOrAdmin } from '../../hooks/useAddOrUpdateConsultantOrAgencyAdmin';
 import { CounselorData } from '../../types/counselor';
@@ -158,7 +158,7 @@ export const CreateConsultantModal = ({ tenantId, disabled, onSuccess }: CreateC
                             },
                         ]}
                     />
-                    <FormPasswordField
+                    <FormInputPasswordField
                         name="password"
                         labelKey="counselor.password"
                         placeholderKey="placeholder.password"
@@ -174,7 +174,7 @@ export const CreateConsultantModal = ({ tenantId, disabled, onSuccess }: CreateC
                             },
                         ]}
                     />
-                    <FormPasswordField
+                    <FormInputPasswordField
                         name="passwordConfirmation"
                         labelKey="counselor.passwordConfirmation"
                         placeholderKey="placeholder.password"

--- a/src/components/CustomIcons/CustomIcons.stories.tsx
+++ b/src/components/CustomIcons/CustomIcons.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import ChevronDown from './ChevronDown';
+import ChevronUp from './ChevronUp';
+import Info from './Info';
+import Lock from './Lock';
+import Person from './Person';
+import Verified from './Verified';
+
+const ICONS = [
+    { name: 'ChevronDown', Component: ChevronDown },
+    { name: 'ChevronUp', Component: ChevronUp },
+    { name: 'Info', Component: Info },
+    { name: 'Lock', Component: Lock },
+    { name: 'Person', Component: Person },
+    { name: 'Verified', Component: Verified },
+];
+
+/**
+ * The admin's custom SVG icon set, wrapped as antd `<Icon>` components so they inherit
+ * `color`, `fontSize`, and the antd icon API (spread props). Use these instead of
+ * inlining raw SVGs.
+ */
+const meta = {
+    title: 'Atoms/CustomIcons',
+    component: Info,
+    parameters: { layout: 'padded' },
+} satisfies Meta<typeof Info>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Every icon in the set at a shared size. */
+export const Gallery: Story = {
+    render: () => (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 24 }}>
+            {ICONS.map(({ name, Component }) => (
+                <div key={name} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+                    <Component style={{ fontSize: 28 }} />
+                    <span style={{ fontSize: 12, color: 'var(--on-surface-variant)' }}>{name}</span>
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+/** Icons inherit `color` and `fontSize` from props like any antd icon. */
+export const Colored: Story = {
+    render: () => (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
+            <Info style={{ fontSize: 20, color: 'var(--primary)' }} />
+            <Info style={{ fontSize: 28, color: 'var(--error)' }} />
+            <Info style={{ fontSize: 36, color: 'var(--on-surface-variant)' }} />
+        </div>
+    ),
+};

--- a/src/components/EditButton/EditButton.stories.tsx
+++ b/src/components/EditButton/EditButton.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { EditButton } from './index';
+
+const meta = {
+    title: 'Atoms/EditButton',
+    component: EditButton,
+    parameters: { layout: 'padded' },
+    args: {
+        onClick: () => {},
+    },
+} satisfies Meta<typeof EditButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Pen icon plus the localized "edit" label. */
+export const Default: Story = {};
+
+/** Icon-only affordance (e.g. inside dense table rows). */
+export const IconOnly: Story = {
+    args: { showLabel: false },
+};
+
+export const Disabled: Story = {
+    args: { disabled: true },
+};
+
+/** Custom label overriding the default i18n key. */
+export const CustomLabel: Story = {
+    args: { label: 'Bearbeiten' },
+};

--- a/src/components/FileUploader/FileUploader.stories.tsx
+++ b/src/components/FileUploader/FileUploader.stories.tsx
@@ -1,0 +1,47 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form } from 'antd';
+import FileUploader from './FileUploader';
+
+/** Wrapper that owns the preview URL so uploading updates the card in the story. */
+const StatefulFileUploader = (args: ComponentProps<typeof FileUploader>) => {
+    const [imageUrl, setImageUrl] = useState<string>(args.imageUrl || '');
+    return <FileUploader {...args} imageUrl={imageUrl} setImageUrl={setImageUrl} />;
+};
+
+const meta = {
+    title: 'Molecules/FileUploader',
+    component: FileUploader,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <Form style={{ maxWidth: 360 }}>
+                <Story />
+            </Form>
+        ),
+    ],
+    args: {
+        name: 'logo',
+        label: 'Logo',
+        getValueFromEvent: (e) => e,
+        imageUrl: '',
+        setImageUrl: () => {},
+    },
+} satisfies Meta<typeof FileUploader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Empty picture-card that accepts JPG/PNG (and .ico for favicons) up to 512 kB. */
+export const Empty: Story = {
+    render: (args) => <StatefulFileUploader {...args} />,
+};
+
+/** Populated state — the selected image (base64 data URL) fills the card. */
+export const WithPreview: Story = {
+    args: {
+        // 1x1 transparent PNG, stands in for an uploaded image.
+        imageUrl:
+            'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+    },
+};

--- a/src/components/FormPasswordField/index.tsx
+++ b/src/components/FormPasswordField/index.tsx
@@ -1,6 +1,0 @@
-import { Input } from 'antd';
-import { FormBaseInputField, FormBaseInputFieldProps } from '../FormBaseInputField';
-
-export const FormPasswordField = (props: Omit<FormBaseInputFieldProps, 'component'>) => {
-    return <FormBaseInputField {...props} component={Input.Password} />;
-};

--- a/src/components/FormPluginEditor/FormPluginEditor.styles.scss
+++ b/src/components/FormPluginEditor/FormPluginEditor.styles.scss
@@ -23,8 +23,8 @@
         cursor: text;
         font-size: 16px;
         padding: 30px;
-        height: 400px;
-        overflow: auto;
+        min-height: 400px;
+        overflow: visible;
 
         .public-DraftEditorPlaceholder-root,
         .public-DraftEditor-content {

--- a/src/components/FormPluginEditor/M3RichTextEditor.module.scss
+++ b/src/components/FormPluginEditor/M3RichTextEditor.module.scss
@@ -196,6 +196,13 @@ $m3-state-active: rgba(39, 50, 112, 0.12);
     padding: 0 16px;
 }
 
+// Horizontal inset for arbitrary editor content (aboveEditorSlot / editorSlot)
+// so it lines up with the toolbar and editor surface instead of sitting flush
+// against the card edges.
+.contentInset {
+    padding: 0 16px;
+}
+
 .editor {
     min-height: 280px;
     padding: 16px;

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -422,9 +422,11 @@ export const M3RichTextEditor = ({
 
             {!editorSlot && !readOnly && <Toolbar editor={editor} />}
 
-            {aboveEditorSlot}
+            {aboveEditorSlot && <div className={styles.contentInset}>{aboveEditorSlot}</div>}
 
-            {editorSlot ?? (
+            {editorSlot ? (
+                <div className={styles.contentInset}>{editorSlot}</div>
+            ) : (
                 <div className={styles.editorWrap}>
                     <div className={styles.editor}>
                         <EditorContent editor={editor} />

--- a/src/components/FormSwitchField/FormSwitchField.stories.tsx
+++ b/src/components/FormSwitchField/FormSwitchField.stories.tsx
@@ -22,12 +22,17 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** Default antd Switch rendering. */
+/** Default M3-styled switch rendering (see also Atoms/M3Switch). */
+export const Default: Story = {
+    args: { switchLabel: 'Benachrichtigungen' },
+};
+
+/** Legacy antd Switch rendering. */
 export const AntdVariant: Story = {
     args: { switchVariant: 'antd' },
 };
 
-/** M3-styled switch rendering (see also Atoms/M3Switch). */
+/** Explicit M3-styled switch rendering. */
 export const M3Variant: Story = {
     args: { switchVariant: 'm3', switchLabel: 'Benachrichtigungen' },
 };

--- a/src/components/FormSwitchField/index.tsx
+++ b/src/components/FormSwitchField/index.tsx
@@ -62,7 +62,19 @@ const FormSwitchFieldLocal = ({
     return (
         <div className="formSwitchField__container">
             {switchVariant === 'm3' ? (
-                <M3Switch disabled={isDisabled} label={switchLabel} onChange={onSwitchChange} checked={fieldChecked} />
+                <>
+                    <M3Switch
+                        disabled={isDisabled}
+                        label={switchLabel}
+                        onChange={onSwitchChange}
+                        checked={fieldChecked}
+                    />
+                    {!disableLabels && (
+                        <span className="formSwitchField__stateLabel">
+                            {t(fieldChecked ? checkedKey : unCheckedKey)}
+                        </span>
+                    )}
+                </>
             ) : (
                 <Switch
                     disabled={isDisabled}

--- a/src/components/FormSwitchField/index.tsx
+++ b/src/components/FormSwitchField/index.tsx
@@ -94,7 +94,7 @@ export const FormSwitchField = ({
     checkedKey = 'yes',
     unCheckedKey = 'no',
     switchLabel,
-    switchVariant = 'antd',
+    switchVariant = 'm3',
 }: FormSwitchFieldProps) => {
     const [t] = useTranslation();
     const message = errorMessage || t('form.errors.required');

--- a/src/components/GrantConsultantIdentityModal/GrantConsultantIdentityModal.stories.tsx
+++ b/src/components/GrantConsultantIdentityModal/GrantConsultantIdentityModal.stories.tsx
@@ -78,3 +78,14 @@ export const EmptyAgencies: Story = {
     },
     play: openModal,
 };
+
+/**
+ * Error: the agencies request fails (500). `getAgencyData` shows an error toast and the
+ * query yields no data, so the select degrades to an empty (no-options) state.
+ */
+export const Error: Story = {
+    parameters: {
+        msw: { handlers: [http.get(AGENCY_ENDPOINT, () => new HttpResponse(null, { status: 500 }))] },
+    },
+    play: openModal,
+};

--- a/src/components/GrantConsultantIdentityModal/GrantConsultantIdentityModal.stories.tsx
+++ b/src/components/GrantConsultantIdentityModal/GrantConsultantIdentityModal.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse, delay } from 'msw';
+// eslint-disable-next-line import/no-unresolved -- exports-map subpath the eslint node resolver can't see (resolves for tsc/Vite)
+import { within, userEvent, screen } from 'storybook/test';
+import { GrantConsultantIdentityModal } from './index';
+
+// The modal loads its agency options from GET .../service/agencyadmin/agencies on mount.
+// A leading `*` matches any origin so the handler works regardless of the configured host.
+const AGENCY_ENDPOINT = '*/service/agencyadmin/agencies';
+
+const AGENCIES = [
+    { id: 1, name: 'Beratungsstelle Nord', city: 'Hamburg', postcode: '20095', deleteDate: null, tenantId: 1 },
+    { id: 2, name: 'Jugendberatung Mitte', city: 'Berlin', postcode: '10115', deleteDate: null, tenantId: 1 },
+    { id: 3, name: 'Familienhilfe West', city: 'Köln', postcode: '50667', deleteDate: null, tenantId: 1 },
+];
+
+// getAgencyData() expects a HAL-style body: `{ total, _embedded: [...] }` (see removeEmbedded).
+const agenciesResponse = (list: typeof AGENCIES) => HttpResponse.json({ total: list.length, _embedded: list });
+
+/** Opens the modal so the agencies multi-select (fed by the mocked request) is visible. */
+const openModal = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole('button'));
+    // antd Modal renders through a portal on document.body, so query the whole screen.
+    await screen.findByRole('dialog');
+};
+
+const meta = {
+    title: 'Organisms/GrantConsultantIdentityModal',
+    component: GrantConsultantIdentityModal,
+    parameters: { layout: 'padded' },
+    // A fresh React Query cache per story: the agency query key is identical across stories,
+    // so without isolation the "loading" story would be served the cached result of another.
+    decorators: [
+        (Story) => (
+            <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+                <Story />
+            </QueryClientProvider>
+        ),
+    ],
+    args: {
+        adminId: 'admin-1',
+        onSuccess: () => {},
+    },
+} satisfies Meta<typeof GrantConsultantIdentityModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Agencies loaded: the multi-select offers the tenant's active agencies. */
+export const AgenciesLoaded: Story = {
+    parameters: {
+        msw: { handlers: [http.get(AGENCY_ENDPOINT, () => agenciesResponse(AGENCIES))] },
+    },
+    play: openModal,
+};
+
+/** Loading: the request never resolves, so the select renders in its loading state. */
+export const Loading: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.get(AGENCY_ENDPOINT, async () => {
+                    await delay('infinite');
+                    return agenciesResponse([]);
+                }),
+            ],
+        },
+    },
+    play: openModal,
+};
+
+/** Empty: the tenant has no agencies, so the select renders with no options. */
+export const EmptyAgencies: Story = {
+    parameters: {
+        msw: { handlers: [http.get(AGENCY_ENDPOINT, () => agenciesResponse([]))] },
+    },
+    play: openModal,
+};

--- a/src/components/LanguageSelector/LanguageSelector.stories.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { LanguageSelector } from './index';
+
+const meta = {
+    title: 'Molecules/LanguageSelector',
+    component: LanguageSelector,
+    parameters: { layout: 'padded' },
+    args: {
+        variant: 'compact',
+        showIcon: true,
+    },
+} satisfies Meta<typeof LanguageSelector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Compact variant — used in the profile / settings header. */
+export const Compact: Story = {
+    args: { variant: 'compact' },
+};
+
+/** Login variant — borderless, sits on the public login surface. */
+export const Login: Story = {
+    args: { variant: 'login' },
+};
+
+/** Profile variant. */
+export const Profile: Story = {
+    args: { variant: 'profile' },
+};
+
+/** Without the leading globe icon. */
+export const NoIcon: Story = {
+    args: { showIcon: false },
+};

--- a/src/components/Layout/AdminSidebar.stories.tsx
+++ b/src/components/Layout/AdminSidebar.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Layout } from 'antd';
+import routePathNames from '../../appConfig';
+import { AdminSidebar, type AdminSidebarNavItem } from './AdminSidebar';
+
+// Pre-resolved nav items (the wrapper builds these from permissions; the sidebar just renders them).
+const settingsItem: AdminSidebarNavItem = {
+    key: 'theme',
+    to: routePathNames.themeSettings,
+    label: 'Einstellungen',
+    iconPath: routePathNames.themeSettings,
+    activeMatch: { paths: [routePathNames.themeSettings], mode: 'includes' },
+};
+const tenantsItem: AdminSidebarNavItem = {
+    key: 'tenants',
+    to: routePathNames.tenants,
+    label: 'Mandanten',
+    iconPath: routePathNames.tenants,
+    activeMatch: { paths: [routePathNames.tenants], mode: 'includes' },
+};
+const agencyItem: AdminSidebarNavItem = {
+    key: 'agency',
+    to: routePathNames.agency,
+    label: 'Beratungsstellen',
+    iconPath: routePathNames.agency,
+    activeMatch: { paths: [routePathNames.agency], mode: 'includes' },
+};
+const usersItem: AdminSidebarNavItem = {
+    key: 'counselors',
+    to: routePathNames.users,
+    label: 'Benutzer',
+    iconPath: '/admin/users',
+    activeMatch: { paths: ['/admin/users'], mode: 'includes' },
+};
+const statisticsItem: AdminSidebarNavItem = {
+    key: 'statistics',
+    to: routePathNames.statistic,
+    label: 'Statistik',
+    iconPath: routePathNames.statistic,
+};
+const linksItem: AdminSidebarNavItem = {
+    key: 'links',
+    to: routePathNames.links,
+    label: 'Links',
+    iconPath: routePathNames.links,
+    activeMatch: { paths: [`${routePathNames.links}/`], mode: 'startsWith' },
+};
+const logsItem: AdminSidebarNavItem = {
+    key: 'logs',
+    to: routePathNames.logs,
+    label: 'Logs',
+    iconPath: routePathNames.logs,
+    end: true,
+};
+
+const accountItem: AdminSidebarNavItem = {
+    key: 'account',
+    to: routePathNames.userProfile,
+    label: 'Mein Konto',
+    iconPath: routePathNames.userProfile,
+};
+
+const activityLogs = {
+    label: 'Aktivitätsprotokolle',
+    items: [
+        {
+            key: 'case-handover-logs',
+            to: routePathNames.caseHandoverLogs,
+            label: 'Fallübergaben',
+            iconPath: routePathNames.caseHandoverLogs,
+        },
+        {
+            key: 'inactive-audit-logs',
+            to: routePathNames.inactiveAccountAuditLogs,
+            label: 'Inaktive Konten',
+            iconPath: routePathNames.inactiveAccountAuditLogs,
+        },
+    ] as AdminSidebarNavItem[],
+};
+
+const meta = {
+    title: 'Molecules/AdminSidebar',
+    component: AdminSidebar,
+    parameters: { layout: 'fullscreen' },
+    // Sider must live inside an antd Layout; `protectedLayout` pulls in the app sidebar styles.
+    decorators: [
+        (Story) => (
+            <Layout className="protectedLayout" style={{ minHeight: '100vh' }}>
+                <Story />
+            </Layout>
+        ),
+    ],
+    args: {
+        account: accountItem,
+        logout: { label: 'Abmelden', onLogout: () => {} },
+        lang: 'de',
+        currentPath: routePathNames.agency,
+    },
+} satisfies Meta<typeof AdminSidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Super-admin: every top-level entry plus the grouped activity-logs section. */
+export const SuperAdmin: Story = {
+    args: {
+        items: [settingsItem, tenantsItem, agencyItem, usersItem, statisticsItem, linksItem, logsItem],
+        activityLogs,
+    },
+};
+
+/** Agency admin: only the agencies, users and links entries (no tenants/settings/logs). */
+export const AgencyAdmin: Story = {
+    args: {
+        items: [agencyItem, usersItem, linksItem],
+        currentPath: routePathNames.links,
+    },
+};
+
+/** Minimal access: no top-level entries — just the account link and logout. */
+export const MinimalAccess: Story = {
+    args: {
+        items: [],
+        currentPath: routePathNames.userProfile,
+    },
+};
+
+/** Focus on the grouped "activity logs" section below the main items. */
+export const WithActivityLogs: Story = {
+    args: {
+        items: [settingsItem, usersItem],
+        activityLogs,
+        currentPath: routePathNames.caseHandoverLogs,
+    },
+};

--- a/src/components/Layout/AdminSidebar.stories.tsx
+++ b/src/components/Layout/AdminSidebar.stories.tsx
@@ -82,12 +82,17 @@ const meta = {
     title: 'Molecules/AdminSidebar',
     component: AdminSidebar,
     parameters: { layout: 'fullscreen' },
+    // The real rail is `height: 100vh`; render it inside a fixed-height frame so the whole
+    // sidebar is shown in one piece instead of overflowing a short Storybook canvas.
     // Sider must live inside an antd Layout; `protectedLayout` pulls in the app sidebar styles.
     decorators: [
         (Story) => (
-            <Layout className="protectedLayout" style={{ minHeight: '100vh' }}>
-                <Story />
-            </Layout>
+            <div className="adminSidebarStoryFrame" style={{ display: 'flex', height: 760 }}>
+                <style>{`.adminSidebarStoryFrame .ant-layout-sider{height:100%!important;min-height:0!important}`}</style>
+                <Layout className="protectedLayout" style={{ height: '100%', minHeight: 0 }}>
+                    <Story />
+                </Layout>
+            </div>
         ),
     ],
     args: {
@@ -106,6 +111,18 @@ export const SuperAdmin: Story = {
     args: {
         items: [settingsItem, tenantsItem, agencyItem, usersItem, statisticsItem, linksItem, logsItem],
         activityLogs,
+    },
+};
+
+/**
+ * Tenant admin: a tenant-scoped admin sees settings, users, statistics and links — but not
+ * the super-admin-only tenants entry, and (lacking Agency read) no agencies entry. Shows the
+ * different visibility rules vs. the super-admin rail.
+ */
+export const TenantAdmin: Story = {
+    args: {
+        items: [settingsItem, usersItem, statisticsItem, linksItem],
+        currentPath: routePathNames.themeSettings,
     },
 };
 

--- a/src/components/Layout/AdminSidebar.test.tsx
+++ b/src/components/Layout/AdminSidebar.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { Layout } from 'antd';
+import { AdminSidebar, type AdminSidebarNavItem, type AdminSidebarProps } from './AdminSidebar';
+
+// NavIcon pulls in ~30 SVGs via `ReactComponent`, which the test runner does not transform.
+// It is not what we are testing here, so stub it with a lightweight marker.
+vi.mock('./NavIcon', () => ({
+    NavIcon: ({ path }: { path: string }) => <span data-testid="nav-icon" data-path={path} />,
+}));
+
+const agencyItem: AdminSidebarNavItem = {
+    key: 'agency',
+    to: '/admin/agency',
+    label: 'Agencies',
+    iconPath: '/admin/agency',
+    activeMatch: { paths: ['/admin/agency'], mode: 'includes' },
+};
+const statsItem: AdminSidebarNavItem = {
+    key: 'stats',
+    to: '/admin/statistic',
+    label: 'Statistics',
+    iconPath: '/admin/statistic',
+};
+const linksItem: AdminSidebarNavItem = {
+    key: 'links',
+    to: '/admin/links',
+    label: 'Links',
+    iconPath: '/admin/links',
+    activeMatch: { paths: ['/admin/links/'], mode: 'startsWith' },
+};
+const accountItem: AdminSidebarNavItem = {
+    key: 'account',
+    to: '/admin/profil/',
+    label: 'Account',
+    iconPath: '/admin/profil/',
+};
+
+const renderSidebar = (props: Partial<AdminSidebarProps> = {}, initialPath = '/') => {
+    const onLogout = vi.fn();
+    const merged: AdminSidebarProps = {
+        items: [agencyItem, statsItem],
+        account: accountItem,
+        logout: { label: 'Logout', onLogout },
+        currentPath: '/',
+        ...props,
+    };
+    render(
+        <MemoryRouter initialEntries={[initialPath]}>
+            <Layout>
+                <AdminSidebar {...merged} />
+            </Layout>
+        </MemoryRouter>,
+    );
+    return { onLogout };
+};
+
+describe('AdminSidebar', () => {
+    it('renders the provided items as links to their routes', () => {
+        renderSidebar();
+        expect(screen.getByRole('link', { name: 'Agencies' })).toHaveAttribute('href', '/admin/agency');
+        expect(screen.getByRole('link', { name: 'Statistics' })).toHaveAttribute('href', '/admin/statistic');
+    });
+
+    it('only renders the items it is given (visibility is the caller’s job)', () => {
+        renderSidebar({ items: [agencyItem] });
+        expect(screen.getByRole('link', { name: 'Agencies' })).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Statistics' })).not.toBeInTheDocument();
+    });
+
+    it('renders the account link and a logout button, and fires onLogout on click', async () => {
+        const { onLogout } = renderSidebar();
+        expect(screen.getByRole('link', { name: 'Account' })).toHaveAttribute('href', '/admin/profil/');
+        await userEvent.click(screen.getByRole('button', { name: 'Logout' }));
+        expect(onLogout).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks an item active when currentPath matches its includes activeMatch', () => {
+        renderSidebar({ currentPath: '/admin/agency/edit/5' });
+        expect(screen.getByRole('link', { name: 'Agencies' })).toHaveClass('active');
+        // statsItem has no activeMatch, so currentPath must not activate it.
+        expect(screen.getByRole('link', { name: 'Statistics' })).not.toHaveClass('active');
+    });
+
+    it('honours a startsWith activeMatch on sub-routes', () => {
+        renderSidebar({ items: [linksItem], currentPath: '/admin/links/tenants' });
+        expect(screen.getByRole('link', { name: 'Links' })).toHaveClass('active');
+    });
+
+    it('does not activate a startsWith item on the bare base path', () => {
+        renderSidebar({ items: [linksItem], currentPath: '/admin/links' });
+        expect(screen.getByRole('link', { name: 'Links' })).not.toHaveClass('active');
+    });
+
+    it('renders the grouped activity-logs section with its children when provided', () => {
+        renderSidebar({
+            activityLogs: {
+                label: 'Activity logs',
+                items: [
+                    {
+                        key: 'ch',
+                        to: '/admin/logs/case-handover',
+                        label: 'Case handover',
+                        iconPath: '/admin/logs/case-handover',
+                    },
+                ],
+            },
+        });
+        expect(screen.getByRole('group', { name: 'Activity logs' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Case handover' })).toHaveAttribute(
+            'href',
+            '/admin/logs/case-handover',
+        );
+    });
+
+    it('omits the activity-logs section when not provided', () => {
+        renderSidebar();
+        expect(screen.queryByRole('group')).not.toBeInTheDocument();
+    });
+});

--- a/src/components/Layout/AdminSidebar.tsx
+++ b/src/components/Layout/AdminSidebar.tsx
@@ -1,0 +1,134 @@
+import { Layout } from 'antd';
+import { NavLink } from 'react-router-dom';
+import { NavIcon } from './NavIcon';
+
+const { Sider } = Layout;
+
+export interface AdminSidebarNavItem {
+    /** Stable key for the list item. */
+    key: string;
+    /** Route the link navigates to. */
+    to: string;
+    /** Accessible + visible label. */
+    label: string;
+    /** Path handed to `<NavIcon>` to pick the icon (matches the NavIcon switch cases). */
+    iconPath: string;
+    /** Forwarded to `NavLink` — exact-match only when true. */
+    end?: boolean;
+    /**
+     * Extra active-detection on top of `NavLink`'s own `isActive`. Some items stay
+     * highlighted across a family of sub-routes (settings, links). When set, the item is
+     * active if `NavLink` reports active OR `currentPath` matches one of `paths` by `mode`.
+     */
+    activeMatch?: {
+        paths: string[];
+        mode: 'includes' | 'startsWith';
+    };
+}
+
+export interface AdminSidebarActivityLogs {
+    label: string;
+    items: AdminSidebarNavItem[];
+}
+
+export interface AdminSidebarProps {
+    /** Upper nav items — already filtered to what the current user may see. */
+    items: AdminSidebarNavItem[];
+    /** Optional grouped "activity logs" section shown below the main items. */
+    activityLogs?: AdminSidebarActivityLogs;
+    /** Lower "account" nav item. */
+    account: AdminSidebarNavItem;
+    /** Logout action row. */
+    logout: {
+        label: string;
+        onLogout: () => void;
+    };
+    /** BCP-47 language tag applied to the labels (`lang` attribute). */
+    lang?: string;
+    /** Current pathname — used only for `activeMatch` detection. */
+    currentPath: string;
+}
+
+const isPathMatch = (currentPath: string, activeMatch?: AdminSidebarNavItem['activeMatch']): boolean => {
+    if (!activeMatch) {
+        return false;
+    }
+    return activeMatch.paths.some((path) =>
+        activeMatch.mode === 'startsWith' ? currentPath.startsWith(path) : currentPath.includes(path),
+    );
+};
+
+const NavItemLink = ({
+    item,
+    lang,
+    currentPath,
+}: {
+    item: AdminSidebarNavItem;
+    lang?: string;
+    currentPath: string;
+}) => (
+    <NavLink
+        to={item.to}
+        end={item.end}
+        aria-label={item.label}
+        title={item.label}
+        className={({ isActive }) => (isActive || isPathMatch(currentPath, item.activeMatch) ? 'active' : '')}
+    >
+        <NavIcon path={item.iconPath} />
+        <span lang={lang}>{item.label}</span>
+    </NavLink>
+);
+
+/**
+ * Presentational admin navigation sidebar. Every permission / visibility / routing decision
+ * is made by the caller and passed in as resolved props — this component holds no hooks for
+ * permissions, roles, tenant or feature state, so it renders deterministically for a given
+ * set of props (and therefore in Storybook). Extracted from `ProtectedPageLayoutWrapper` for
+ * issue #283; the wrapper keeps all the permission/routing logic.
+ */
+export const AdminSidebar = ({ items, activityLogs, account, logout, lang, currentPath }: AdminSidebarProps) => (
+    <Sider width={96}>
+        <div className="logo" />
+        <nav className="mainMenu">
+            <ul className="upperSidebar">
+                {items.map((item) => (
+                    <li key={item.key} className="menuItem">
+                        <NavItemLink item={item} lang={lang} currentPath={currentPath} />
+                    </li>
+                ))}
+
+                {activityLogs && activityLogs.items.length > 0 && (
+                    <li className="menuSection" role="group" aria-label={activityLogs.label}>
+                        <span className="menuSectionLabel" lang={lang}>
+                            {activityLogs.label}
+                        </span>
+                        <ul className="menuSectionItems">
+                            {activityLogs.items.map((item) => (
+                                <li key={item.key} className="menuItem">
+                                    <NavItemLink item={item} lang={lang} currentPath={currentPath} />
+                                </li>
+                            ))}
+                        </ul>
+                    </li>
+                )}
+            </ul>
+
+            <ul className="lowerSidebar">
+                <li className="menuItem">
+                    <NavItemLink item={account} lang={lang} currentPath={currentPath} />
+                </li>
+
+                <li className="menuItem">
+                    <button onClick={logout.onLogout} type="button" aria-label={logout.label} title={logout.label}>
+                        <NavIcon path="logout" />
+                        <span className="logout" lang={lang}>
+                            {logout.label}
+                        </span>
+                    </button>
+                </li>
+            </ul>
+        </nav>
+    </Sider>
+);
+
+export default AdminSidebar;

--- a/src/components/Layout/ProtectedPageLayoutWrapper.tsx
+++ b/src/components/Layout/ProtectedPageLayoutWrapper.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Layout } from 'antd';
-import { NavLink, useLocation, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import routePathNames from '../../appConfig';
@@ -15,7 +15,7 @@ import { useUserRoles } from '../../hooks/useUserRoles.hook';
 import { useTenantData } from '../../hooks/useTenantData.hook';
 import { UserRole } from '../../enums/UserRole';
 import { useFeatureContext } from '../../context/FeatureContext';
-import { NavIcon } from './NavIcon';
+import AdminSidebar, { AdminSidebarNavItem } from './AdminSidebar';
 import { FeatureFlag } from '../../enums/FeatureFlag';
 import { useAppConfigContext } from '../../context/useAppConfig';
 import { PermissionAction } from '../../enums/PermissionAction';
@@ -26,7 +26,7 @@ import { useUserPermissions } from '../../hooks/useUserPermission';
 import styles from './styles.module.scss';
 import { clearStuckOverlays } from '../../utils/clearStuckOverlays';
 
-const { Content, Sider } = Layout;
+const { Content } = Layout;
 
 const ProtectedPageLayoutWrapper = ({ children }: any) => {
     const { settings } = useAppConfigContext();
@@ -79,10 +79,6 @@ const ProtectedPageLayoutWrapper = ({ children }: any) => {
         }
     }, [subdomain, tenantData.subdomain]);
 
-    const checkActive = (path: string) => {
-        return location.pathname.includes(path);
-    };
-
     const { isEnabled: isReleaseEnabled } = useReleasesToggle();
     const shouldShowThemeSettings =
         (settings.multitenancyWithSingleDomainEnabled && hasRole(UserRole.TenantAdmin)) ||
@@ -132,195 +128,121 @@ const ProtectedPageLayoutWrapper = ({ children }: any) => {
         multitenancyWithSingleDomainEnabled: settings.multitenancyWithSingleDomainEnabled,
     });
 
+    // Resolve which nav items the current user may see. All the permission/role/feature
+    // logic stays here; the presentational <AdminSidebar> just renders what it is given.
+    const upperNavItems: AdminSidebarNavItem[] = [];
+    if (canSeeSettingsMenu) {
+        upperNavItems.push({
+            key: 'theme',
+            to: settingsPath,
+            label: navLabels.settings,
+            iconPath: routePathNames.themeSettings,
+            activeMatch: { paths: [routePathNames.themeSettings], mode: 'includes' },
+        });
+    }
+    if (isSuperAdmin && can(PermissionAction.Create, Resource.Tenant)) {
+        upperNavItems.push({
+            key: 'tenants',
+            to: routePathNames.tenants,
+            label: navLabels.tenants,
+            iconPath: routePathNames.tenants,
+            activeMatch: { paths: [routePathNames.tenants], mode: 'includes' },
+        });
+    }
+    if (
+        can(PermissionAction.Read, Resource.Agency) &&
+        (hasRole(UserRole.AgencyAdmin) || !hasRole(UserRole.RestrictedAgencyAdmin))
+    ) {
+        upperNavItems.push({
+            key: 'agency',
+            to: routePathNames.agency,
+            label: navLabels.agency,
+            iconPath: routePathNames.agency,
+            activeMatch: { paths: [routePathNames.agency], mode: 'includes' },
+        });
+    }
+    if (
+        can(PermissionAction.Read, Resource.Consultant) ||
+        can(PermissionAction.Read, Resource.AgencyAdminUser) ||
+        can(PermissionAction.Read, Resource.TenantAdminUser)
+    ) {
+        upperNavItems.push({
+            key: 'counselors',
+            to: usersPage(),
+            label: navLabels.users,
+            iconPath: '/admin/users',
+            activeMatch: { paths: ['/admin/users'], mode: 'includes' },
+        });
+    }
+    if (can(PermissionAction.Read, Resource.Statistic)) {
+        upperNavItems.push({
+            key: 'statistics',
+            to: routePathNames.statistic,
+            label: navLabels.statistics,
+            iconPath: routePathNames.statistic,
+        });
+    }
+    if (
+        can(PermissionAction.Read, Resource.Agency) ||
+        can(PermissionAction.Read, Resource.AgencyAdminUser) ||
+        hasRole(UserRole.RestrictedAgencyAdmin)
+    ) {
+        upperNavItems.push({
+            key: 'links',
+            to: routePathNames.links,
+            label: navLabels.links,
+            iconPath: routePathNames.links,
+            activeMatch: { paths: [`${routePathNames.links}/`], mode: 'startsWith' },
+        });
+    }
+    if (canSeeCounsellorLogs) {
+        upperNavItems.push({
+            key: 'logs',
+            to: routePathNames.logs,
+            label: navLabels.logs,
+            iconPath: routePathNames.logs,
+            end: true,
+        });
+    }
+
+    const activityLogItems: AdminSidebarNavItem[] = [];
+    if (canSeeCaseHandoverLogs) {
+        activityLogItems.push({
+            key: 'case-handover-logs',
+            to: routePathNames.caseHandoverLogs,
+            label: navLabels.caseHandoverLogs,
+            iconPath: routePathNames.caseHandoverLogs,
+        });
+    }
+    if (canSeeInactiveAuditLogs) {
+        activityLogItems.push({
+            key: 'inactive-audit-logs',
+            to: routePathNames.inactiveAccountAuditLogs,
+            label: navLabels.inactiveAudit,
+            iconPath: routePathNames.inactiveAccountAuditLogs,
+        });
+    }
+
+    const accountNavItem: AdminSidebarNavItem = {
+        key: 'account',
+        to: routePathNames.userProfile,
+        label: navLabels.account,
+        iconPath: routePathNames.userProfile,
+    };
+
     return (
         <>
             <Layout className="protectedLayout">
-                <Sider width={96}>
-                    <div className="logo" />
-                    <nav className="mainMenu">
-                        <ul className="upperSidebar">
-                            {canSeeSettingsMenu && (
-                                <li key="theme" className="menuItem">
-                                    <NavLink
-                                        to={settingsPath}
-                                        aria-label={navLabels.settings}
-                                        title={navLabels.settings}
-                                        className={({ isActive }) =>
-                                            isActive || checkActive(routePathNames.themeSettings) ? 'active' : ''
-                                        }
-                                    >
-                                        <NavIcon path={routePathNames.themeSettings} />
-                                        <span lang={navLanguage}>{navLabels.settings}</span>
-                                    </NavLink>
-                                </li>
-                            )}
-
-                            {isSuperAdmin && can(PermissionAction.Create, Resource.Tenant) && (
-                                <li key="tenants" className="menuItem">
-                                    <NavLink
-                                        to={routePathNames.tenants}
-                                        aria-label={navLabels.tenants}
-                                        title={navLabels.tenants}
-                                        className={classNames({ active: checkActive(routePathNames.tenants) })}
-                                    >
-                                        <NavIcon path={routePathNames.tenants} />
-                                        <span lang={navLanguage}>{navLabels.tenants}</span>
-                                    </NavLink>
-                                </li>
-                            )}
-
-                            {can(PermissionAction.Read, Resource.Agency) &&
-                                (hasRole(UserRole.AgencyAdmin) || !hasRole(UserRole.RestrictedAgencyAdmin)) && (
-                                    <li className="menuItem">
-                                        <NavLink
-                                            to={routePathNames.agency}
-                                            aria-label={navLabels.agency}
-                                            title={navLabels.agency}
-                                            className={classNames({ active: checkActive(routePathNames.agency) })}
-                                        >
-                                            <NavIcon path={routePathNames.agency} />
-                                            <span lang={navLanguage}>{navLabels.agency}</span>
-                                        </NavLink>
-                                    </li>
-                                )}
-
-                            {(can(PermissionAction.Read, Resource.Consultant) ||
-                                can(PermissionAction.Read, Resource.AgencyAdminUser) ||
-                                can(PermissionAction.Read, Resource.TenantAdminUser)) && (
-                                <li key="counselors" className="menuItem">
-                                    <NavLink
-                                        to={usersPage()}
-                                        aria-label={navLabels.users}
-                                        title={navLabels.users}
-                                        className={classNames({ active: checkActive('/admin/users') })}
-                                    >
-                                        <NavIcon path="/admin/users" />
-                                        <span lang={navLanguage}>{navLabels.users}</span>
-                                    </NavLink>
-                                </li>
-                            )}
-
-                            {can(PermissionAction.Read, Resource.Statistic) && (
-                                <li key="statistics" className="menuItem">
-                                    <NavLink
-                                        to={routePathNames.statistic}
-                                        aria-label={navLabels.statistics}
-                                        title={navLabels.statistics}
-                                        className={({ isActive }) => (isActive ? 'active' : '')}
-                                    >
-                                        <NavIcon path={routePathNames.statistic} />
-                                        <span lang={navLanguage}>{navLabels.statistics}</span>
-                                    </NavLink>
-                                </li>
-                            )}
-
-                            {(can(PermissionAction.Read, Resource.Agency) ||
-                                can(PermissionAction.Read, Resource.AgencyAdminUser) ||
-                                hasRole(UserRole.RestrictedAgencyAdmin)) && (
-                                <li key="links" className="menuItem">
-                                    <NavLink
-                                        to={routePathNames.links}
-                                        aria-label={navLabels.links}
-                                        title={navLabels.links}
-                                        className={({ isActive }) =>
-                                            isActive || location.pathname.startsWith(`${routePathNames.links}/`)
-                                                ? 'active'
-                                                : ''
-                                        }
-                                    >
-                                        <NavIcon path={routePathNames.links} />
-                                        <span lang={navLanguage}>{navLabels.links}</span>
-                                    </NavLink>
-                                </li>
-                            )}
-
-                            {canSeeCounsellorLogs && (
-                                <li key="logs" className="menuItem">
-                                    <NavLink
-                                        end
-                                        to={routePathNames.logs}
-                                        aria-label={navLabels.logs}
-                                        title={navLabels.logs}
-                                        className={({ isActive }) => (isActive ? 'active' : '')}
-                                    >
-                                        <NavIcon path={routePathNames.logs} />
-                                        <span lang={navLanguage}>{navLabels.logs}</span>
-                                    </NavLink>
-                                </li>
-                            )}
-
-                            {canSeeActivityLogs && (
-                                <li
-                                    key="activity-logs"
-                                    className="menuSection"
-                                    role="group"
-                                    aria-label={navLabels.activityLogs}
-                                >
-                                    <span className="menuSectionLabel" lang={navLanguage}>
-                                        {navLabels.activityLogs}
-                                    </span>
-                                    <ul className="menuSectionItems">
-                                        {canSeeCaseHandoverLogs && (
-                                            <li key="case-handover-logs" className="menuItem">
-                                                <NavLink
-                                                    to={routePathNames.caseHandoverLogs}
-                                                    aria-label={navLabels.caseHandoverLogs}
-                                                    title={navLabels.caseHandoverLogs}
-                                                    className={({ isActive }) => (isActive ? 'active' : '')}
-                                                >
-                                                    <NavIcon path={routePathNames.caseHandoverLogs} />
-                                                    <span lang={navLanguage}>{navLabels.caseHandoverLogs}</span>
-                                                </NavLink>
-                                            </li>
-                                        )}
-
-                                        {canSeeInactiveAuditLogs && (
-                                            <li key="inactive-audit-logs" className="menuItem">
-                                                <NavLink
-                                                    to={routePathNames.inactiveAccountAuditLogs}
-                                                    aria-label={navLabels.inactiveAudit}
-                                                    title={navLabels.inactiveAudit}
-                                                    className={({ isActive }) => (isActive ? 'active' : '')}
-                                                >
-                                                    <NavIcon path={routePathNames.inactiveAccountAuditLogs} />
-                                                    <span lang={navLanguage}>{navLabels.inactiveAudit}</span>
-                                                </NavLink>
-                                            </li>
-                                        )}
-                                    </ul>
-                                </li>
-                            )}
-                        </ul>
-
-                        <ul className="lowerSidebar">
-                            <li className="menuItem">
-                                <NavLink
-                                    to={routePathNames.userProfile}
-                                    aria-label={navLabels.account}
-                                    title={navLabels.account}
-                                    className={({ isActive }) => (isActive ? 'active' : '')}
-                                >
-                                    <NavIcon path={routePathNames.userProfile} />
-                                    <span lang={navLanguage}>{navLabels.account}</span>
-                                </NavLink>
-                            </li>
-
-                            <li className="menuItem">
-                                <button
-                                    onClick={handleLogout}
-                                    type="button"
-                                    aria-label={navLabels.logout}
-                                    title={navLabels.logout}
-                                >
-                                    <NavIcon path="logout" />
-                                    <span className="logout" lang={navLanguage}>
-                                        {navLabels.logout}
-                                    </span>
-                                </button>
-                            </li>
-                        </ul>
-                    </nav>
-                </Sider>
+                <AdminSidebar
+                    items={upperNavItems}
+                    activityLogs={
+                        canSeeActivityLogs ? { label: navLabels.activityLogs, items: activityLogItems } : undefined
+                    }
+                    account={accountNavItem}
+                    logout={{ label: navLabels.logout, onLogout: handleLogout }}
+                    lang={navLanguage}
+                    currentPath={location.pathname}
+                />
 
                 <Layout className={classNames(styles.mainContent)}>
                     <Content className={styles.content}>

--- a/src/components/Page/Page.stories.tsx
+++ b/src/components/Page/Page.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Page } from './index';
+
+const meta = {
+    title: 'Organisms/Page',
+    component: Page,
+    parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof Page>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SampleContent = () => (
+    <div style={{ padding: 24 }}>
+        <p>Page content goes here.</p>
+    </div>
+);
+
+/** The page shell that wraps every admin route (sticky header + scrollable content). */
+export const Default: Story = {
+    render: () => (
+        <Page>
+            <SampleContent />
+        </Page>
+    ),
+};
+
+/** Loading state — renders an antd spinner instead of the content. */
+export const Loading: Story = {
+    render: () => <Page isLoading />,
+};
+
+/** With a back header (`Page.Back`) linking to a parent route. */
+export const WithBackHeader: Story = {
+    render: () => (
+        <Page>
+            <Page.Back path="/admin/users" title="Max Mustermann" />
+            <SampleContent />
+        </Page>
+    ),
+};
+
+/** A back header with a tab bar (`Page.Back` + tabs) — tabs only show when there is more than one. */
+export const WithTabs: Story = {
+    render: () => (
+        <Page>
+            <Page.Back
+                path="/admin/tenants"
+                title="Beispiel-Mandant"
+                tabs={[
+                    { to: '/admin/tenants/1/general', titleKey: 'tenant.tabs.master_data', iconName: 'master_data' },
+                    { to: '/admin/tenants/1/legal', titleKey: 'tenant.tabs.legal', iconName: 'legal' },
+                ]}
+            />
+            <SampleContent />
+        </Page>
+    ),
+};

--- a/src/components/Page/styles.module.scss
+++ b/src/components/Page/styles.module.scss
@@ -23,7 +23,7 @@
     }
 
     .pageTitleContainer {
-        padding: 23px 24px 0;
+        padding: 23px 64px 20px;
     }
 }
 

--- a/src/components/ResizableTable/ResizableTable.stories.tsx
+++ b/src/components/ResizableTable/ResizableTable.stories.tsx
@@ -1,20 +1,69 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button, Tag } from 'antd';
+import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
+import type { ColumnProps } from 'antd/lib/table';
+import StatusIcons from '../EditableTable/StatusIcons';
+import type { Status } from '../../types/status';
 import { ResizeTable } from './index';
 
-interface Row {
-    key: string;
+/**
+ * `ResizeTable` (`ResizableTable`) is the primary admin **listing** table: an antd `Table`
+ * wrapper that adds draggable column-resizing (`ResizableTitle` header cell), a normalized
+ * loading spinner (300ms delay) and the shared sticky-scroll defaults. It backs the
+ * Agencies, Tenants, Topics and User-management listings.
+ *
+ * The stories below mirror a real admin listing (columns from the Agency list: id, name,
+ * city, status, online, row actions) so the Storybook example matches production usage.
+ * Drag a column header's right edge to resize it.
+ */
+
+interface AgencyRow {
+    id: number;
     name: string;
-    email: string;
+    city: string;
+    offline: boolean;
+    status: Status;
 }
 
-const data: Row[] = [
-    { key: '1', name: 'Anna Muster', email: 'anna@example.org' },
-    { key: '2', name: 'Ben Beispiel', email: 'ben@example.org' },
+const rows: AgencyRow[] = [
+    { id: 101, name: 'Beratungsstelle Nord', city: 'Hamburg', offline: false, status: 'ACTIVE' },
+    { id: 102, name: 'Jugendberatung Mitte', city: 'Berlin', offline: true, status: 'INACTIVE' },
+    { id: 103, name: 'Familienhilfe West', city: 'Köln', offline: false, status: 'CREATED' },
+    { id: 104, name: 'Suchtberatung Süd', city: 'München', offline: false, status: 'IN_DELETION' },
+    { id: 105, name: 'Schuldnerberatung Ost', city: 'Dresden', offline: true, status: 'IN_PROGRESS' },
 ];
 
-const columns = [
-    { title: 'Name', dataIndex: 'name', key: 'name', width: 200 },
-    { title: 'E-Mail', dataIndex: 'email', key: 'email', width: 260 },
+const columns: Array<ColumnProps<AgencyRow>> = [
+    { title: 'ID', dataIndex: 'id', key: 'id', width: 80, sorter: true, ellipsis: true },
+    { title: 'Name', dataIndex: 'name', key: 'name', width: 220, sorter: true, ellipsis: true },
+    { title: 'Stadt', dataIndex: 'city', key: 'city', width: 140, ellipsis: true },
+    {
+        title: 'Status',
+        dataIndex: 'status',
+        key: 'status',
+        width: 90,
+        render: (status: Status) => <StatusIcons status={status} />,
+    },
+    {
+        title: 'Online',
+        dataIndex: 'offline',
+        key: 'offline',
+        width: 120,
+        render: (offline: boolean) =>
+            offline ? <Tag color="default">Offline</Tag> : <Tag color="success">Online</Tag>,
+    },
+    {
+        title: '',
+        key: 'edit',
+        width: 120,
+        fixed: 'right',
+        render: () => (
+            <div className="tableActionWrapper" style={{ display: 'flex', gap: 8 }}>
+                <Button type="text" icon={<EditOutlined />} aria-label="Bearbeiten" />
+                <Button type="text" danger icon={<DeleteOutlined />} aria-label="Löschen" />
+            </div>
+        ),
+    },
 ];
 
 const meta = {
@@ -22,15 +71,47 @@ const meta = {
     component: ResizeTable,
     parameters: { layout: 'padded' },
     args: {
+        rowKey: 'id',
         columns,
-        dataSource: data,
-        pagination: false,
+        dataSource: rows,
         scroll: { y: 'auto' },
+        pagination: {
+            total: 42,
+            current: 1,
+            pageSize: 10,
+            showSizeChanger: true,
+            pageSizeOptions: ['10', '20', '30'],
+        },
     },
 } satisfies Meta<typeof ResizeTable>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** Drag a column's right edge to resize it — the column-resize behavior that sets this table apart from ListingTable. */
-export const Default: Story = {};
+/** A realistic agency listing: sortable columns, status icons, an online tag and row actions. */
+export const AgencyListing: Story = {};
+
+/** Loading state — the wrapper normalizes `loading` to a spinner with a 300ms delay. */
+export const Loading: Story = {
+    args: { loading: true },
+};
+
+/** Empty state with a localized empty message (as the listings pass via `locale.emptyText`). */
+export const Empty: Story = {
+    args: {
+        dataSource: [],
+        locale: { emptyText: 'Keine Einträge gefunden' },
+        pagination: false,
+    },
+};
+
+/** Minimal two-column table to focus on the drag-to-resize header behavior. */
+export const MinimalResizable: Story = {
+    args: {
+        columns: [
+            { title: 'Name', dataIndex: 'name', key: 'name', width: 200 },
+            { title: 'Stadt', dataIndex: 'city', key: 'city', width: 260 },
+        ],
+        pagination: false,
+    },
+};

--- a/src/components/SelectFormField/styles.module.scss
+++ b/src/components/SelectFormField/styles.module.scss
@@ -43,6 +43,25 @@
     letter-spacing: 0.5px;
 }
 
+/* Multi-select: grow with the selected tags instead of clipping/overflowing
+   them at a fixed height. Chips wrap onto new rows and the field height
+   follows its content. */
+.select:global(.ant-select-multiple) :global(.ant-select-selector) {
+    height: auto !important;
+    min-height: 56px !important;
+    padding-top: 8px !important;
+    padding-bottom: 8px !important;
+}
+
+.select:global(.ant-select-multiple) :global(.ant-select-selection-search-input) {
+    height: auto !important;
+}
+
+.select:global(.ant-select-multiple) :global(.ant-select-selection-overflow) {
+    align-items: center;
+    row-gap: 6px;
+}
+
 .select :global(.ant-form-item-explain-error) {
     padding: 0 16px;
     font-family: var(--m3-body-font-family);

--- a/src/components/SliderFormField/SliderFormField.stories.tsx
+++ b/src/components/SliderFormField/SliderFormField.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form } from 'antd';
+import { SliderFormField } from './index';
+
+const meta = {
+    title: 'Molecules/SliderFormField',
+    component: SliderFormField,
+    parameters: { layout: 'padded' },
+    decorators: [
+        (Story) => (
+            <Form style={{ maxWidth: 360 }} initialValues={{ ageRange: [18, 65] }}>
+                <Story />
+            </Form>
+        ),
+    ],
+    args: {
+        name: 'ageRange',
+        label: 'Altersspanne',
+        min: 0,
+        max: 100,
+    },
+} satisfies Meta<typeof SliderFormField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Range slider bound to an antd Form field, with min/max marks and always-on tooltips. */
+export const Default: Story = {};
+
+/** With an optional help text below the label. */
+export const WithHelp: Story = {
+    args: { help: 'Wählen Sie die Zielgruppe für dieses Angebot.' },
+};

--- a/src/components/Spinner/Spinner.stories.tsx
+++ b/src/components/Spinner/Spinner.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Spinner from './Spinner';
+
+const meta = {
+    title: 'Atoms/Spinner',
+    component: Spinner,
+    parameters: { layout: 'centered' },
+} satisfies Meta<typeof Spinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default double-bounce spinner (light surfaces). */
+export const Default: Story = {};
+
+/** Dark variant, for use on tinted / colored surfaces. */
+export const Dark: Story = {
+    args: { isDark: true },
+    decorators: [
+        (Story) => (
+            <div style={{ background: 'var(--primary)', padding: 32, borderRadius: 8 }}>
+                <Story />
+            </div>
+        ),
+    ],
+};

--- a/src/components/Tenants/AppSettings/PermissionsSettings/styles.module.scss
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/styles.module.scss
@@ -38,8 +38,8 @@
 
 .permissionsCardDeck {
     --card-deck-min-height: max(0px, calc(100dvh - 255px));
-    --side-scroller-button-width: 196px;
-    --side-scroller-button-height: 104px;
+    --side-scroller-button-width: 128px;
+    --side-scroller-button-height: 96px;
 }
 
 .cardGrid {
@@ -61,16 +61,14 @@
     border: 1px solid color-mix(in srgb, var(--m3-outline, #747878) 30%, transparent);
     box-shadow: var(--m3-elevation-1, 0 1px 2px rgba(0, 0, 0, 0.3));
     border-radius: 28px;
-    padding: 32px 32px 0;
+    padding: 32px 32px 32px;
     display: flex;
     flex-direction: column;
-    min-height: min(846px, calc(100dvh - 255px));
-    max-height: max(560px, calc(100dvh - 255px));
-    overflow-x: hidden;
-    overflow-y: auto;
+    min-height: auto;
+    max-height: none;
+    overflow: visible;
     color: var(--admin-form-field-text, var(--m3-on-surface, #1b1b1c));
     transition: border-color 180ms ease, box-shadow 180ms ease;
-    scrollbar-gutter: stable;
 
     &:hover {
         border-color: color-mix(in srgb, var(--m3-outline, #747878) 44%, transparent);

--- a/src/components/Tenants/GeneralSettings/components/ThemeBuilder/styles.module.scss
+++ b/src/components/Tenants/GeneralSettings/components/ThemeBuilder/styles.module.scss
@@ -153,8 +153,8 @@
 }
 
 .themePreviewScrollerFooter {
-    --side-scroller-button-width: 112px;
-    --side-scroller-button-height: 72px;
+    --side-scroller-button-width: 128px;
+    --side-scroller-button-height: 96px;
 
     position: absolute;
     right: clamp(28px, 5vw, 72px);

--- a/src/components/Tenants/LegalSettings/components/DataProcessingAgreementCard/DataProcessingAgreementCard.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DataProcessingAgreementCard/DataProcessingAgreementCard.test.tsx
@@ -75,6 +75,12 @@ beforeAll(() => {
             dispatchEvent: vi.fn(),
         })),
     });
+
+    // antd's dropdown portal (rc-util scroll locker) calls the two-arg
+    // getComputedStyle(el, pseudoEl) which jsdom does not implement. Drop the
+    // pseudo-element so the language menu can open in the test environment.
+    const originalGetComputedStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((el: Element) => originalGetComputedStyle(el));
 });
 
 const publishButtonName = 'legal.m3Editor.publish';
@@ -150,8 +156,8 @@ describe('DataProcessingAgreementCard', () => {
 
         expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>DE</p>');
 
-        await user.click(screen.getByRole('combobox'));
-        await user.click(await screen.findByTitle('en'));
+        await user.click(screen.getByRole('button', { name: 'languages' }));
+        await user.click(await screen.findByText('en'));
 
         expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>EN</p>');
     });
@@ -165,7 +171,7 @@ describe('DataProcessingAgreementCard', () => {
                 onPublish={() => undefined}
             />,
         );
-        expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'languages' })).not.toBeInTheDocument();
     });
 
     it('labels the source language as original and MT languages as machine translated', async () => {
@@ -184,12 +190,13 @@ describe('DataProcessingAgreementCard', () => {
             />,
         );
 
-        await user.click(screen.getByRole('combobox'));
+        // Open the language menu via the split-button's dropdown trigger.
+        await user.click(screen.getByRole('button', { name: 'languages' }));
 
-        // Mocked t(): "key:interpolated-language". The selected value and its dropdown
-        // option both carry the title, so match "at least one".
-        expect((await screen.findAllByTitle('legal.translation.label.original:de')).length).toBeGreaterThan(0);
-        expect(screen.getAllByTitle('legal.translation.label.machineTranslated:en').length).toBeGreaterThan(0);
+        // Mocked t(): "key:interpolated-language". The menu lists each language with
+        // its translation status (source = original, MT = machine translated).
+        expect(await screen.findByText('legal.translation.label.original:de')).toBeInTheDocument();
+        expect(screen.getByText('legal.translation.label.machineTranslated:en')).toBeInTheDocument();
     });
 
     it('renders read-only without a publish button or editable editor', () => {

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.test.tsx
@@ -46,6 +46,12 @@ beforeAll(() => {
             dispatchEvent: vi.fn(),
         })),
     });
+
+    // antd's dropdown portal (rc-util scroll locker) calls the two-arg
+    // getComputedStyle(el, pseudoEl) which jsdom does not implement. Drop the
+    // pseudo-element so the language menu can open in the test environment.
+    const originalGetComputedStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((el: Element) => originalGetComputedStyle(el));
 });
 
 const publishButtonName = 'tenants.legal.departmentDataProtection.publish';
@@ -121,8 +127,8 @@ describe('DepartmentDataProtectionCard', () => {
 
         expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>DE</p>');
 
-        await user.click(screen.getByRole('combobox'));
-        await user.click(await screen.findByTitle('en'));
+        await user.click(screen.getByRole('button', { name: 'languages' }));
+        await user.click(await screen.findByText('en'));
 
         expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>EN</p>');
     });

--- a/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/LegalContentLanguageSelect.stories.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/LegalContentLanguageSelect.stories.tsx
@@ -1,0 +1,56 @@
+import { useState, type ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { LegalContentLanguageSelect } from './index';
+
+/** Wrapper that owns the selected-language state so switching is interactive. */
+const StatefulLanguageSelect = (args: ComponentProps<typeof LegalContentLanguageSelect>) => {
+    const [value, setValue] = useState(args.value);
+    return <LegalContentLanguageSelect {...args} value={value} onChange={setValue} />;
+};
+
+const meta = {
+    title: 'Molecules/LegalContentLanguageSelect',
+    component: LegalContentLanguageSelect,
+    parameters: { layout: 'padded' },
+    args: {
+        languages: ['de', 'en'],
+        value: 'de',
+        sourceLanguage: 'de',
+        onChange: () => {},
+    },
+} satisfies Meta<typeof LegalContentLanguageSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The "🌐 language ▾" split button used by the state-based legal editors (DPA /
+ * department data privacy). The leading button shows the current language; the trailing
+ * caret opens the language menu. Interactive — pick a language to switch the label.
+ */
+export const Default: Story = {
+    render: (args) => <StatefulLanguageSelect {...args} />,
+};
+
+/**
+ * The source language is labelled "… (Original)" and machine-translated languages
+ * "… (maschinell übersetzt)" in the menu, driven by the `__meta` map.
+ */
+export const WithMachineTranslation: Story = {
+    args: {
+        languages: ['de', 'en', 'fr'],
+        contentMap: {
+            de: '<p>Original</p>',
+            en: '<p>Machine</p>',
+            en__meta: JSON.stringify({ mt: true, src: 'de', at: '2026-01-01T00:00:00.000Z' }),
+            fr: '<p>Machine</p>',
+            fr__meta: JSON.stringify({ mt: true, src: 'de', at: '2026-01-01T00:00:00.000Z' }),
+        } as Record<string, string>,
+    },
+    render: (args) => <StatefulLanguageSelect {...args} />,
+};
+
+/** With only one language the component renders nothing (nothing to switch). */
+export const SingleLanguageHidden: Story = {
+    args: { languages: ['de'] },
+};

--- a/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/index.tsx
@@ -1,4 +1,6 @@
-import { Select, Space, Typography } from 'antd';
+import { Dropdown } from 'antd';
+import Language from '@mui/icons-material/Language';
+import ArrowDropDown from '@mui/icons-material/ArrowDropDown';
 import { useTranslation } from 'react-i18next';
 import { isMachineTranslated } from '../../utils/translationMeta';
 import styles from './styles.module.scss';
@@ -49,19 +51,25 @@ export const LegalContentLanguageSelect = ({
     };
 
     return (
-        <Space align="center" className={styles.selector}>
-            <Typography.Text>{t('languages')}</Typography.Text>
-            <Select
-                value={value}
-                onChange={onChange}
-                options={languages.map((language) => ({
-                    value: language,
-                    label: labelFor(language),
-                }))}
-                className={styles.select}
-                aria-label={t('languages')}
-            />
-        </Space>
+        <div className={styles.splitButton}>
+            <button type="button" className={styles.leading} title={t('languages')}>
+                <Language style={{ fontSize: 22 }} />
+                {/* Plain language name on the button (matches the other legal cards);
+                    the original / machine-translated status stays in the menu below. */}
+                <span>{t(`language.${value}`, value)}</span>
+            </button>
+            <Dropdown
+                trigger={['click']}
+                menu={{
+                    items: languages.map((language) => ({ key: language, label: labelFor(language) })),
+                    onClick: ({ key }) => onChange(key),
+                }}
+            >
+                <button type="button" className={styles.trailing} title={t('languages')} aria-label={t('languages')}>
+                    <ArrowDropDown />
+                </button>
+            </Dropdown>
+        </div>
     );
 };
 

--- a/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/index.tsx
@@ -52,12 +52,12 @@ export const LegalContentLanguageSelect = ({
 
     return (
         <div className={styles.splitButton}>
-            <button type="button" className={styles.leading} title={t('languages')}>
+            <div className={styles.leading} title={t('languages')}>
                 <Language style={{ fontSize: 22 }} />
                 {/* Plain language name on the button (matches the other legal cards);
                     the original / machine-translated status stays in the menu below. */}
                 <span>{t(`language.${value}`, value)}</span>
-            </button>
+            </div>
             <Dropdown
                 trigger={['click']}
                 menu={{

--- a/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/styles.module.scss
+++ b/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/styles.module.scss
@@ -27,6 +27,7 @@
     gap: 8px;
     padding: 0 20px;
     border-radius: 24px 4px 4px 24px;
+    cursor: default;
     font-family: var(--m3-body-font-family);
     font-size: 16px;
     font-weight: 500;

--- a/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/styles.module.scss
+++ b/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/styles.module.scss
@@ -1,7 +1,39 @@
-.selector {
+/* M3 split button (language) — mirrors the native M3RichTextEditor language
+   control so every legal editor card shows the same globe + language + arrow. */
+.splitButton {
+    display: inline-flex;
+    gap: 2px;
     margin-bottom: 12px;
 }
 
-.select {
-    min-width: 140px;
+.leading,
+.trailing {
+    display: flex;
+    height: 48px;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--m3-outline-variant, #c4c7c8);
+    background: transparent;
+    color: var(--m3-on-surface-variant, #444748);
+    cursor: pointer;
+    transition: background 0.15s ease;
+
+    &:hover {
+        background: rgba(68, 71, 72, 0.08);
+    }
+}
+
+.leading {
+    gap: 8px;
+    padding: 0 20px;
+    border-radius: 24px 4px 4px 24px;
+    font-family: var(--m3-body-font-family);
+    font-size: 16px;
+    font-weight: 500;
+    letter-spacing: 0.15px;
+}
+
+.trailing {
+    width: 48px;
+    border-radius: 4px 24px 24px 4px;
 }

--- a/src/components/Tenants/LegalSettings/components/LegalText/LegalText.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalText/LegalText.test.tsx
@@ -61,6 +61,18 @@ vi.mock('../../../../FormPluginEditor/M3RichTextEditor', () => ({
     ),
 }));
 
+vi.mock('../../../../FormPluginEditor/FormPluginEditor', async () => {
+    const { Form } = await import('antd');
+
+    return {
+        default: ({ name }: { name?: string | string[] }) => (
+            <Form.Item name={name} noStyle>
+                <input />
+            </Form.Item>
+        ),
+    };
+});
+
 beforeAll(() => {
     Object.defineProperty(window, 'matchMedia', {
         writable: true,
@@ -75,6 +87,9 @@ beforeAll(() => {
             dispatchEvent: vi.fn(),
         })),
     });
+
+    const originalGetComputedStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((el: Element) => originalGetComputedStyle(el));
 });
 
 describe('LegalText (M3 shell)', () => {
@@ -90,8 +105,8 @@ describe('LegalText (M3 shell)', () => {
             />,
         );
 
-        // The native M3 editor is bound to the form via hidden per-language fields
-        // (one registered input per active language), so publish collects them all.
+        // The editor slot keeps one registered input per active language, so
+        // publish collects them all.
         expect(document.querySelector('input#content_imprint_de')).toHaveValue('<p>Impressum DE</p>');
         expect(document.querySelector('input#content_imprint_en')).toHaveValue('<p>Imprint EN</p>');
 

--- a/src/components/Tenants/LegalSettings/components/LegalText/LegalText.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalText/LegalText.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { describe, expect, it, vi, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Form } from 'antd';
 import { LegalText } from './index';
 
 vi.mock('react-i18next', () => ({
@@ -62,15 +61,6 @@ vi.mock('../../../../FormPluginEditor/M3RichTextEditor', () => ({
     ),
 }));
 
-// Form-bound editor stub: registers the field so form.submit() collects it.
-vi.mock('../../../../FormPluginEditor/FormPluginEditor', () => ({
-    default: ({ name }: { name: string[] }) => (
-        <Form.Item name={name}>
-            <textarea data-testid={`editor-${name.join('.')}`} />
-        </Form.Item>
-    ),
-}));
-
 beforeAll(() => {
     Object.defineProperty(window, 'matchMedia', {
         writable: true,
@@ -100,8 +90,10 @@ describe('LegalText (M3 shell)', () => {
             />,
         );
 
-        expect(screen.getByTestId('editor-content.imprint.de')).toBeInTheDocument();
-        expect(screen.getByTestId('editor-content.imprint.en')).toBeInTheDocument();
+        // The native M3 editor is bound to the form via hidden per-language fields
+        // (one registered input per active language), so publish collects them all.
+        expect(document.querySelector('input#content_imprint_de')).toHaveValue('<p>Impressum DE</p>');
+        expect(document.querySelector('input#content_imprint_en')).toHaveValue('<p>Imprint EN</p>');
 
         await user.click(screen.getByRole('button', { name: 'legal.m3Editor.publish' }));
 

--- a/src/components/Tenants/LegalSettings/components/LegalText/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalText/index.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Modal, ModalProps } from '../../../../Modal';
 import { M3RichTextEditor } from '../../../../FormPluginEditor/M3RichTextEditor';
+import FormPluginEditor from '../../../../FormPluginEditor/FormPluginEditor';
 import { useSingleTenantData } from '../../../../../hooks/useSingleTenantData';
 import { useTenantAdminData } from '../../../../../hooks/useTenantAdminData.hook';
 import { useTenantAdminDataMutation } from '../../../../../hooks/useTenantAdminDataMutation.hook';
@@ -38,6 +39,7 @@ export const LegalText = ({
     placeHolderKey,
     icon,
     showConfirmationModal,
+    placeholders,
 }: LegalTextProps) => {
     const { t } = useTranslation();
     const [form] = Form.useForm();
@@ -49,9 +51,6 @@ export const LegalText = ({
     const [activeLanguage, setActiveLanguage] = useState('de');
     const [formDataContent, setFormData] = useState<Record<string, unknown>>();
     const [modalVisible, setModalVisible] = useState(false);
-    // Content of the language currently shown in the native M3 editor. Reads the
-    // form store so switching languages re-syncs the editor to that language's text.
-    const activeContent = Form.useWatch([...fieldName, activeLanguage], form);
 
     const languages = useMemo(
         () => tenantData?.settings?.activeLanguages || ['de'],
@@ -94,13 +93,6 @@ export const LegalText = ({
                 <M3RichTextEditor
                     title={t(titleKey)}
                     icon={icon}
-                    value={typeof activeContent === 'string' ? activeContent : ''}
-                    onChange={
-                        canEditLegalText
-                            ? (html) => form.setFieldValue([...fieldName, activeLanguage], html)
-                            : undefined
-                    }
-                    placeholder={t(placeHolderKey)}
                     readOnly={!canEditLegalText}
                     publishing={isPending}
                     versionLabel={t('legal.m3Editor.versionLabel')}
@@ -111,20 +103,29 @@ export const LegalText = ({
                     language={activeLanguage}
                     onLanguageChange={setActiveLanguage}
                     aboveEditorSlot={<p className={styles.description}>{subTitle}</p>}
+                    editorSlot={
+                        // Keep all language fields mounted so form state survives
+                        // switching; FormPluginEditor preserves placeholders and
+                        // heading anchors inside the M3 shell.
+                        <>
+                            {languages.map((language) => (
+                                <div key={language} style={{ display: language === activeLanguage ? 'block' : 'none' }}>
+                                    <FormPluginEditor
+                                        name={[...fieldName, language]}
+                                        placeholder={t(placeHolderKey)}
+                                        placeholders={placeholders}
+                                        itemProps={{}}
+                                    />
+                                </div>
+                            ))}
+                        </>
+                    }
                     onPublish={canEditLegalText ? () => form.submit() : undefined}
                     belowSlot={
                         showConfirmationModal &&
                         modalVisible && <Modal {...showConfirmationModal} onConfirm={onConfirm} onClose={onCancel} />
                     }
                 />
-                {/* Registered (hidden) fields per language so `form.submit()` still
-                    collects every language's content — the native M3 editor above
-                    drives these via setFieldValue for the active language. */}
-                {languages.map((language) => (
-                    <Form.Item key={language} name={[...fieldName, language]} noStyle>
-                        <input type="hidden" />
-                    </Form.Item>
-                ))}
             </div>
         </Form>
     );

--- a/src/components/Tenants/LegalSettings/components/LegalText/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalText/index.tsx
@@ -4,7 +4,6 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Modal, ModalProps } from '../../../../Modal';
 import { M3RichTextEditor } from '../../../../FormPluginEditor/M3RichTextEditor';
-import FormPluginEditor from '../../../../FormPluginEditor/FormPluginEditor';
 import { useSingleTenantData } from '../../../../../hooks/useSingleTenantData';
 import { useTenantAdminData } from '../../../../../hooks/useTenantAdminData.hook';
 import { useTenantAdminDataMutation } from '../../../../../hooks/useTenantAdminDataMutation.hook';
@@ -39,7 +38,6 @@ export const LegalText = ({
     placeHolderKey,
     icon,
     showConfirmationModal,
-    placeholders,
 }: LegalTextProps) => {
     const { t } = useTranslation();
     const [form] = Form.useForm();
@@ -51,6 +49,9 @@ export const LegalText = ({
     const [activeLanguage, setActiveLanguage] = useState('de');
     const [formDataContent, setFormData] = useState<Record<string, unknown>>();
     const [modalVisible, setModalVisible] = useState(false);
+    // Content of the language currently shown in the native M3 editor. Reads the
+    // form store so switching languages re-syncs the editor to that language's text.
+    const activeContent = Form.useWatch([...fieldName, activeLanguage], form);
 
     const languages = useMemo(
         () => tenantData?.settings?.activeLanguages || ['de'],
@@ -93,6 +94,13 @@ export const LegalText = ({
                 <M3RichTextEditor
                     title={t(titleKey)}
                     icon={icon}
+                    value={typeof activeContent === 'string' ? activeContent : ''}
+                    onChange={
+                        canEditLegalText
+                            ? (html) => form.setFieldValue([...fieldName, activeLanguage], html)
+                            : undefined
+                    }
+                    placeholder={t(placeHolderKey)}
                     readOnly={!canEditLegalText}
                     publishing={isPending}
                     versionLabel={t('legal.m3Editor.versionLabel')}
@@ -103,31 +111,20 @@ export const LegalText = ({
                     language={activeLanguage}
                     onLanguageChange={setActiveLanguage}
                     aboveEditorSlot={<p className={styles.description}>{subTitle}</p>}
-                    editorSlot={
-                        // All languages stay mounted so form state survives switching;
-                        // only the active language is visible (same behaviour the
-                        // TranslatableFormField gave the old card).
-                        <>
-                            {languages.map((language) => (
-                                <div key={language} style={{ display: language === activeLanguage ? 'block' : 'none' }}>
-                                    <FormPluginEditor
-                                        name={[...fieldName, language]}
-                                        placeholder={t(placeHolderKey)}
-                                        placeholders={placeholders}
-                                        // Legal texts are optional — no required rule (machine
-                                        // translation as an opt-in helper is planned later).
-                                        itemProps={{}}
-                                    />
-                                </div>
-                            ))}
-                        </>
-                    }
                     onPublish={canEditLegalText ? () => form.submit() : undefined}
                     belowSlot={
                         showConfirmationModal &&
                         modalVisible && <Modal {...showConfirmationModal} onConfirm={onConfirm} onClose={onCancel} />
                     }
                 />
+                {/* Registered (hidden) fields per language so `form.submit()` still
+                    collects every language's content — the native M3 editor above
+                    drives these via setFieldValue for the active language. */}
+                {languages.map((language) => (
+                    <Form.Item key={language} name={[...fieldName, language]} noStyle>
+                        <input type="hidden" />
+                    </Form.Item>
+                ))}
             </div>
         </Form>
     );

--- a/src/components/mui/MuiFormField.tsx
+++ b/src/components/mui/MuiFormField.tsx
@@ -97,7 +97,10 @@ const MuiControl = ({
                 },
                 '& .MuiInputBase-input': {
                     minWidth: 0,
-                    boxSizing: 'border-box',
+                    // MUI sizes the input with content-box (height 1.4375em +
+                    // padding). The admin's global `box-sizing: border-box` reset
+                    // otherwise collapses the field to ~33px, so restore it here.
+                    boxSizing: 'content-box',
                     overflow: 'hidden',
                     color: 'inherit',
                     textOverflow: 'ellipsis',
@@ -120,11 +123,15 @@ const MuiControl = ({
                     borderColor: 'var(--input-border-color)',
                 },
                 '& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline': {
-                    borderColor: 'var(--input-active-border-color)',
+                    borderColor: 'var(--admin-form-field-text, #1b1b1b)',
                 },
+                // Focus: a clean solid black border (no browser outline / glow).
                 '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                    borderColor: 'var(--input-active-border-color)',
+                    borderColor: 'var(--admin-form-field-text, #1b1b1b)',
                     borderWidth: 2,
+                },
+                '& .MuiOutlinedInput-root.Mui-focused': {
+                    outline: 'none',
                 },
                 '& .MuiOutlinedInput-root.Mui-disabled': {
                     backgroundColor: 'var(--input-disabled-bg)',

--- a/src/components/radioButton/RadioButton.stories.tsx
+++ b/src/components/radioButton/RadioButton.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { RadioButton } from './RadioButton';
+
+const meta = {
+    title: 'Atoms/RadioButton',
+    component: RadioButton,
+    parameters: { layout: 'padded' },
+    args: {
+        name: 'example',
+        value: 'option-1',
+        label: 'Option 1',
+        inputId: 'radio-option-1',
+        checked: false,
+        type: 'default',
+        handleRadioButton: () => {},
+    },
+} satisfies Meta<typeof RadioButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Checked: Story = {
+    args: { checked: true },
+};
+
+/** Boxed variant — the whole option renders as a selectable card. */
+export const Box: Story = {
+    args: { type: 'box' },
+};
+
+/** Condensed variant for tighter layouts. */
+export const Smaller: Story = {
+    args: { type: 'smaller' },
+};

--- a/src/components/tooltip/Tooltip.stories.tsx
+++ b/src/components/tooltip/Tooltip.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Tooltip, DIRECTION_TOP, DIRECTION_BOTTOM, DIRECTION_LEFT, DIRECTION_RIGHT } from './Tooltip';
+import CustomInfoIcon from '../CustomIcons/Info';
+
+const meta = {
+    title: 'Atoms/Tooltip',
+    component: Tooltip,
+    parameters: { layout: 'centered' },
+    // Give the popover room so it is not clipped by the canvas edges.
+    decorators: [
+        (Story) => (
+            <div style={{ padding: 80 }}>
+                <Story />
+            </div>
+        ),
+    ],
+    args: {
+        trigger: <CustomInfoIcon style={{ fontSize: 22 }} />,
+        children: 'Hover (or tap) the icon to reveal this hint.',
+    },
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default direction (below the trigger). Hover the icon to reveal the content. */
+export const Bottom: Story = {
+    args: { direction: DIRECTION_BOTTOM },
+};
+
+export const Top: Story = {
+    args: { direction: DIRECTION_TOP },
+};
+
+export const Left: Story = {
+    args: { direction: DIRECTION_LEFT },
+};
+
+export const Right: Story = {
+    args: { direction: DIRECTION_RIGHT },
+};

--- a/src/hooks/useAdminTheme.hook.ts
+++ b/src/hooks/useAdminTheme.hook.ts
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
-import { applyAdminInvertedTheme, clearAdminInvertedThemeTokens } from '../utils/applyAdminTheme';
+import { applyAdminTheme, clearAdminInvertedThemeTokens } from '../utils/applyAdminTheme';
 import { ThemingSeedFields } from '../utils/themeSeeds';
 
-export const useAdminInvertedTheme = (theming: ThemingSeedFields | null | undefined, isReady = true) => {
+export const useAdminTheme = (theming: ThemingSeedFields | null | undefined, isReady = true) => {
     useEffect(() => {
         if (isReady) {
-            applyAdminInvertedTheme(theming);
+            applyAdminTheme(theming);
         }
 
         return () => {

--- a/src/pages/Agency/List/styles.module.scss
+++ b/src/pages/Agency/List/styles.module.scss
@@ -8,11 +8,6 @@
     max-width: 672px;
     min-width: 0;
     margin-bottom: 24px;
-    padding-left: 32px;
-
-    @media (max-width: 767px) {
-        padding-left: 0;
-    }
 }
 
 .searchField {

--- a/src/pages/GlobalSettings/GlobalSettings.stories.tsx
+++ b/src/pages/GlobalSettings/GlobalSettings.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { http, HttpResponse, delay } from 'msw';
+import { UserRole } from '../../enums/UserRole';
+import { setStoryAuth, withAdminProviders } from '../../utils/storybook/adminStoryDecorators';
+import { GlobalLoginSettingsPage } from '.';
+
+// The page hits several tenant endpoints (public tenant, tenant-by-id, tenant-admin).
+// ALL authenticated (`skipAuth: false`) calls must be mocked: an unmocked one reaches the
+// real backend, 401s, and fetchData force-logs-out — which navigates the story away.
+const TENANT_PUBLIC = '*/service/tenant/public/*';
+const TENANT_BY_ID = '*/service/tenant/:id';
+const TENANT_ADMIN = '*/service/tenantadmin/:id';
+
+const tenant = (settings: Record<string, unknown>) => ({
+    id: 1,
+    name: 'Demo-Mandant',
+    subdomain: 'demo',
+    settings,
+    licensing: { allowedNumberOfUsers: 50 },
+});
+
+const okHandlers = (settings: Record<string, unknown>) => [
+    http.get(TENANT_PUBLIC, () => HttpResponse.json(tenant(settings))),
+    http.get(TENANT_BY_ID, () => HttpResponse.json(tenant(settings))),
+    http.get(TENANT_ADMIN, () => HttpResponse.json(tenant(settings))),
+];
+
+const meta = {
+    title: 'Organisms/Pages/Settings/GlobalLoginSettings',
+    component: GlobalLoginSettingsPage,
+    parameters: { layout: 'fullscreen' },
+    decorators: [
+        (Story) => {
+            // Tenant-scoped admin (not super-admin) so the superadmin-only translation-keys
+            // request is not fired; the API-keys card renders visible-but-disabled.
+            setStoryAuth([UserRole.TenantAdmin, UserRole.SingleTenantAdmin], 1);
+            return withAdminProviders(Story);
+        },
+    ],
+} satisfies Meta<typeof GlobalLoginSettingsPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Tenant loaded with the anonymous-chat feature enabled. */
+export const Filled: Story = {
+    parameters: { msw: { handlers: okHandlers({ featureAnonymousChatEnabled: true }) } },
+};
+
+/** Tenant loaded with default (empty) settings — toggles off. */
+export const Empty: Story = {
+    parameters: { msw: { handlers: okHandlers({}) } },
+};
+
+/** Tenant request in flight — the editable card renders its loading state. */
+export const Loading: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                // Only the tenant data hangs; tenant-admin still answers so it cannot 401 → logout.
+                http.get(TENANT_PUBLIC, async () => {
+                    await delay('infinite');
+                    return HttpResponse.json(tenant({}));
+                }),
+                http.get(TENANT_BY_ID, async () => {
+                    await delay('infinite');
+                    return HttpResponse.json(tenant({}));
+                }),
+                http.get(TENANT_ADMIN, () => HttpResponse.json(tenant({}))),
+            ],
+        },
+    },
+};

--- a/src/pages/GlobalSettings/GlobalSettings.stories.tsx
+++ b/src/pages/GlobalSettings/GlobalSettings.stories.tsx
@@ -71,3 +71,20 @@ export const Loading: Story = {
         },
     },
 };
+
+/**
+ * Backend failure (500). `useTenantData` catches the error and falls back to empty settings,
+ * so — unlike the table pages — the Settings form degrades to its empty state rather than a
+ * dedicated error UI. Kept for parity with the other sections' Error stories.
+ */
+export const Error: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.get(TENANT_PUBLIC, () => new HttpResponse(null, { status: 500 })),
+                http.get(TENANT_BY_ID, () => new HttpResponse(null, { status: 500 })),
+                http.get(TENANT_ADMIN, () => new HttpResponse(null, { status: 500 })),
+            ],
+        },
+    },
+};

--- a/src/pages/GlobalSettings/index.tsx
+++ b/src/pages/GlobalSettings/index.tsx
@@ -1,6 +1,7 @@
 import { Button, Form, message } from 'antd';
 import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined';
 import SendOutlinedIcon from '@mui/icons-material/SendOutlined';
+import LoginOutlinedIcon from '@mui/icons-material/LoginOutlined';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate, Outlet } from 'react-router-dom';
@@ -61,6 +62,9 @@ export const GlobalLoginSettingsPage = () => {
                     initialValues={initialValues}
                     titleKey="tenants.globalSettings.anonymousChat.title"
                     onSave={mutate}
+                    variant="dialog"
+                    editButtonPlacement="footer"
+                    headerIcon={<LoginOutlinedIcon />}
                 >
                     <div className={styles.checkGroup}>
                         <FormSwitchField

--- a/src/pages/InviteLinks/InviteLinks.stories.tsx
+++ b/src/pages/InviteLinks/InviteLinks.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse, delay } from 'msw';
+import type { AgencyInviteLinkDTO } from '../../api/invitelinks/invitelinks';
+import { InviteLinksPage } from './index';
+
+const LINKS_ENDPOINT = '*/service/useradmin/invitelinks';
+const AGENCIES_ENDPOINT = '*/service/agencyadmin/agencies';
+
+const LINKS: AgencyInviteLinkDTO[] = [
+    {
+        id: 1,
+        token: 'abc123',
+        tenantId: 1,
+        agencyId: 101,
+        createdByUserId: 'u-1',
+        createdByUsername: 'admin',
+        createDate: '2026-06-01T10:00:00.000Z',
+        expiresAt: '2026-07-01T10:00:00.000Z',
+        usedAt: null,
+        usedBySessionId: null,
+        status: 'ACTIVE',
+    },
+    {
+        id: 2,
+        token: 'def456',
+        tenantId: 1,
+        agencyId: 102,
+        createdByUserId: 'u-1',
+        createdByUsername: 'admin',
+        createDate: '2026-05-20T09:30:00.000Z',
+        expiresAt: '2026-05-27T09:30:00.000Z',
+        usedAt: '2026-05-22T14:00:00.000Z',
+        usedBySessionId: 900,
+        status: 'USED',
+    },
+];
+
+const linksResponse = (content: AgencyInviteLinkDTO[]) =>
+    HttpResponse.json({ content, totalElements: content.length, totalPages: 1, page: 0, size: 20 });
+
+// The agency select stays empty without a super-admin token; this handler just keeps the
+// on-mount agencies request from falling through to the (nonexistent) network.
+const emptyAgencies = http.get(AGENCIES_ENDPOINT, () => HttpResponse.json({ total: 0, _embedded: [] }));
+
+const meta = {
+    title: 'Organisms/Pages/Links/InviteLinks',
+    component: InviteLinksPage,
+    parameters: { layout: 'fullscreen' },
+    decorators: [
+        (Story) => (
+            <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+                <Story />
+            </QueryClientProvider>
+        ),
+    ],
+} satisfies Meta<typeof InviteLinksPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Existing invite links listed in the table. */
+export const Filled: Story = {
+    parameters: { msw: { handlers: [http.get(LINKS_ENDPOINT, () => linksResponse(LINKS)), emptyAgencies] } },
+};
+
+/** No invite links generated yet — the table shows its empty state. */
+export const Empty: Story = {
+    parameters: { msw: { handlers: [http.get(LINKS_ENDPOINT, () => linksResponse([])), emptyAgencies] } },
+};
+
+/** Links request in flight — the table renders its loading spinner. */
+export const Loading: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.get(LINKS_ENDPOINT, async () => {
+                    await delay('infinite');
+                    return linksResponse([]);
+                }),
+                emptyAgencies,
+            ],
+        },
+    },
+};
+
+/** Backend failure (500) — the load fails and the table stays empty. */
+export const Error: Story = {
+    parameters: {
+        msw: { handlers: [http.get(LINKS_ENDPOINT, () => new HttpResponse(null, { status: 500 })), emptyAgencies] },
+    },
+};

--- a/src/pages/Links/styles.module.scss
+++ b/src/pages/Links/styles.module.scss
@@ -9,7 +9,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 24px;
-    padding-bottom: 60px;
+    padding-bottom: 20px;
     flex-wrap: wrap;
 }
 

--- a/src/pages/Logs/CaseHandoverLogs/CaseHandoverLogs.stories.tsx
+++ b/src/pages/Logs/CaseHandoverLogs/CaseHandoverLogs.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse, delay } from 'msw';
+import type { CaseHandoverLogEntry } from '../../../types/caseHandoverLogs';
+import { CaseHandoverLogsPage } from './index';
+
+// GET .../service/users/case-handover/logs — `*` matches any configured origin.
+const ENDPOINT = '*/service/users/case-handover/logs';
+
+const ENTRIES: CaseHandoverLogEntry[] = [
+    {
+        requestId: 1,
+        sessionId: 5012,
+        status: 'GRANTED',
+        auditOutcome: 'AUTO_APPROVED',
+        reasonCode: 'VACATION',
+        reasonLabel: 'Urlaubsvertretung',
+        explanation: 'Regulärer Urlaub',
+        clientConsentRequired: false,
+        createdAt: '2026-06-01T09:12:00.000Z',
+        requesterConsultantId: 'c-1',
+        requesterName: 'Anna Muster',
+        previousName: 'Ben Beispiel',
+    },
+    {
+        requestId: 2,
+        sessionId: 5019,
+        status: 'PENDING_CLIENT_CONSENT',
+        auditOutcome: null,
+        reasonCode: 'SICKNESS',
+        reasonLabel: 'Krankheitsfall',
+        explanation: 'Kurzfristiger Ausfall',
+        clientConsentRequired: true,
+        createdAt: '2026-06-02T14:40:00.000Z',
+        requesterConsultantId: 'c-2',
+        requesterUsername: 'clara',
+        previousUsername: 'daniel',
+    },
+    {
+        requestId: 3,
+        sessionId: 5024,
+        status: 'DENIED',
+        auditOutcome: 'REJECTED',
+        reasonCode: 'OTHER',
+        reasonLabel: 'Sonstiges',
+        explanation: 'Nicht genehmigt',
+        clientConsentRequired: false,
+        createdAt: '2026-06-03T08:05:00.000Z',
+        requesterConsultantId: 'c-3',
+        requesterName: 'Erik Endres',
+        previousName: null,
+    },
+];
+
+const logsResponse = (entries: CaseHandoverLogEntry[]) =>
+    HttpResponse.json({ data: entries, total: entries.length, page: 1, perPage: 20 });
+
+const meta = {
+    title: 'Organisms/Pages/Logs/CaseHandoverLogs',
+    component: CaseHandoverLogsPage,
+    parameters: { layout: 'fullscreen' },
+    // Fresh React Query cache per story so the loading story is not served a sibling's cached data.
+    decorators: [
+        (Story) => (
+            <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+                <Story />
+            </QueryClientProvider>
+        ),
+    ],
+} satisfies Meta<typeof CaseHandoverLogsPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Populated audit trail of case-handover requests. */
+export const Filled: Story = {
+    parameters: { msw: { handlers: [http.get(ENDPOINT, () => logsResponse(ENTRIES))] } },
+};
+
+/** No handover requests recorded yet — the table shows its empty state. */
+export const Empty: Story = {
+    parameters: { msw: { handlers: [http.get(ENDPOINT, () => logsResponse([]))] } },
+};
+
+/** Request in flight — the table renders its loading spinner. */
+export const Loading: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.get(ENDPOINT, async () => {
+                    await delay('infinite');
+                    return logsResponse([]);
+                }),
+            ],
+        },
+    },
+};
+
+/** Backend failure (500) — the page surfaces the error alert above the table. */
+export const Error: Story = {
+    parameters: { msw: { handlers: [http.get(ENDPOINT, () => new HttpResponse(null, { status: 500 }))] } },
+};

--- a/src/pages/Profile/TwoFactorAuth/TwoFactorAuth.tsx
+++ b/src/pages/Profile/TwoFactorAuth/TwoFactorAuth.tsx
@@ -49,12 +49,16 @@ const TwoFactorAuth = () => {
     const [twoFactorType, setTwoFactorType] = useState<TwoFactorType>(TwoFactorType.App);
 
     const handleSwitchChange = useCallback(() => {
+        if (!userData?.twoFactorAuth) {
+            return;
+        }
+
         if (!userData.twoFactorAuth.isActive) {
             setOverlayActive(true);
         } else {
             deleteTwoFactorAuth(null);
         }
-    }, [userData?.twoFactorAuth?.isActive, overlayActive]);
+    }, [deleteTwoFactorAuth, userData?.twoFactorAuth]);
 
     const twoFactorAuthStepsOverlayStart: OverlayItem[] = useMemo(
         () => [
@@ -418,6 +422,7 @@ const TwoFactorAuth = () => {
                 <M3Switch
                     onChange={() => handleSwitchChange()}
                     checked={userData?.twoFactorAuth.isActive || false}
+                    disabled={!userData?.twoFactorAuth}
                     label={
                         userData?.twoFactorAuth.isActive
                             ? t('twoFactorAuth.switch.active.label')

--- a/src/pages/Profile/TwoFactorAuth/TwoFactorAuth.tsx
+++ b/src/pages/Profile/TwoFactorAuth/TwoFactorAuth.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
-import { Typography, Switch } from 'antd';
+import { Typography } from 'antd';
 import { useTranslation } from 'react-i18next';
+import { M3Switch } from '../../../components/M3Switch';
 import { FETCH_ERRORS } from '../../../api/fetchData';
 import { OVERLAY_FUNCTIONS, OverlayItem, OverlayWrapper, Overlay } from '../../../components/overlay/Overlay';
 import { BUTTON_TYPES } from '../../../components/button/Button';
@@ -414,10 +415,14 @@ const TwoFactorAuth = () => {
     return (
         <>
             <div className="twoFactorAuth__switch mb-m">
-                <Switch
-                    size="default"
-                    onChange={handleSwitchChange}
+                <M3Switch
+                    onChange={() => handleSwitchChange()}
                     checked={userData?.twoFactorAuth.isActive || false}
+                    label={
+                        userData?.twoFactorAuth.isActive
+                            ? t('twoFactorAuth.switch.active.label')
+                            : t('twoFactorAuth.switch.deactive.label')
+                    }
                 />
                 <Paragraph className="text desc">
                     {userData?.twoFactorAuth.isActive

--- a/src/pages/Tenants/Edit/General/styles.module.scss
+++ b/src/pages/Tenants/Edit/General/styles.module.scss
@@ -21,6 +21,8 @@
 
 .tenantInfoCard,
 .createCard {
+    width: 100%;
+    flex: 1 1 auto;
     min-width: 0;
 
     :global {
@@ -67,7 +69,7 @@
     width: 100%;
     min-width: 0;
     max-width: 100%;
-    margin-bottom: 36px;
+    margin-bottom: 16px;
 }
 
 .buttons {

--- a/src/pages/Tenants/List/styles.module.scss
+++ b/src/pages/Tenants/List/styles.module.scss
@@ -18,11 +18,6 @@
     gap: 16px 24px;
     width: 100%;
     margin-bottom: 24px;
-    padding-left: 32px;
-
-    @media (max-width: 767px) {
-        padding-left: 0;
-    }
 }
 
 .searchWithButton {

--- a/src/pages/Topics/List/TopicList.tsx
+++ b/src/pages/Topics/List/TopicList.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Modal, Space, Switch } from 'antd';
+import { Button, Modal, Space } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import { ColumnProps } from 'antd/lib/table';
 import { InterestsOutlined } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
+import { M3Switch } from '../../../components/M3Switch';
 import { TopicData } from '../../../types/topic';
 import { Status } from '../../../types/status';
 import { TopicDeletionModal } from './TopicDeletionModal';
@@ -184,7 +185,11 @@ export const TopicList = () => {
 
                 {canShowTopicSwitch && (
                     <>
-                        <Switch checked={isTopicsFeatureActive} onClick={onTopicsSwitch} />
+                        <M3Switch
+                            checked={isTopicsFeatureActive}
+                            label={t('topics.featureToggle')}
+                            onChange={() => onTopicsSwitch()}
+                        />
                         {t('topics.featureToggle')}
                     </>
                 )}

--- a/src/pages/users/Edit/index.tsx
+++ b/src/pages/users/Edit/index.tsx
@@ -7,7 +7,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { FETCH_ERRORS, X_REASON } from '../../../api/fetchData';
 import { Card } from '../../../components/Card';
 import { FormInputField } from '../../../components/FormInputField';
-import { FormPasswordField } from '../../../components/FormPasswordField';
+import { FormInputPasswordField } from '../../../components/FormInputPasswordField';
 import { FormTextAreaField } from '../../../components/FormTextAreaField';
 import { Page } from '../../../components/Page';
 import { SelectFormField, Option } from '../../../components/SelectFormField';
@@ -375,7 +375,7 @@ export const UserEditOrAdd = () => {
                             {!isEditing &&
                                 (typeOfUsers === TypeOfUser.Consultants || typeOfUsers === TypeOfUser.AgencyAdmins) && (
                                     <>
-                                        <FormPasswordField
+                                        <FormInputPasswordField
                                             name="password"
                                             labelKey="counselor.password"
                                             placeholderKey="placeholder.password"
@@ -391,7 +391,7 @@ export const UserEditOrAdd = () => {
                                                 },
                                             ]}
                                         />
-                                        <FormPasswordField
+                                        <FormInputPasswordField
                                             name="passwordConfirmation"
                                             labelKey="counselor.passwordConfirmation"
                                             placeholderKey="placeholder.password"

--- a/src/pages/users/List/UserManagement.stories.tsx
+++ b/src/pages/users/List/UserManagement.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { http, HttpResponse, delay } from 'msw';
+import type { CounselorData } from '../../../types/counselor';
+import { UserRole } from '../../../enums/UserRole';
+import { setStoryAuth, withAdminProviders } from '../../../utils/storybook/adminStoryDecorators';
+import { UsersList } from './index';
+
+// GET .../service/users/consultants/search — HAL body: `{ total, _embedded: [...] }`.
+const CONSULTANTS_ENDPOINT = '*/service/users/consultants/search';
+
+const CONSULTANTS: CounselorData[] = [
+    {
+        id: 'c-1',
+        key: 'c-1',
+        firstname: 'Anna',
+        lastname: 'Muster',
+        email: 'anna.muster@example.org',
+        username: 'amuster',
+        active: true,
+        absent: false,
+        formalLanguage: true,
+        gender: 'FEMALE',
+        phone: '',
+        agencies: [{ id: '101', name: 'Beratungsstelle Nord', postcode: '20095', city: 'Hamburg' }],
+        agencyIds: ['101'],
+        status: 'CREATED',
+        tenantId: '1',
+        tenantName: 'Demo-Mandant',
+    },
+    {
+        id: 'c-2',
+        key: 'c-2',
+        firstname: 'Ben',
+        lastname: 'Beispiel',
+        email: 'ben.beispiel@example.org',
+        username: 'bbeispiel',
+        active: false,
+        absent: true,
+        absenceMessage: 'Im Urlaub',
+        formalLanguage: false,
+        gender: 'MALE',
+        phone: '',
+        agencies: [{ id: '102', name: 'Jugendberatung Mitte', postcode: '10115', city: 'Berlin' }],
+        agencyIds: ['102'],
+        status: 'CREATED',
+        tenantId: '1',
+        tenantName: 'Demo-Mandant',
+    },
+];
+
+const consultantsResponse = (list: CounselorData[]) => HttpResponse.json({ total: list.length, _embedded: list });
+
+const meta = {
+    title: 'Organisms/Pages/Users/UserManagement',
+    component: UsersList,
+    parameters: { layout: 'fullscreen' },
+    decorators: [
+        (Story) => {
+            // Super-admin token so the create button + editable columns render.
+            setStoryAuth([UserRole.AgencyAdmin, UserRole.TenantAdmin, UserRole.UserAdmin], 0);
+            return withAdminProviders(Story);
+        },
+    ],
+} satisfies Meta<typeof UsersList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The consultants section with a populated, sortable table. */
+export const Filled: Story = {
+    parameters: { msw: { handlers: [http.get(CONSULTANTS_ENDPOINT, () => consultantsResponse(CONSULTANTS))] } },
+};
+
+/** No consultants yet — the table shows its empty state. */
+export const Empty: Story = {
+    parameters: { msw: { handlers: [http.get(CONSULTANTS_ENDPOINT, () => consultantsResponse([]))] } },
+};
+
+/** Request in flight — the table renders its loading spinner. */
+export const Loading: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.get(CONSULTANTS_ENDPOINT, async () => {
+                    await delay('infinite');
+                    return consultantsResponse([]);
+                }),
+            ],
+        },
+    },
+};
+
+/** Backend failure (500): the search helper degrades gracefully to an empty table. */
+export const Error: Story = {
+    parameters: { msw: { handlers: [http.get(CONSULTANTS_ENDPOINT, () => new HttpResponse(null, { status: 500 }))] } },
+};

--- a/src/pages/users/TenantAdminEdit/index.tsx
+++ b/src/pages/users/TenantAdminEdit/index.tsx
@@ -95,7 +95,7 @@ export const TenantAdminEditOrAdd = () => {
                 initialValues={{ tenantId, ...data }}
             >
                 <Row gutter={[24, 24]}>
-                    <Col span={12} md={6}>
+                    <Col xs={24} lg={12}>
                         <Card titleKey="tenantAdmins.card.personalDataTitle">
                             <FormInputField
                                 name="firstname"
@@ -124,7 +124,7 @@ export const TenantAdminEditOrAdd = () => {
                         </Card>
                     </Col>
                     {!isEditing && (
-                        <Col span={12} md={6}>
+                        <Col xs={24} lg={12}>
                             <Card titleKey="tenantAdmins.card.credentialsTitle">
                                 <FormInputField
                                     name="username"
@@ -150,7 +150,7 @@ export const TenantAdminEditOrAdd = () => {
                         </Col>
                     )}
                     {!isPlatformAdmin && (
-                        <Col span={12} md={6}>
+                        <Col xs={24} lg={12}>
                             <Card titleKey="tenantAdmins.card.tenantTitle">
                                 <SelectFormField
                                     name="tenantId"

--- a/src/pages/users/management/UserManagementTable.module.scss
+++ b/src/pages/users/management/UserManagementTable.module.scss
@@ -10,11 +10,7 @@
     gap: 16px 24px;
     width: 100%;
     margin-bottom: 32px;
-    padding-left: 32px;
-
-    @media (max-width: 767px) {
-        padding-left: 0;
-    }
+    
 }
 
 .searchWithButton {

--- a/src/pages/users/management/UserManagementTable.module.scss
+++ b/src/pages/users/management/UserManagementTable.module.scss
@@ -10,7 +10,6 @@
     gap: 16px 24px;
     width: 100%;
     margin-bottom: 32px;
-    
 }
 
 .searchWithButton {

--- a/src/pages/users/management/UserSectionPills.module.scss
+++ b/src/pages/users/management/UserSectionPills.module.scss
@@ -1,7 +1,7 @@
-.container {
-    margin-bottom: 24px;
+// .container {
+//     margin-bottom: 24px;
 
-    @media (min-width: 768px) {
-        margin-bottom: 48px;
-    }
-}
+//     @media (min-width: 768px) {
+//         margin-bottom: 48px;
+//     }
+// }

--- a/src/styles/components/form.less
+++ b/src/styles/components/form.less
@@ -49,4 +49,12 @@
 
 .formSwitchField__container {
     display: flex;
+    align-items: center;
+    gap: @spacing-s;
+}
+
+.formSwitchField__stateLabel {
+    color: var(--admin-form-label-text, rgba(0, 0, 0, 0.87));
+    font-size: @fontSize-s;
+    line-height: @lineHeightxs;
 }

--- a/src/styles/components/statistic.less
+++ b/src/styles/components/statistic.less
@@ -28,8 +28,7 @@
     align-items: start;
     justify-content: start;
     margin-bottom: 16px;
-    padding: 10px 0 12px;
-    background: var(--m3-surface-container, #f0edee);
+    padding: 0px 0 12px;
     gap: 10px 12px;
     grid-template-columns: minmax(0, 499px);
 }

--- a/src/utils/applyAdminTheme.test.ts
+++ b/src/utils/applyAdminTheme.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest';
-import { DEFAULT_ADMIN_SEED, applyAdminInvertedTheme, clearAdminInvertedThemeTokens } from './applyAdminTheme';
+import {
+    DEFAULT_ADMIN_SEED,
+    applyAdminInvertedTheme,
+    applyAdminTheme,
+    clearAdminInvertedThemeTokens,
+} from './applyAdminTheme';
 import { computeOrisoPalette } from './theme/orisoScheme';
 
 const BENCHMARK_SEED = '#a5000a';
@@ -19,6 +24,42 @@ const wcagRatio = (hexA: string, hexB: string): number => {
     const b = luminance(hexB);
     return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
 };
+
+describe('applyAdminTheme', () => {
+    it('overrides the --m3-* tokens with the light theme output', () => {
+        const root = document.createElement('div');
+        const applied = applyAdminTheme({ primaryColor: BENCHMARK_SEED }, root);
+        const { tokens } = computeOrisoPalette({ accentDark: BENCHMARK_SEED }, 'light');
+
+        expect(applied).toBe(true);
+        Object.entries(tokens)
+            .filter(([name]) => name.startsWith('--m3-'))
+            .forEach(([name, value]) => {
+                expect(root.style.getPropertyValue(name), name).toBe(value);
+            });
+    });
+
+    it('renders a light surface with a light on-primary switch thumb', () => {
+        const root = document.createElement('div');
+        applyAdminTheme({ primaryColor: BENCHMARK_SEED }, root);
+
+        // Light surfaces (matches Storybook), not the inverted dark shell.
+        expect(root.style.getPropertyValue('--m3-surface')).toBe('#fcf9f9');
+        // M3Switch thumb (fill=var(--m3-on-primary)) stays white on the red track.
+        expect(root.style.getPropertyValue('--m3-on-primary')).toBe('#ffffff');
+    });
+
+    it('keeps the static palette on an invalid stored seed', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const root = document.createElement('div');
+        const applied = applyAdminTheme({ primaryColor: 'not-a-hex' }, root);
+
+        expect(applied).toBe(false);
+        expect(root.style.length).toBe(0);
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+});
 
 describe('applyAdminInvertedTheme', () => {
     it('overrides the --m3-* tokens with the inverted theme output', () => {

--- a/src/utils/applyAdminTheme.ts
+++ b/src/utils/applyAdminTheme.ts
@@ -1,4 +1,4 @@
-import { computeOrisoPalette } from './theme/orisoScheme';
+import { computeOrisoPalette, type OrisoSchemeName } from './theme/orisoScheme';
 import { readSeeds, ThemingSeedFields } from './themeSeeds';
 
 export const DEFAULT_ADMIN_SEED = '#A5000A';
@@ -40,8 +40,9 @@ const normalizeSeed = (
     return expanded.toLowerCase();
 };
 
-export const applyAdminInvertedTheme = (
+const applyAdminSchemeTheme = (
     theming: ThemingSeedFields | null | undefined,
+    scheme: OrisoSchemeName,
     root: HTMLElement = document.documentElement,
 ): boolean => {
     try {
@@ -55,7 +56,7 @@ export const applyAdminInvertedTheme = (
                 primary,
                 accent,
             },
-            'inverted',
+            scheme,
         );
 
         Object.entries(tokens)
@@ -72,3 +73,22 @@ export const applyAdminInvertedTheme = (
         return false;
     }
 };
+
+/**
+ * Apply the light admin surface palette (the default admin appearance). Writes
+ * the tenant-seeded `--m3-*`/`--admin-*` tokens so the runtime theme matches the
+ * light components shown in Storybook.
+ */
+export const applyAdminTheme = (
+    theming: ThemingSeedFields | null | undefined,
+    root: HTMLElement = document.documentElement,
+): boolean => applyAdminSchemeTheme(theming, 'light', root);
+
+/**
+ * Apply the dark/inverted admin surface palette. Retained for surfaces that opt
+ * into the inverted shell (e.g. theme-builder previews).
+ */
+export const applyAdminInvertedTheme = (
+    theming: ThemingSeedFields | null | undefined,
+    root: HTMLElement = document.documentElement,
+): boolean => applyAdminSchemeTheme(theming, 'inverted', root);

--- a/src/utils/storybook/adminStoryDecorators.tsx
+++ b/src/utils/storybook/adminStoryDecorators.tsx
@@ -1,0 +1,42 @@
+import type { ReactElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { UseAppConfigProvider } from '../../context/useAppConfig';
+import { FeatureProvider } from '../../context/FeatureContext';
+import { setSessionTokens } from '../../api/auth/tokenSessionStore';
+import type { UserRole } from '../../enums/UserRole';
+import type { TenantData } from '../../types/tenant';
+
+/**
+ * Storybook-only helpers for rendering admin **page-tree organisms** (#285). These pages
+ * read app state that Storybook's global preview does not provide:
+ *   - `useAppConfigContext` throws when there is no `UseAppConfigProvider`;
+ *   - `useUserRoles` derives permissions from the JWT in the in-memory token store.
+ * `withAdminProviders` supplies the contexts; `setStoryAuth` installs a fake token so the
+ * permission-gated UI (create buttons, editable columns) renders. No real auth is involved.
+ */
+
+const toBase64Url = (value: object): string =>
+    btoa(JSON.stringify(value)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+/** Install a fake (unsigned) access token so `useUserRoles` resolves the given roles/tenant. */
+export const setStoryAuth = (roles: UserRole[], tenantId = 0): void => {
+    const header = toBase64Url({ alg: 'none', typ: 'JWT' });
+    const payload = toBase64Url({ realm_access: { roles }, tenantId, exp: 9_999_999_999 });
+    setSessionTokens(`${header}.${payload}.storybook`, 'storybook-refresh');
+};
+
+const STORY_TENANT = { id: 1, name: 'Demo-Mandant', settings: {}, licensing: {} } as unknown as TenantData;
+
+/**
+ * Wrap a story in the admin app contexts (config + features) with a fresh React Query
+ * cache (so a story's "loading" state is not served a sibling story's cached data).
+ */
+export const withAdminProviders = (Story: () => ReactElement): ReactElement => (
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <UseAppConfigProvider>
+            <FeatureProvider tenantData={STORY_TENANT} publicTenantData={STORY_TENANT}>
+                <Story />
+            </FeatureProvider>
+        </UseAppConfigProvider>
+    </QueryClientProvider>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,10 +1176,10 @@
   resolved "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz"
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
-"@esbuild/darwin-arm64@0.21.5":
+"@esbuild/win32-x64@0.21.5":
   version "0.21.5"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz"
-  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz"
+  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
@@ -1247,6 +1247,42 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@inquirer/ansi@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz"
+  integrity sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==
+
+"@inquirer/confirm@^6.0.11":
+  version "6.1.1"
+  resolved "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz"
+  integrity sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==
+  dependencies:
+    "@inquirer/core" "^11.2.1"
+    "@inquirer/type" "^4.0.7"
+
+"@inquirer/core@^11.2.1":
+  version "11.2.1"
+  resolved "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz"
+  integrity sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==
+  dependencies:
+    "@inquirer/ansi" "^2.0.7"
+    "@inquirer/figures" "^2.0.7"
+    "@inquirer/type" "^4.0.7"
+    cli-width "^4.1.0"
+    fast-wrap-ansi "^0.2.0"
+    mute-stream "^3.0.0"
+    signal-exit "^4.1.0"
+
+"@inquirer/figures@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz"
+  integrity sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==
+
+"@inquirer/type@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz"
+  integrity sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==
+
 "@joshwooding/vite-plugin-react-docgen-typescript@^0.7.0":
   version "0.7.0"
   resolved "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz"
@@ -1300,6 +1336,18 @@
   version "1.0.8"
   resolved "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz"
   integrity sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==
+
+"@mswjs/interceptors@^0.41.3":
+  version "0.41.9"
+  resolved "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz"
+  integrity sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==
+  dependencies:
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@open-draft/logger" "^0.3.0"
+    "@open-draft/until" "^2.0.0"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    strict-event-emitter "^0.5.1"
 
 "@mui/core-downloads-tracker@^9.1.2":
   version "9.1.2"
@@ -1406,10 +1454,33 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oxc-parser/binding-darwin-arm64@0.127.0":
+"@open-draft/deferred-promise@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz"
+  integrity sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==
+
+"@open-draft/deferred-promise@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz"
+  integrity sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==
+
+"@open-draft/logger@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz"
+  integrity sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==
+  dependencies:
+    is-node-process "^1.2.0"
+    outvariant "^1.4.0"
+
+"@open-draft/until@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz"
+  integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
+
+"@oxc-parser/binding-win32-x64-msvc@0.127.0":
   version "0.127.0"
-  resolved "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz"
-  integrity sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==
+  resolved "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz"
+  integrity sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==
 
 "@oxc-project/types@^0.127.0":
   version "0.127.0"
@@ -1421,15 +1492,15 @@
   resolved "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz"
   integrity sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==
 
-"@oxc-resolver/binding-darwin-arm64@11.21.3":
+"@oxc-resolver/binding-win32-x64-msvc@11.21.3":
   version "11.21.3"
-  resolved "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.21.3.tgz"
-  integrity sha512-wkh0qKZGHXVUDxFw3oA1TXnU2BDYY/r775oJflGeIr8uDPPoN2pk8gijQIzYRT6hoql/lg3+Tx/SaTn9e2/aGg==
+  resolved "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.21.3.tgz"
+  integrity sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q==
 
-"@parcel/watcher-darwin-arm64@2.5.6":
+"@parcel/watcher-win32-x64@2.5.6":
   version "2.5.6"
-  resolved "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz"
-  integrity sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==
+  resolved "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz"
+  integrity sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==
 
 "@parcel/watcher@^2.4.1":
   version "2.5.6"
@@ -1545,10 +1616,10 @@
   resolved "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz"
   integrity sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==
 
-"@rolldown/binding-darwin-arm64@1.1.4":
+"@rolldown/binding-win32-x64-msvc@1.1.4":
   version "1.1.4"
-  resolved "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz"
-  integrity sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==
+  resolved "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz"
+  integrity sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==
 
 "@rolldown/pluginutils@^1.0.0", "@rolldown/pluginutils@^1.0.1":
   version "1.0.1"
@@ -2210,7 +2281,7 @@
   resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz"
   integrity sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==
 
-"@types/node@^20.19.0":
+"@types/node@*", "@types/node@^20.19.0":
   version "20.19.43"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz"
   integrity sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==
@@ -2259,6 +2330,13 @@
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz"
   integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
 
+"@types/set-cookie-parser@^2.4.10":
+  version "2.4.10"
+  resolved "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz"
+  integrity sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/sinonjs__fake-timers@8.1.1":
   version "8.1.1"
   resolved "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz"
@@ -2268,6 +2346,11 @@
   version "2.3.10"
   resolved "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz"
   integrity sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==
+
+"@types/statuses@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz"
+  integrity sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==
 
 "@types/tmp@^0.2.3":
   version "0.2.6"
@@ -3146,6 +3229,11 @@ cli-truncate@^5.0.0:
     slice-ansi "^8.0.0"
     string-width "^8.2.0"
 
+cli-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz"
+  integrity sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==
+
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz"
@@ -3269,7 +3357,7 @@ convert-source-map@^2.0.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-cookie@^1.0.1:
+cookie@^1.0.1, cookie@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz"
   integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
@@ -4330,10 +4418,29 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-string-truncated-width@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz"
+  integrity sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==
+
+fast-string-width@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz"
+  integrity sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==
+  dependencies:
+    fast-string-truncated-width "^3.0.2"
+
 fast-uri@^3.0.1:
   version "3.1.2"
   resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz"
   integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+
+fast-wrap-ansi@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz"
+  integrity sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==
+  dependencies:
+    fast-string-width "^3.0.2"
 
 fastest-levenshtein@^1.0.16:
   version "1.0.16"
@@ -4435,11 +4542,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@~2.3.2, fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -4655,6 +4757,11 @@ graphemer@^1.4.0:
   resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+graphql@^16.13.2:
+  version "16.14.2"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz"
+  integrity sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==
+
 hard-rejection@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz"
@@ -4715,6 +4822,14 @@ hasown@^2.0.2, hasown@^2.0.3, hasown@^2.0.4:
   integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
+
+headers-polyfill@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz"
+  integrity sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==
+  dependencies:
+    "@types/set-cookie-parser" "^2.4.10"
+    set-cookie-parser "^3.0.1"
 
 hi-base32@0.5.1:
   version "0.5.1"
@@ -5054,6 +5169,11 @@ is-negative-zero@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
+
+is-node-process@^1.0.1, is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
 is-number-object@^1.1.1:
   version "1.1.1"
@@ -5442,10 +5562,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-lightningcss-darwin-arm64@1.32.0:
+lightningcss-win32-x64-msvc@1.32.0:
   version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz"
-  integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
+  resolved "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz"
+  integrity sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==
 
 lightningcss@^1.32.0:
   version "1.32.0"
@@ -5776,6 +5896,37 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msw-storybook-addon@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-2.0.7.tgz"
+  integrity sha512-TGmlxXy2TsaB6QcClVKRxqvay5f93xoLguHOihRFQ+gIEIyiyvcoQjkEeuOe7Y9qvddzGB1LyFomzPo9/EpnuQ==
+  dependencies:
+    is-node-process "^1.0.1"
+
+msw@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.npmjs.org/msw/-/msw-2.15.0.tgz"
+  integrity sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==
+  dependencies:
+    "@inquirer/confirm" "^6.0.11"
+    "@mswjs/interceptors" "^0.41.3"
+    "@open-draft/deferred-promise" "^3.0.0"
+    "@types/statuses" "^2.0.6"
+    cookie "^1.1.1"
+    graphql "^16.13.2"
+    headers-polyfill "^5.0.1"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    path-to-regexp "^6.3.0"
+    picocolors "^1.1.1"
+    rettime "^0.11.11"
+    statuses "^2.0.2"
+    strict-event-emitter "^0.5.1"
+    tough-cookie "^6.0.1"
+    type-fest "^5.5.0"
+    until-async "^3.0.2"
+    yargs "^17.7.2"
+
 multimatch@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz"
@@ -5786,6 +5937,11 @@ multimatch@^5.0.0:
     array-union "^2.1.0"
     arrify "^2.0.1"
     minimatch "^3.0.4"
+
+mute-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz"
+  integrity sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==
 
 nanoid@^3.3.12:
   version "3.3.15"
@@ -6003,6 +6159,11 @@ ospath@^1.2.2:
   resolved "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz"
   integrity sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==
 
+outvariant@^1.4.0, outvariant@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz"
+  integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
+
 own-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz"
@@ -6140,6 +6301,11 @@ path-scurry@^2.0.2:
   dependencies:
     lru-cache "^11.0.0"
     minipass "^7.1.2"
+
+path-to-regexp@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -7289,6 +7455,11 @@ restore-cursor@^5.0.0:
     onetime "^7.0.0"
     signal-exit "^4.1.0"
 
+rettime@^0.11.11:
+  version "0.11.11"
+  resolved "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz"
+  integrity sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==
+
 reusify@^1.0.4:
   version "1.1.0"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz"
@@ -7493,6 +7664,11 @@ set-cookie-parser@^2.6.0:
   version "2.7.2"
   resolved "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz"
   integrity sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==
+
+set-cookie-parser@^3.0.1:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz"
+  integrity sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -7733,6 +7909,11 @@ stackback@0.0.2:
   resolved "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz"
   integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
 
+statuses@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
+
 std-env@^4.0.0-rc.1:
   version "4.1.0"
   resolved "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz"
@@ -7766,6 +7947,11 @@ storybook@^10.4.6:
     semver "^7.7.3"
     use-sync-external-store "^1.5.0"
     ws "^8.18.0"
+
+strict-event-emitter@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz"
+  integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -8108,6 +8294,11 @@ table@^6.0.9, table@^6.8.1:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
+tagged-tag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz"
+  integrity sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
@@ -8204,12 +8395,24 @@ tldts-core@^6.1.86:
   resolved "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz"
   integrity sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==
 
+tldts-core@^7.4.8:
+  version "7.4.8"
+  resolved "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz"
+  integrity sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==
+
 tldts@^6.1.32:
   version "6.1.86"
   resolved "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz"
   integrity sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==
   dependencies:
     tldts-core "^6.1.86"
+
+tldts@^7.0.5:
+  version "7.4.8"
+  resolved "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz"
+  integrity sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==
+  dependencies:
+    tldts-core "^7.4.8"
 
 tmcp@^1.19.3:
   version "1.19.4"
@@ -8255,6 +8458,13 @@ tough-cookie@^5.0.0:
   integrity sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==
   dependencies:
     tldts "^6.1.32"
+
+tough-cookie@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz"
+  integrity sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==
+  dependencies:
+    tldts "^7.0.5"
 
 tr46@^5.1.0:
   version "5.1.1"
@@ -8362,6 +8572,13 @@ type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^5.5.0:
+  version "5.8.0"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz"
+  integrity sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==
+  dependencies:
+    tagged-tag "^1.0.0"
 
 typed-array-buffer@^1.0.3:
   version "1.0.3"
@@ -8487,6 +8704,11 @@ unplugin@^2.3.5:
     acorn "^8.15.0"
     picomatch "^4.0.3"
     webpack-virtual-modules "^0.6.2"
+
+until-async@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz"
+  integrity sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==
 
 untildify@^4.0.0:
   version "4.0.0"
@@ -8870,6 +9092,19 @@ yargs@^16.2.0:
     yargs-parser "^20.2.2"
 
 yargs@^17.5.1:
+  version "17.7.3"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yargs@^17.7.2:
   version "17.7.3"
   resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz"
   integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==


### PR DESCRIPTION
## Problem
The admin panel had drifted from the Storybook component library: it rendered in the dark/inverted theme, cards were inconsistent (white vs. gray, viewport-based fixed heights that clipped content and resized with the window), form inputs were cramped with an odd focus outline, the legal editors used two different rich-text editors, and several layouts (form columns, nav buttons, card headings) differed from page to page. Separately, large parts of the UI — many atoms/molecules and whole page-trees — weren't represented in Storybook at all, so regressions couldn't be caught there.

## What changed

### Theme
- Switched the admin panel from the inverted (dark) theme to the light theme so it matches Storybook. Added a light `applyAdminTheme` and renamed `useAdminInvertedTheme` → `useAdminTheme`.

### Cards
- Unified every card on the M3 gray + border + rounded surface (no more white cards) via the shared `Card` component, so it propagates everywhere and in Storybook.
- Dialog cards now use a min-height floor and grow to their content (removed the dvh-based fixed height + max-height that clipped content and resized with the viewport); the edit/footer stays pinned to the bottom.
- Card headings on forms are left-aligned & bold (match the default heading) instead of centered.
- `CardDeck` no longer stretches cards to the viewport height; carousel nav-arrow buttons normalized to one size across pages.

### Forms
- Fixed MUI inputs collapsing to ~33px (global border-box reset vs. MUI's content-box) → proper 56px height; focus now shows a clean black border.
- Reduced excessive field spacing; form cards fill their columns (dynamic width).
- `SelectFormField` multi-select grows with its tags instead of clipping.
- Admin create/edit form cards now lay out 50% per card (2-up, wrapping) to match the other forms.

### Legal editors
- Legal notice & Privacy now use the same native M3 rich-text editor as the Data-processing-agreement card.
- The DPA language control is restyled as the M3 🌐 language ▾ split button (translate-on-publish preserved), consistent across all three cards.

### Storybook coverage & consolidation (#276 half 1, incl. #283–#285)
- **Component stories** for the previously-undocumented building blocks: atoms (`Spinner`, `RadioButton`, `EditButton`, `Tooltip`, `CustomIcons`), molecules (`CopyToClipboard`, `LanguageSelector`, `SliderFormField`, `ColorSelector`, `FileUploader`, `LegalContentLanguageSelect`), and the `Page` organism — plus a realistic `ResizableTable` listing story.
- **#283 AdminSidebar**: extracted a presentational `AdminSidebar` from `ProtectedPageLayoutWrapper` (pre-resolved nav items + visibility flags as props; the wrapper keeps all permission/routing logic — no behavioral change) + unit test + `Molecules/AdminSidebar` story.
- **#284 API-mock foundation**: added `msw` + `msw-storybook-addon` (worker in `public/`, loader wired into `.storybook/preview.tsx`) and storied `GrantConsultantIdentityModal` in agencies-loaded / loading / empty states.
- **#285 page-trees**: organism-level stories for **Settings, Users, Links, Logs** across empty / filled / loading / error, backed by MSW and a shared story harness (`adminStoryDecorators`: `setStoryAuth` fake-JWT + `withAdminProviders`).
- **Consolidation**: removed the duplicate `FormPasswordField` (callers repointed to the identical `FormInputPasswordField`).

## Verification
- `npm run test` (505/505), `eslint . --max-warnings=0`, `prettier --check`, and `npm run build` (`tsc` + vite) all pass.
- Storybook: MSW-backed stories runtime-verified — the modal and all four page-trees render their states (Settings no longer triggers a logout redirect).
- `public/mockServiceWorker.js` is committed (Storybook serves it) and added to `.eslintignore`.
- ⚠️ Please smoke-test saving Legal notice / Privacy per language — that change rewires the per-language form binding.