### PR TITLE
Merge pre-dev into dev

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -37,6 +37,7 @@ runs:
                   type=sha
                   type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
                   type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+                  type=raw,value=pre-dev,enable=${{ github.ref == 'refs/heads/pre-dev' }}
 
         - name: Build and Push Docker image
           id: build

--- a/.github/workflows/ci-feature-branch.yml
+++ b/.github/workflows/ci-feature-branch.yml
@@ -5,6 +5,7 @@ on:
         branches-ignore:
             - main
             - dev
+            - pre-dev
 
 jobs:
     build:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -5,6 +5,7 @@ on:
         branches:
             - main
             - dev
+            - pre-dev
 
 env:
     REGISTRY: ghcr.io

--- a/.github/workflows/ci-storybook-main.yml
+++ b/.github/workflows/ci-storybook-main.yml
@@ -5,6 +5,7 @@ on:
         branches:
             - main
             - dev
+            - pre-dev
 
 env:
     REGISTRY: ghcr.io

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/icons": "^5.6.1",
+        "@ant-design/v5-patch-for-react-19": "^1.0.3",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^9.1.1",
@@ -233,6 +234,20 @@
       },
       "peerDependencies": {
         "react": ">=16.9.0"
+      }
+    },
+    "node_modules/@ant-design/v5-patch-for-react-19": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/v5-patch-for-react-19/-/v5-patch-for-react-19-1.0.3.tgz",
+      "integrity": "sha512-iWfZuSUl5kuhqLUw7jJXUQFMMkM7XpW7apmKzQBQHU0cpifYW4A79xIBt9YVO5IBajKpPG5UKP87Ft7Yrw1p/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "antd": ">=5.22.6",
+        "react": ">=19.0.0",
+        "react-dom": ">=19.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "http://tenant1.onlineberatung.local/admin",
   "dependencies": {
     "@ant-design/icons": "^5.6.1",
+    "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^9.1.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,8 @@
 import 'react-app-polyfill/stable';
+// React 19 removed ReactDOM.render/unmountComponentAtNode, which antd v5's static
+// message/notification/Modal APIs rely on. Without this official patch those static
+// calls silently no-op (toasts/alerts never appear). Must run before any antd usage.
+import '@ant-design/v5-patch-for-react-19';
 import { useEffect, useState, type JSX } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createRoot, type Root } from 'react-dom/client';


### PR DESCRIPTION
Syncs `dev` with the latest `pre-dev` changes. `pre-dev` is ahead of `dev` with no divergent commits on `dev` (clean fast-forward relationship).

## Commits
- Merge pull request #288 from OpenResilienceInitiative/fix/error-toasts-not-showing
- feat: add @ant-design/v5-patch-for-react-19 dependency to support React 19 compatibility
- ci: build pre-dev branch (mirror dev pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)