### PR TITLE
fix: restore missing toasts/notifications (antd v5 + React 19)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/icons": "^5.6.1",
+        "@ant-design/v5-patch-for-react-19": "^1.0.3",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^9.1.1",
@@ -233,6 +234,20 @@
       },
       "peerDependencies": {
         "react": ">=16.9.0"
+      }
+    },
+    "node_modules/@ant-design/v5-patch-for-react-19": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/v5-patch-for-react-19/-/v5-patch-for-react-19-1.0.3.tgz",
+      "integrity": "sha512-iWfZuSUl5kuhqLUw7jJXUQFMMkM7XpW7apmKzQBQHU0cpifYW4A79xIBt9YVO5IBajKpPG5UKP87Ft7Yrw1p/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "antd": ">=5.22.6",
+        "react": ">=19.0.0",
+        "react-dom": ">=19.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "http://tenant1.onlineberatung.local/admin",
   "dependencies": {
     "@ant-design/icons": "^5.6.1",
+    "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^9.1.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,8 @@
 import 'react-app-polyfill/stable';
+// React 19 removed ReactDOM.render/unmountComponentAtNode, which antd v5's static
+// message/notification/Modal APIs rely on. Without this official patch those static
+// calls silently no-op (toasts/alerts never appear). Must run before any antd usage.
+import '@ant-design/v5-patch-for-react-19';
 import { useEffect, useState, type JSX } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createRoot, type Root } from 'react-dom/client';


### PR DESCRIPTION
## Problem
Success / warning / error toasts (and notifications/confirm dialogs) stopped appearing on admin-panel actions. Root cause: the app runs antd v5 on React 19, whose removal of `ReactDOM.render` breaks antd's static `message` / `notification` / `Modal` APIs — they silently no-op without the official compatibility patch. Inline components (`<Alert>`) still rendered, which is why the regression looked partial.

## What changed
- Added `@ant-design/v5-patch-for-react-19` and imported it once at the top of `src/index.tsx` (before `message.config()` / any antd usage). Restores the static APIs — no changes needed at the ~34 call sites.

## Verification
- `tsc` and `npm run build` pass.
- Confirmed at runtime that `message.success(...)` now mounts a toast under React 19 (a temporary probe, since the static call no-ops without the patch).