### PR TITLE
chore(coderabbit): enable auto review on dev

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,7 +13,7 @@ reviews:
     poem: false
 
     auto_review:
-        enabled: false
+        enabled: true
         description_keyword: 'coderabbit: review'
         auto_incremental_review: false
         drafts: false


### PR DESCRIPTION
Flip `reviews.auto_review.enabled` from `false` to `true`. One-line change; `base_branches` already was `["dev"]`.

## Why

CodeRabbit is treated as a merge-blocking review gate for ORISO, but it has been **auto-reviewing nothing, silently**. Discovered on ORISO-UserService PR #370, where the check reported:

```
CodeRabbit / Review — skipping
"Auto reviews are disabled on base/target branches other than the default branch."
```

State before this change:

| repo | `.coderabbit.yaml` | effect |
|---|---|---|
| ORISO-Frontend, ORISO-Admin | present, but `auto_review.enabled: false` | never auto-reviews |
| ORISO-UserService, ORISO-AgencyService, ORISO-TenantService, ORISO-Helm | **absent** | CodeRabbit defaults → only auto-reviews PRs targeting the GitHub default branch, which is `main` — and nothing targets `main` |

Net effect: **no PR in any repo received an automatic CodeRabbit review.**

## What changes

`reviews.auto_review.enabled: true`, with `base_branches: ["dev"]`. A review gate that never runs protects nothing.

## Scope decision

`dev` only, deliberately. PRs targeting `pre-dev` still get no automatic review — the gate sits at `dev`. If feature PRs into `pre-dev` should also be reviewed, add `"pre-dev"` to `base_branches`.

## Base branch

This PR targets **`dev`**, not `pre-dev`: CodeRabbit reads `.coderabbit.yaml` from the base branch of the PR it reviews, so with `base_branches: ["dev"]` the config has to exist on `dev` to have any effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
