### PR TITLE
feat: wire statistics dashboard to real data

### DIFF
--- a/src/api/statistic/getDashboardStatistics.ts
+++ b/src/api/statistic/getDashboardStatistics.ts
@@ -1,0 +1,71 @@
+import { adminStatisticsDashboardEndpoint } from '../../appConfig';
+
+import { FETCH_METHODS, fetchData, FETCH_SUCCESS } from '../fetchData';
+
+export interface AdminDashboardPeriodCounts {
+    today: number;
+    yesterday: number;
+    thisWeek: number;
+    total: number;
+    thisYear: number;
+    lastYear: number;
+}
+
+export interface AdminDashboardMetrics {
+    enquiriesCurrentMonth: number;
+    enquiriesPreviousMonth: number;
+    activeCases: number;
+    activeConversationsToday: number;
+    groupChatsTotal: number;
+}
+
+export interface AdminDashboardDailyCount {
+    date: string;
+    count: number;
+}
+
+export interface AdminDashboardMonthlyTopic {
+    month: string;
+    topicId: number | null;
+    sessionCount: number;
+    sharePercent: number;
+}
+
+export interface AdminDashboardTarget {
+    targetType: 'TENANT' | 'AGENCY';
+    tenantId: number | null;
+    agencyId: number | null;
+    counselorCount: number;
+    /**
+     * KDG small-cell suppression: true when the target covers fewer than two counsellor
+     * accounts. All counselling metrics are omitted by the backend in that case.
+     */
+    suppressed: boolean;
+    metrics: AdminDashboardMetrics | null;
+    dailyNewSessions: AdminDashboardDailyCount[];
+    monthlyTopTopics: AdminDashboardMonthlyTopic[];
+    sessionCountsByPeriod: AdminDashboardPeriodCounts | null;
+    groupChatCountsByPeriod: AdminDashboardPeriodCounts | null;
+}
+
+export interface AdminDashboardStatisticsResponse {
+    generatedAt: string;
+    scope: 'PLATFORM' | 'TENANT' | 'AGENCY';
+    targets: AdminDashboardTarget[];
+}
+
+/**
+ * Retrieves real counselling statistics for the admin dashboard, scoped to the caller
+ * (platform admin, tenant admin or agency admin). Served by the UserService from the
+ * application-layer database only.
+ */
+const getDashboardStatistics = (): Promise<AdminDashboardStatisticsResponse> => {
+    return fetchData({
+        url: adminStatisticsDashboardEndpoint,
+        method: FETCH_METHODS.GET,
+        skipAuth: false,
+        responseHandling: [FETCH_SUCCESS.CONTENT],
+    });
+};
+
+export default getDashboardStatistics;

--- a/src/api/statistic/getDashboardStatistics.ts
+++ b/src/api/statistic/getDashboardStatistics.ts
@@ -51,6 +51,11 @@ export interface AdminDashboardTarget {
 export interface AdminDashboardStatisticsResponse {
     generatedAt: string;
     scope: 'PLATFORM' | 'TENANT' | 'AGENCY';
+    /**
+     * True only when the backend skipped KDG small-cell suppression — possible in
+     * non-production environments only (fail-closed on the prod profile).
+     */
+    suppressionDisabled?: boolean;
     targets: AdminDashboardTarget[];
 }
 

--- a/src/appConfig.ts
+++ b/src/appConfig.ts
@@ -57,6 +57,7 @@ export const caseHandoverReasonPoliciesEndpoint = `${userServiceURL}/service/use
 export const inactiveAccountAuditLogsEndpoint = `${userServiceURL}/service/users/inactive-accounts/audit-logs`;
 export const agencyAdminsSearchEndpoint = `${userServiceURL}/service/useradmin/agencyadmins/search`;
 export const registrationDataEndpoint = `${mainURL}/service/statistics/registration`;
+export const adminStatisticsDashboardEndpoint = `${userServiceURL}/service/useradmin/statistics/dashboard`;
 export const invitelinksEndpoint = `${userServiceURL}/service/useradmin/invitelinks`;
 export const accountInvitesEndpoint = `${userServiceURL}/service/useradmin/account-invites`;
 export const inviteEmailTemplatesEndpoint = `${userServiceURL}/service/useradmin/invite-email-templates`;

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1162,5 +1162,6 @@
     "statistic.dashboard.text.currentlyInCounselling": "Aktuell in Beratung",
     "statistic.dashboard.filter.suppressed": "Statistik unterdrückt",
     "statistic.dashboard.suppressedNotice": "Für Bereiche mit weniger als zwei Beratenden werden aus Datenschutzgründen keine Statistiken angezeigt.",
-    "statistic.dashboard.loadError": "Statistikdaten konnten nicht geladen werden."
+    "statistic.dashboard.loadError": "Statistikdaten konnten nicht geladen werden.",
+    "statistic.dashboard.suppressionDisabledNotice": "Kleinzellen-Schutz deaktiviert – nur für Testumgebungen"
 }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1158,5 +1158,9 @@
     "tenant.settings.cardDeck.previous": "Vorherige Einstellungen anzeigen",
     "searchInput.clear": "Suche löschen",
     "searchInput.submit": "Suche ausführen",
-    "agency.postcode.minimum": "Die Postleitzahl muss aus 5 Ziffern bestehen."
+    "agency.postcode.minimum": "Die Postleitzahl muss aus 5 Ziffern bestehen.",
+    "statistic.dashboard.text.currentlyInCounselling": "Aktuell in Beratung",
+    "statistic.dashboard.filter.suppressed": "Statistik unterdrückt",
+    "statistic.dashboard.suppressedNotice": "Für Bereiche mit weniger als zwei Beratenden werden aus Datenschutzgründen keine Statistiken angezeigt.",
+    "statistic.dashboard.loadError": "Statistikdaten konnten nicht geladen werden."
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1162,5 +1162,6 @@
     "statistic.dashboard.text.currentlyInCounselling": "Currently in counselling",
     "statistic.dashboard.filter.suppressed": "Statistics suppressed",
     "statistic.dashboard.suppressedNotice": "For privacy reasons, no statistics are shown for units with fewer than two counsellors.",
-    "statistic.dashboard.loadError": "Statistics data could not be loaded."
+    "statistic.dashboard.loadError": "Statistics data could not be loaded.",
+    "statistic.dashboard.suppressionDisabledNotice": "Small-cell protection disabled – test environments only"
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1158,5 +1158,9 @@
     "users.sections.myAccess": "My access",
     "users.sections.tenants": "Tenant admin",
     "searchInput.clear": "Clear search",
-    "searchInput.submit": "Run search"
+    "searchInput.submit": "Run search",
+    "statistic.dashboard.text.currentlyInCounselling": "Currently in counselling",
+    "statistic.dashboard.filter.suppressed": "Statistics suppressed",
+    "statistic.dashboard.suppressedNotice": "For privacy reasons, no statistics are shown for units with fewer than two counsellors.",
+    "statistic.dashboard.loadError": "Statistics data could not be loaded."
 }

--- a/src/pages/Statistic.test.tsx
+++ b/src/pages/Statistic.test.tsx
@@ -115,6 +115,25 @@ describe('Statistic page', () => {
         expect(screen.queryByText('Caritas NRW')).toBeNull();
     });
 
+    it('shows a warning banner when small-cell suppression is disabled', async () => {
+        dashboardMock.mockResolvedValue({ ...response, suppressionDisabled: true });
+
+        renderStatistic();
+
+        await waitFor(() =>
+            expect(screen.getByText('Kleinzellen-Schutz deaktiviert – nur für Testumgebungen')).toBeInTheDocument(),
+        );
+    });
+
+    it('does not show the suppression warning banner by default', async () => {
+        dashboardMock.mockResolvedValue(response);
+
+        renderStatistic();
+
+        await waitFor(() => expect(screen.getAllByText('12').length).toBeGreaterThan(0));
+        expect(screen.queryByText('Kleinzellen-Schutz deaktiviert – nur für Testumgebungen')).toBeNull();
+    });
+
     it('shows an error notice when the statistics endpoint fails', async () => {
         dashboardMock.mockRejectedValue(new Error('boom'));
 

--- a/src/pages/Statistic.test.tsx
+++ b/src/pages/Statistic.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { AdminDashboardStatisticsResponse } from '../api/statistic/getDashboardStatistics';
+import { UserRole } from '../enums/UserRole';
+
+vi.mock('../api/statistic/getDashboardStatistics', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../api/statistic/getDashboardStatistics')>();
+    return { ...actual, default: vi.fn() };
+});
+vi.mock('../api/agency/getAgencyData', () => ({ default: vi.fn().mockResolvedValue({ total: 0, data: [] }) }));
+vi.mock('../api/tenant/searchTenantData', () => ({
+    searchTenantData: vi.fn().mockResolvedValue({ total: 0, data: [] }),
+}));
+vi.mock('../api/topic/getTopicData', () => ({ default: vi.fn().mockResolvedValue({ total: 0, data: [] }) }));
+vi.mock('../hooks/useUserRoles.hook', () => ({
+    useUserRoles: () => ({
+        roles: [UserRole.TenantAdmin],
+        hasRole: (role: UserRole | UserRole[]) => (Array.isArray(role) ? role : [role]).includes(UserRole.TenantAdmin),
+        isSuperAdmin: false,
+        isTechnicalAccount: false,
+        isTenantScopedAdmin: true,
+        tenantId: 5,
+    }),
+}));
+
+import getDashboardStatistics from '../api/statistic/getDashboardStatistics';
+import i18n from '../i18n';
+import { Statistic } from './Statistic';
+
+const dashboardMock = vi.mocked(getDashboardStatistics);
+
+const periodCounts = (total: number) => ({
+    today: 0,
+    yesterday: 0,
+    thisWeek: 1,
+    total,
+    thisYear: total,
+    lastYear: 0,
+});
+
+const response: AdminDashboardStatisticsResponse = {
+    generatedAt: '2026-07-11T10:00:00Z',
+    scope: 'TENANT',
+    targets: [
+        {
+            targetType: 'TENANT',
+            tenantId: 5,
+            agencyId: null,
+            counselorCount: 4,
+            suppressed: false,
+            metrics: {
+                enquiriesCurrentMonth: 12,
+                enquiriesPreviousMonth: 10,
+                activeCases: 7,
+                activeConversationsToday: 2,
+                groupChatsTotal: 3,
+            },
+            dailyNewSessions: [],
+            monthlyTopTopics: [],
+            sessionCountsByPeriod: periodCounts(20),
+            groupChatCountsByPeriod: periodCounts(3),
+        },
+    ],
+};
+
+const renderStatistic = () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    return render(
+        <QueryClientProvider client={client}>
+            <Statistic />
+        </QueryClientProvider>,
+    );
+};
+
+beforeEach(() => {
+    dashboardMock.mockReset();
+    window.localStorage.clear();
+    // jsdom has no matchMedia; report prefers-reduced-motion so animated
+    // counter values render their final numbers synchronously.
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+});
+
+describe('Statistic page', () => {
+    it('initialises i18n with German translations', async () => {
+        await i18n.changeLanguage('de');
+        expect(i18n.language).toBe('de');
+    });
+
+    it('renders real backend values instead of mock data', async () => {
+        dashboardMock.mockResolvedValue(response);
+
+        renderStatistic();
+
+        // enquiries of the current month from the API response
+        await waitFor(() => expect(screen.getAllByText('12').length).toBeGreaterThan(0));
+        // previous month detail is computed from the real comparison value
+        expect(screen.getAllByText(/Vormonat gesamt 10/).length).toBeGreaterThan(0);
+        // metrics without an application-layer source degrade to "Keine Daten"
+        expect(screen.getAllByText('Keine Daten').length).toBeGreaterThan(0);
+        // legacy mock numbers must be gone
+        expect(screen.queryByText('312')).toBeNull();
+        expect(screen.queryByText('Caritas NRW')).toBeNull();
+    });
+
+    it('shows an error notice when the statistics endpoint fails', async () => {
+        dashboardMock.mockRejectedValue(new Error('boom'));
+
+        renderStatistic();
+
+        await waitFor(() =>
+            expect(screen.getByText('Statistikdaten konnten nicht geladen werden.')).toBeInTheDocument(),
+        );
+    });
+});

--- a/src/pages/Statistic.tsx
+++ b/src/pages/Statistic.tsx
@@ -2774,6 +2774,15 @@ export const Statistic = () => {
                                 )}
                             </p>
                         )}
+                        {statisticData.suppressionDisabled && (
+                            <p className="statisticDashboard__notice statisticDashboard__notice--warning" role="alert">
+                                {translateDashboardKey(
+                                    translate,
+                                    'statistic.dashboard.suppressionDisabledNotice',
+                                    'Kleinzellen-Schutz deaktiviert – nur für Testumgebungen',
+                                )}
+                            </p>
+                        )}
                         {suppressedSelectedTargetCount > 0 && (
                             <p className="statisticDashboard__notice statisticDashboard__notice--info">
                                 {translateDashboardKey(

--- a/src/pages/Statistic.tsx
+++ b/src/pages/Statistic.tsx
@@ -38,6 +38,22 @@ import {
     storeCardMenuSelection,
     storeFilterTargetSelection,
 } from './Statistic/statisticPreferences';
+import {
+    buildCaseChartDateLabels,
+    caseChartDayCodes,
+    getTodayDayCode,
+    NO_DATA_LABEL,
+} from './Statistic/statisticDashboardData';
+import type {
+    ConversationValues,
+    FilterTarget,
+    FilterTargetMetricStats,
+    FilterTargetStatistics,
+    MetricValue,
+    StatisticData,
+    TopicStatistic,
+} from './Statistic/statisticDashboardData';
+import { useStatisticDashboardData } from './Statistic/useStatisticDashboardData.hook';
 import type {
     CardMenuKey,
     CardMenuOption,
@@ -129,6 +145,8 @@ const dashboardTextKeyByValue: Record<string, string> = {
     Interna: 'statistic.dashboard.text.internal',
     'Kennzahl in diesem Dashboard-Slot auswählen': 'statistic.dashboard.menu.selectDashboardMetric',
     'Keine Daten': 'statistic.dashboard.text.noData',
+    'Aktuell in Beratung': 'statistic.dashboard.text.currentlyInCounselling',
+    'Statistik unterdrückt': 'statistic.dashboard.filter.suppressed',
     'Keine Filter verfügbar': 'statistic.dashboard.filter.noFilters',
     'Letzter Monat': 'statistic.dashboard.text.lastMonth',
     Live: 'statistic.dashboard.text.live',
@@ -355,84 +373,6 @@ const scopeDefinitions: Record<ScopeKey, ScopeDefinition> = {
         label: 'Auf Beratungsstellenebene',
         icon: ScopeAgencyIcon,
     },
-};
-
-type FilterTargetType = 'Träger' | 'Beratungsstelle';
-
-interface FilterTarget {
-    id: string;
-    label: string;
-    type: FilterTargetType;
-    detail: string;
-}
-
-const filterTargetsByScope: Record<ScopeKey, FilterTarget[]> = {
-    platform: [
-        {
-            id: 'tenant-caritas-nrw',
-            label: 'Caritas NRW',
-            type: 'Träger',
-            detail: '35 Beratungsstellen',
-        },
-        {
-            id: 'tenant-diakonie-rwl',
-            label: 'Diakonie RWL',
-            type: 'Träger',
-            detail: '22 Beratungsstellen',
-        },
-        {
-            id: 'tenant-paritaet-nrw',
-            label: 'Der Paritätische NRW',
-            type: 'Träger',
-            detail: '14 Beratungsstellen',
-        },
-        {
-            id: 'agency-u25-duesseldorf',
-            label: 'U25 Düsseldorf',
-            type: 'Beratungsstelle',
-            detail: 'Caritas NRW',
-        },
-        {
-            id: 'agency-schuldnerberatung-koeln',
-            label: 'Schuldnerberatung Köln',
-            type: 'Beratungsstelle',
-            detail: 'Caritas NRW',
-        },
-        {
-            id: 'agency-jugendberatung-essen',
-            label: 'Jugendberatung Essen',
-            type: 'Beratungsstelle',
-            detail: 'Caritas NRW',
-        },
-    ],
-    tenant: [
-        {
-            id: 'agency-u25-duesseldorf',
-            label: 'U25 Düsseldorf',
-            type: 'Beratungsstelle',
-            detail: 'Caritas NRW',
-        },
-        {
-            id: 'agency-schuldnerberatung-koeln',
-            label: 'Schuldnerberatung Köln',
-            type: 'Beratungsstelle',
-            detail: 'Caritas NRW',
-        },
-        {
-            id: 'agency-jugendberatung-essen',
-            label: 'Jugendberatung Essen',
-            type: 'Beratungsstelle',
-            detail: 'Caritas NRW',
-        },
-    ],
-    agency: [
-        {
-            id: 'agency-u25-duesseldorf',
-            label: 'U25 Düsseldorf',
-            type: 'Beratungsstelle',
-            detail: 'eigene Beratungsstelle',
-        },
-    ],
 };
 
 const normalizeFilterSearch = (value: string, locale: string) => value.trim().toLocaleLowerCase(locale);
@@ -1079,431 +1019,30 @@ const withMetricMenuDescription = (option: CardMenuOption): CardMenuOption => ({
     description: option.description || metricMenuDescriptionByKey[option.key],
 });
 
-const demoMetricOverridesByScope: Record<ScopeKey, Partial<Record<CardMenuKey, Partial<CardMenuOption>>>> = {
-    platform: {
-        activeAgencies: { value: '3' },
-        activeConversations: { value: '4' },
-        all: { value: '9', detail: 'Vormonat gesamt 11' },
-        cases: { value: '8' },
-        conversationsTotal: { value: '7' },
-        counselors: { value: '6' },
-        groups: { value: '2' },
-        liveChat: { value: '3' },
-        messagesCounselors: { value: '5' },
-        messagesPerSession: { value: '2,6' },
-        messagesSeekers: { value: '13' },
-        oneToOne: { value: '4' },
-        textMessagesTotal: { value: '18' },
-        videoCallCount: { value: '1' },
-    },
-    tenant: {
-        activeAgencies: { value: '2' },
-        activeConversations: { value: '3' },
-        all: { value: '5', detail: 'Vormonat gesamt 6' },
-        cases: { value: '5' },
-        conversationsTotal: { value: '5' },
-        counselors: { value: '4' },
-        groups: { value: '1' },
-        liveChat: { value: '2' },
-        messagesCounselors: { value: '4' },
-        messagesPerSession: { value: '2,4' },
-        messagesSeekers: { value: '8' },
-        oneToOne: { value: '2' },
-        textMessagesTotal: { value: '12' },
-        videoCallCount: { value: '0' },
-    },
-    agency: {
-        activeCounselors: { value: '2' },
-        activeConversations: { value: '2' },
-        all: { value: '3', detail: 'Vormonat gesamt 4' },
-        cases: { value: '3' },
-        conversationsTotal: { value: '3' },
-        counselors: { value: '2' },
-        groups: { value: '1' },
-        liveChat: { value: '1' },
-        messagesCounselors: { value: '2' },
-        messagesPerSession: { value: '2,3' },
-        messagesSeekers: { value: '5' },
-        oneToOne: { value: '1' },
-        textMessagesTotal: { value: '7' },
-        videoCallCount: { value: '0' },
-    },
-};
-
-const caseChartDateLabelsByPeriod: Record<CasePeriodKey, string[]> = {
-    thisWeek: ['Mo, 9 Jul', 'Di, 10 Jul', 'Mi, 11 Jul', 'Do, 12 Jul', 'Fr, 13 Jul', 'Sa, 14 Jul', 'So, 15 Jul'],
-    lastWeek: ['Mo, 2 Jul', 'Di, 3 Jul', 'Mi, 4 Jul', 'Do, 5 Jul', 'Fr, 6 Jul', 'Sa, 7 Jul', 'So, 8 Jul'],
-    twoWeeksAgo: ['Mo, 25 Jun', 'Di, 26 Jun', 'Mi, 27 Jun', 'Do, 28 Jun', 'Fr, 29 Jun', 'Sa, 30 Jun', 'So, 1 Jul'],
-    threeWeeksAgo: ['Mo, 18 Jun', 'Di, 19 Jun', 'Mi, 20 Jun', 'Do, 21 Jun', 'Fr, 22 Jun', 'Sa, 23 Jun', 'So, 24 Jun'],
-    fourWeeksAgo: ['Mo, 11 Jun', 'Di, 12 Jun', 'Mi, 13 Jun', 'Do, 14 Jun', 'Fr, 15 Jun', 'Sa, 16 Jun', 'So, 17 Jun'],
-};
-
-const caseChartDays = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
-
-const createDemoCaseChart = (period: CasePeriodKey, values: number[]): CaseChartBar[] =>
-    caseChartDays.map((day, index) => ({
-        day,
-        dateLabel: caseChartDateLabelsByPeriod[period][index],
-        value: values[index],
-        isDefaultSelected: day === 'Do',
-    }));
-
-const demoCaseChartsByScope: Record<ScopeKey, Record<CasePeriodKey, CaseChartBar[]>> = {
-    platform: {
-        thisWeek: createDemoCaseChart('thisWeek', [1, 2, 1, 4, 3, 1, 0]),
-        lastWeek: createDemoCaseChart('lastWeek', [0, 1, 2, 3, 2, 1, 0]),
-        twoWeeksAgo: createDemoCaseChart('twoWeeksAgo', [1, 1, 1, 2, 2, 0, 0]),
-        threeWeeksAgo: createDemoCaseChart('threeWeeksAgo', [0, 1, 1, 2, 1, 0, 0]),
-        fourWeeksAgo: createDemoCaseChart('fourWeeksAgo', [0, 1, 0, 1, 1, 0, 0]),
-    },
-    tenant: {
-        thisWeek: createDemoCaseChart('thisWeek', [0, 1, 1, 3, 1, 0, 0]),
-        lastWeek: createDemoCaseChart('lastWeek', [0, 1, 0, 2, 1, 0, 0]),
-        twoWeeksAgo: createDemoCaseChart('twoWeeksAgo', [0, 0, 1, 2, 0, 0, 0]),
-        threeWeeksAgo: createDemoCaseChart('threeWeeksAgo', [0, 1, 0, 1, 1, 0, 0]),
-        fourWeeksAgo: createDemoCaseChart('fourWeeksAgo', [0, 0, 1, 1, 0, 0, 0]),
-    },
-    agency: {
-        thisWeek: createDemoCaseChart('thisWeek', [0, 1, 0, 2, 1, 0, 0]),
-        lastWeek: createDemoCaseChart('lastWeek', [0, 0, 1, 1, 1, 0, 0]),
-        twoWeeksAgo: createDemoCaseChart('twoWeeksAgo', [0, 1, 0, 1, 0, 0, 0]),
-        threeWeeksAgo: createDemoCaseChart('threeWeeksAgo', [0, 0, 0, 1, 1, 0, 0]),
-        fourWeeksAgo: createDemoCaseChart('fourWeeksAgo', [0, 0, 1, 0, 1, 0, 0]),
-    },
-};
-
-type ConversationValues = [number, number, number, number];
-
-interface TopicStatistic {
-    label: string;
-    share: number;
-}
-
-interface FilterTargetMetricStats {
-    activeAgencies: number;
-    activeConversations: number;
-    cases: number;
-    conversationsTotal: number;
-    counselors: number;
-    groups: number;
-    liveChat: number;
-    messagesCounselors: number;
-    messagesSeekers: number;
-    oneToOne: number;
-    phoneCalls: number;
-    textMessagesTotal: number;
-    videoCalls: number;
-    voiceMessages: number;
-    topTopic: TopicStatistic;
-    previousMonth: TopicStatistic;
-    twoMonthsAgo: TopicStatistic;
-    threeMonthsAgo: TopicStatistic;
-}
-
-interface FilterTargetStatistics {
-    caseCharts: Record<CasePeriodKey, number[]>;
-    conversation: Record<ConversationPeriodKey, ConversationValues>;
-    metrics: FilterTargetMetricStats;
-}
-
-const fallbackStatisticTargetIdsByScope: Record<ScopeKey, string[]> = {
-    platform: ['tenant-caritas-nrw', 'tenant-diakonie-rwl', 'tenant-paritaet-nrw'],
-    tenant: ['tenant-caritas-nrw'],
-    agency: ['agency-u25-duesseldorf'],
-};
-
-const filterTargetStatisticsById: Record<string, FilterTargetStatistics> = {
-    'tenant-caritas-nrw': {
-        metrics: {
-            activeAgencies: 35,
-            activeConversations: 4,
-            cases: 8,
-            conversationsTotal: 7,
-            counselors: 6,
-            groups: 2,
-            liveChat: 3,
-            messagesCounselors: 5,
-            messagesSeekers: 13,
-            oneToOne: 4,
-            phoneCalls: 1,
-            textMessagesTotal: 18,
-            videoCalls: 0,
-            voiceMessages: 2,
-            topTopic: { label: 'Schulden', share: 59 },
-            previousMonth: { label: 'Wohnen', share: 44 },
-            twoMonthsAgo: { label: 'Trennung', share: 31 },
-            threeMonthsAgo: { label: 'Sucht', share: 27 },
-        },
-        caseCharts: {
-            thisWeek: [1, 2, 1, 4, 3, 1, 0],
-            lastWeek: [0, 1, 2, 3, 2, 1, 0],
-            twoWeeksAgo: [1, 1, 1, 2, 2, 0, 0],
-            threeWeeksAgo: [0, 1, 1, 2, 1, 0, 0],
-            fourWeeksAgo: [0, 1, 0, 1, 1, 0, 0],
-        },
-        conversation: {
-            today: [1, 2, 0, 0],
-            yesterday: [1, 1, 1, 0],
-            thisWeek: [2, 5, 3, 0],
-            total: [7, 14, 11, 0],
-            thisYear: [4, 11, 8, 0],
-            lastYear: [5, 9, 6, 1],
-        },
-    },
-    'tenant-diakonie-rwl': {
-        metrics: {
-            activeAgencies: 22,
-            activeConversations: 3,
-            cases: 5,
-            conversationsTotal: 4,
-            counselors: 4,
-            groups: 1,
-            liveChat: 2,
-            messagesCounselors: 4,
-            messagesSeekers: 8,
-            oneToOne: 2,
-            phoneCalls: 1,
-            textMessagesTotal: 12,
-            videoCalls: 0,
-            voiceMessages: 1,
-            topTopic: { label: 'Familie', share: 42 },
-            previousMonth: { label: 'Schulden', share: 34 },
-            twoMonthsAgo: { label: 'Wohnen', share: 25 },
-            threeMonthsAgo: { label: 'Trennung', share: 21 },
-        },
-        caseCharts: {
-            thisWeek: [0, 1, 1, 2, 1, 0, 0],
-            lastWeek: [0, 1, 0, 2, 1, 0, 0],
-            twoWeeksAgo: [0, 0, 1, 1, 1, 0, 0],
-            threeWeeksAgo: [0, 1, 0, 1, 0, 0, 0],
-            fourWeeksAgo: [0, 0, 1, 1, 0, 0, 0],
-        },
-        conversation: {
-            today: [1, 1, 0, 0],
-            yesterday: [0, 1, 1, 0],
-            thisWeek: [2, 3, 1, 0],
-            total: [5, 8, 5, 0],
-            thisYear: [3, 6, 4, 0],
-            lastYear: [4, 6, 3, 1],
-        },
-    },
-    'tenant-paritaet-nrw': {
-        metrics: {
-            activeAgencies: 14,
-            activeConversations: 2,
-            cases: 4,
-            conversationsTotal: 3,
-            counselors: 3,
-            groups: 1,
-            liveChat: 1,
-            messagesCounselors: 3,
-            messagesSeekers: 6,
-            oneToOne: 2,
-            phoneCalls: 0,
-            textMessagesTotal: 9,
-            videoCalls: 0,
-            voiceMessages: 1,
-            topTopic: { label: 'Ausbildung', share: 38 },
-            previousMonth: { label: 'Familie', share: 28 },
-            twoMonthsAgo: { label: 'Schulden', share: 22 },
-            threeMonthsAgo: { label: 'Wohnen', share: 18 },
-        },
-        caseCharts: {
-            thisWeek: [1, 0, 1, 1, 0, 0, 0],
-            lastWeek: [0, 1, 0, 1, 1, 0, 0],
-            twoWeeksAgo: [0, 0, 1, 1, 0, 0, 0],
-            threeWeeksAgo: [0, 0, 0, 1, 1, 0, 0],
-            fourWeeksAgo: [0, 0, 1, 0, 0, 0, 0],
-        },
-        conversation: {
-            today: [0, 1, 0, 0],
-            yesterday: [1, 0, 0, 0],
-            thisWeek: [1, 2, 1, 0],
-            total: [3, 5, 3, 0],
-            thisYear: [2, 4, 2, 0],
-            lastYear: [3, 3, 2, 1],
-        },
-    },
-    'agency-u25-duesseldorf': {
-        metrics: {
-            activeAgencies: 1,
-            activeConversations: 2,
-            cases: 3,
-            conversationsTotal: 3,
-            counselors: 2,
-            groups: 1,
-            liveChat: 1,
-            messagesCounselors: 2,
-            messagesSeekers: 5,
-            oneToOne: 1,
-            phoneCalls: 1,
-            textMessagesTotal: 7,
-            videoCalls: 0,
-            voiceMessages: 1,
-            topTopic: { label: 'Trennung', share: 34 },
-            previousMonth: { label: 'Schulden', share: 28 },
-            twoMonthsAgo: { label: 'Familie', share: 24 },
-            threeMonthsAgo: { label: 'Wohnen', share: 19 },
-        },
-        caseCharts: {
-            thisWeek: [0, 1, 0, 2, 1, 0, 0],
-            lastWeek: [0, 0, 1, 1, 1, 0, 0],
-            twoWeeksAgo: [0, 1, 0, 1, 0, 0, 0],
-            threeWeeksAgo: [0, 0, 0, 1, 1, 0, 0],
-            fourWeeksAgo: [0, 0, 1, 0, 1, 0, 0],
-        },
-        conversation: {
-            today: [1, 1, 0, 0],
-            yesterday: [1, 0, 1, 0],
-            thisWeek: [2, 2, 1, 0],
-            total: [3, 4, 3, 0],
-            thisYear: [2, 3, 2, 0],
-            lastYear: [3, 2, 1, 0],
-        },
-    },
-    'agency-schuldnerberatung-koeln': {
-        metrics: {
-            activeAgencies: 1,
-            activeConversations: 1,
-            cases: 2,
-            conversationsTotal: 2,
-            counselors: 1,
-            groups: 0,
-            liveChat: 1,
-            messagesCounselors: 1,
-            messagesSeekers: 4,
-            oneToOne: 1,
-            phoneCalls: 0,
-            textMessagesTotal: 5,
-            videoCalls: 0,
-            voiceMessages: 0,
-            topTopic: { label: 'Schulden', share: 71 },
-            previousMonth: { label: 'Wohnen', share: 35 },
-            twoMonthsAgo: { label: 'Arbeit', share: 25 },
-            threeMonthsAgo: { label: 'Sucht', share: 18 },
-        },
-        caseCharts: {
-            thisWeek: [0, 0, 0, 1, 1, 0, 0],
-            lastWeek: [0, 0, 1, 1, 0, 0, 0],
-            twoWeeksAgo: [0, 0, 0, 1, 0, 0, 0],
-            threeWeeksAgo: [0, 0, 0, 1, 0, 0, 0],
-            fourWeeksAgo: [0, 0, 0, 0, 1, 0, 0],
-        },
-        conversation: {
-            today: [1, 0, 0, 0],
-            yesterday: [0, 1, 0, 0],
-            thisWeek: [1, 2, 0, 0],
-            total: [2, 3, 1, 0],
-            thisYear: [1, 2, 1, 0],
-            lastYear: [2, 2, 1, 0],
-        },
-    },
-    'agency-jugendberatung-essen': {
-        metrics: {
-            activeAgencies: 1,
-            activeConversations: 2,
-            cases: 3,
-            conversationsTotal: 2,
-            counselors: 2,
-            groups: 1,
-            liveChat: 2,
-            messagesCounselors: 2,
-            messagesSeekers: 3,
-            oneToOne: 1,
-            phoneCalls: 1,
-            textMessagesTotal: 5,
-            videoCalls: 0,
-            voiceMessages: 1,
-            topTopic: { label: 'Ausbildung', share: 48 },
-            previousMonth: { label: 'Familie', share: 31 },
-            twoMonthsAgo: { label: 'Trennung', share: 28 },
-            threeMonthsAgo: { label: 'Wohnen', share: 16 },
-        },
-        caseCharts: {
-            thisWeek: [1, 0, 0, 1, 1, 0, 0],
-            lastWeek: [0, 1, 0, 1, 0, 0, 0],
-            twoWeeksAgo: [0, 1, 0, 0, 1, 0, 0],
-            threeWeeksAgo: [0, 0, 1, 0, 0, 0, 0],
-            fourWeeksAgo: [0, 0, 0, 1, 0, 0, 0],
-        },
-        conversation: {
-            today: [0, 1, 0, 0],
-            yesterday: [1, 0, 0, 0],
-            thisWeek: [1, 2, 1, 0],
-            total: [2, 4, 2, 0],
-            thisYear: [1, 3, 1, 0],
-            lastYear: [2, 3, 1, 0],
-        },
-    },
-    'agency-familienberatung-dortmund': {
-        metrics: {
-            activeAgencies: 1,
-            activeConversations: 1,
-            cases: 2,
-            conversationsTotal: 1,
-            counselors: 1,
-            groups: 1,
-            liveChat: 1,
-            messagesCounselors: 1,
-            messagesSeekers: 2,
-            oneToOne: 0,
-            phoneCalls: 0,
-            textMessagesTotal: 3,
-            videoCalls: 0,
-            voiceMessages: 0,
-            topTopic: { label: 'Familie', share: 63 },
-            previousMonth: { label: 'Trennung', share: 29 },
-            twoMonthsAgo: { label: 'Wohnen', share: 21 },
-            threeMonthsAgo: { label: 'Schulden', share: 14 },
-        },
-        caseCharts: {
-            thisWeek: [0, 1, 0, 1, 0, 0, 0],
-            lastWeek: [0, 0, 0, 1, 1, 0, 0],
-            twoWeeksAgo: [0, 0, 1, 0, 0, 0, 0],
-            threeWeeksAgo: [0, 0, 0, 1, 0, 0, 0],
-            fourWeeksAgo: [0, 0, 0, 0, 0, 0, 0],
-        },
-        conversation: {
-            today: [0, 1, 0, 0],
-            yesterday: [0, 0, 1, 0],
-            thisWeek: [1, 1, 1, 0],
-            total: [1, 3, 2, 0],
-            thisYear: [1, 2, 1, 0],
-            lastYear: [1, 2, 2, 0],
-        },
-    },
-};
-
 const formatIntegerMetric = (value: number) => value.toLocaleString('de-DE');
 
-const formatDecimalMetric = (value: number) =>
-    value.toLocaleString('de-DE', {
-        maximumFractionDigits: 1,
-        minimumFractionDigits: 1,
-    });
-
-const formatShareMetric = (value: number, total: number) => `${total ? Math.round((value / total) * 100) : 0}%`;
-
 const getEmptyFilterTargetStatistics = (): FilterTargetStatistics => ({
+    suppressed: false,
+    enquiriesPreviousMonth: null,
     metrics: {
-        activeAgencies: 0,
-        activeConversations: 0,
-        cases: 0,
-        conversationsTotal: 0,
-        counselors: 0,
-        groups: 0,
-        liveChat: 0,
-        messagesCounselors: 0,
-        messagesSeekers: 0,
-        oneToOne: 0,
-        phoneCalls: 0,
-        textMessagesTotal: 0,
-        videoCalls: 0,
-        voiceMessages: 0,
-        topTopic: { label: 'Keine Daten', share: 0 },
-        previousMonth: { label: 'Keine Daten', share: 0 },
-        twoMonthsAgo: { label: 'Keine Daten', share: 0 },
-        threeMonthsAgo: { label: 'Keine Daten', share: 0 },
+        activeAgencies: null,
+        activeConversations: null,
+        cases: null,
+        conversationsTotal: null,
+        counselors: null,
+        groups: null,
+        liveChat: null,
+        messagesCounselors: null,
+        messagesSeekers: null,
+        oneToOne: null,
+        phoneCalls: null,
+        textMessagesTotal: null,
+        videoCalls: null,
+        voiceMessages: null,
+        topTopic: { label: NO_DATA_LABEL, share: 0 },
+        previousMonth: { label: NO_DATA_LABEL, share: 0 },
+        twoMonthsAgo: { label: NO_DATA_LABEL, share: 0 },
+        threeMonthsAgo: { label: NO_DATA_LABEL, share: 0 },
     },
     caseCharts: {
         thisWeek: [0, 0, 0, 0, 0, 0, 0],
@@ -1547,18 +1086,22 @@ const numericFilterMetricKeys: NumericFilterMetricKey[] = [
     'voiceMessages',
 ];
 
-const aggregateFilterTargetStatistics = (targetIds: string[]) =>
-    targetIds.reduce<FilterTargetStatistics>((aggregatedStats, targetId) => {
-        const targetStats = filterTargetStatisticsById[targetId];
+const addMetricValues = (first: MetricValue, second: MetricValue): MetricValue =>
+    first === null && second === null ? null : (first ?? 0) + (second ?? 0);
 
-        if (!targetStats) {
+const aggregateFilterTargetStatistics = (targetIds: string[], statisticsById: Record<string, FilterTargetStatistics>) =>
+    targetIds.reduce<FilterTargetStatistics>((aggregatedStats, targetId) => {
+        const targetStats = statisticsById[targetId];
+
+        // KDG small-cell suppression: suppressed targets contribute nothing
+        if (!targetStats || targetStats.suppressed) {
             return aggregatedStats;
         }
 
         const metrics = numericFilterMetricKeys.reduce<FilterTargetMetricStats>(
             (nextMetrics, metricKey) => ({
                 ...nextMetrics,
-                [metricKey]: aggregatedStats.metrics[metricKey] + targetStats.metrics[metricKey],
+                [metricKey]: addMetricValues(aggregatedStats.metrics[metricKey], targetStats.metrics[metricKey]),
             }),
             {
                 ...aggregatedStats.metrics,
@@ -1596,112 +1139,159 @@ const aggregateFilterTargetStatistics = (targetIds: string[]) =>
         );
 
         return {
+            suppressed: false,
+            enquiriesPreviousMonth: addMetricValues(
+                aggregatedStats.enquiriesPreviousMonth,
+                targetStats.enquiriesPreviousMonth,
+            ),
             caseCharts,
             conversation,
             metrics,
         };
     }, getEmptyFilterTargetStatistics());
 
-const getEffectiveStatisticTargetIds = (activeScope: ScopeKey, selectedTargetIds: string[]) => {
-    const selectableTargetIds = new Set(filterTargetsByScope[activeScope].map((target) => target.id));
+const getEffectiveStatisticTargetIds = (
+    activeScope: ScopeKey,
+    selectedTargetIds: string[],
+    statisticData: StatisticData,
+) => {
+    const selectableTargetIds = new Set(statisticData.targetsByScope[activeScope].map((target) => target.id));
     const selectedAvailableTargetIds = selectedTargetIds.filter(
-        (targetId) => selectableTargetIds.has(targetId) && Boolean(filterTargetStatisticsById[targetId]),
+        (targetId) => selectableTargetIds.has(targetId) && Boolean(statisticData.statisticsById[targetId]),
     );
 
     return selectedAvailableTargetIds.length
         ? selectedAvailableTargetIds
-        : fallbackStatisticTargetIdsByScope[activeScope];
+        : statisticData.fallbackIdsByScope[activeScope];
 };
 
+const formatMetricValue = (value: MetricValue) => (value === null ? NO_DATA_LABEL : formatIntegerMetric(value));
+
+const buildChangeTrend = (current: MetricValue, previous: MetricValue): TrendBadgeDefinition | undefined => {
+    if (current === null || previous === null || (previous === 0 && current === 0)) {
+        return undefined;
+    }
+
+    const change = previous === 0 ? 100 : Math.round(((current - previous) / previous) * 100);
+    const magnitude = Math.abs(change);
+
+    if (change < 0) {
+        return { value: `~ ${magnitude}%`, tone: 'red', direction: magnitude >= 15 ? 'down' : 'downRight' };
+    }
+
+    return { value: `~ ${magnitude}%`, tone: 'blue', direction: magnitude >= 15 ? 'up' : 'upRight' };
+};
+
+const buildTopicTrend = (topic: TopicStatistic): TrendBadgeDefinition | undefined =>
+    topic.share > 0 ? { value: `~ ${topic.share}%`, tone: 'dark' } : undefined;
+
+/**
+ * Maps aggregated real statistics onto the dashboard metric slots. Metrics without an
+ * application-layer data source are rendered as "Keine Daten"; trends are only shown
+ * where a real comparison value exists (requests vs. previous month, topic shares).
+ */
 const buildMetricOverridesFromFilterStats = (
     stats: FilterTargetStatistics,
 ): Partial<Record<CardMenuKey, Partial<CardMenuOption>>> => {
-    const totalRequests = stats.metrics.oneToOne + stats.metrics.liveChat + stats.metrics.groups;
-    const messageTotal = stats.metrics.messagesSeekers + stats.metrics.messagesCounselors;
-    const messagesPerSession = messageTotal / Math.max(stats.metrics.conversationsTotal, 1);
-    const previousRequestTotal = Math.max(totalRequests + 1, Math.round(totalRequests * 1.18));
-    const previousCasesTotal = Math.max(stats.metrics.cases + 1, Math.round(stats.metrics.cases * 1.12));
+    const requestTrend = buildChangeTrend(stats.metrics.oneToOne, stats.enquiriesPreviousMonth);
+    const requestDetail =
+        stats.enquiriesPreviousMonth !== null
+            ? `Vormonat gesamt ${formatIntegerMetric(stats.enquiriesPreviousMonth)}`
+            : undefined;
 
     return {
         activeAgencies: {
-            value: formatIntegerMetric(stats.metrics.activeAgencies),
+            value: formatMetricValue(stats.metrics.activeAgencies),
             detail: 'zugeordnete Beratungsstellen',
+            trend: undefined,
         },
         activeConversations: {
-            value: formatIntegerMetric(stats.metrics.activeConversations),
+            value: formatMetricValue(stats.metrics.activeConversations),
+            detail: 'heute aktiv',
+            trend: undefined,
+        },
+        activeCounselors: {
+            value: formatMetricValue(stats.metrics.counselors),
+            detail: undefined,
+            trend: undefined,
         },
         all: {
-            value: formatIntegerMetric(totalRequests),
-            detail: `Vormonat gesamt ${formatIntegerMetric(previousRequestTotal)}`,
+            value: formatMetricValue(stats.metrics.oneToOne),
+            detail: requestDetail,
+            trend: requestTrend,
         },
         cases: {
-            value: formatIntegerMetric(stats.metrics.cases),
-            detail: `Vorwoche gesamt ${formatIntegerMetric(previousCasesTotal)}`,
+            value: formatMetricValue(stats.metrics.cases),
+            detail: 'Aktuell in Beratung',
+            trend: undefined,
         },
+        consultations: { value: NO_DATA_LABEL, detail: undefined, trend: undefined },
         conversationsTotal: {
-            value: formatIntegerMetric(stats.metrics.conversationsTotal),
+            value: formatMetricValue(stats.metrics.conversationsTotal),
+            detail: 'gesamt',
+            trend: undefined,
         },
         counselors: {
-            value: formatIntegerMetric(stats.metrics.counselors),
+            value: formatMetricValue(stats.metrics.counselors),
+            detail: undefined,
+            trend: undefined,
         },
         groups: {
-            value: formatIntegerMetric(stats.metrics.groups),
+            value: formatMetricValue(stats.metrics.groups),
+            detail: 'gesamt',
+            trend: undefined,
         },
-        liveChat: {
-            value: formatIntegerMetric(stats.metrics.liveChat),
-        },
-        messagesCounselors: {
-            value: formatIntegerMetric(stats.metrics.messagesCounselors),
-        },
-        messagesPerSession: {
-            value: formatDecimalMetric(messagesPerSession),
-        },
-        messagesSeekers: {
-            value: formatIntegerMetric(stats.metrics.messagesSeekers),
-        },
+        liveChat: { value: NO_DATA_LABEL, detail: undefined, trend: undefined },
+        messagesCounselors: { value: NO_DATA_LABEL, detail: undefined, trend: undefined },
+        messagesPerSession: { value: NO_DATA_LABEL, detail: undefined, trend: undefined },
+        messagesSeekers: { value: NO_DATA_LABEL, detail: undefined, trend: undefined },
         oneToOne: {
-            value: formatIntegerMetric(stats.metrics.oneToOne),
+            value: formatMetricValue(stats.metrics.oneToOne),
+            detail: '1:1-Anfragen',
+            trend: requestTrend,
         },
-        phoneShare: {
-            value: formatShareMetric(stats.metrics.phoneCalls, stats.metrics.conversationsTotal),
-        },
+        phoneShare: { value: NO_DATA_LABEL, detail: undefined, trend: undefined },
         previousMonth: {
             value: stats.metrics.previousMonth.label,
-            trend: { value: `~ ${stats.metrics.previousMonth.share}%`, tone: 'dark' },
+            detail: 'Letzter Monat',
+            trend: buildTopicTrend(stats.metrics.previousMonth),
         },
-        textMessagesTotal: {
-            value: formatIntegerMetric(stats.metrics.textMessagesTotal),
-        },
+        textMessagesTotal: { value: NO_DATA_LABEL, detail: undefined, trend: undefined },
         threeMonthsAgo: {
             value: stats.metrics.threeMonthsAgo.label,
-            trend: { value: `~ ${stats.metrics.threeMonthsAgo.share}%`, tone: 'dark' },
+            detail: 'Vor 3 Monaten',
+            trend: buildTopicTrend(stats.metrics.threeMonthsAgo),
         },
         topTopic: {
             value: stats.metrics.topTopic.label,
-            detail: 'gefilterte Ansicht',
-            trend: { value: `~ ${stats.metrics.topTopic.share}%`, tone: 'dark' },
+            detail: 'Dieser Monat',
+            trend: buildTopicTrend(stats.metrics.topTopic),
         },
         twoMonthsAgo: {
             value: stats.metrics.twoMonthsAgo.label,
-            trend: { value: `~ ${stats.metrics.twoMonthsAgo.share}%`, tone: 'dark' },
+            detail: 'Vor 2 Monaten',
+            trend: buildTopicTrend(stats.metrics.twoMonthsAgo),
         },
-        videoCallCount: {
-            value: formatIntegerMetric(stats.metrics.videoCalls),
-        },
-        videoShare: {
-            value: formatShareMetric(stats.metrics.videoCalls, stats.metrics.conversationsTotal),
-        },
-        voiceShare: {
-            value: formatShareMetric(stats.metrics.voiceMessages, Math.max(messageTotal, 1)),
-        },
+        videoCallCount: { value: NO_DATA_LABEL, detail: undefined, trend: undefined },
+        videoShare: { value: NO_DATA_LABEL, detail: undefined, trend: undefined },
+        voiceShare: { value: NO_DATA_LABEL, detail: undefined, trend: undefined },
     };
 };
 
-const buildCaseChartsFromFilterStats = (stats: FilterTargetStatistics): Record<CasePeriodKey, CaseChartBar[]> =>
+const buildCaseChartsFromFilterStats = (
+    stats: FilterTargetStatistics,
+    dateLabelsByPeriod: Record<CasePeriodKey, string[]>,
+    todayDayCode: string,
+): Record<CasePeriodKey, CaseChartBar[]> =>
     casePeriodOptions.reduce(
         (charts, { key }) => ({
             ...charts,
-            [key]: createDemoCaseChart(key, stats.caseCharts[key]),
+            [key]: caseChartDayCodes.map((day, index) => ({
+                day,
+                dateLabel: dateLabelsByPeriod[key][index],
+                value: stats.caseCharts[key][index],
+                isDefaultSelected: day === todayDayCode,
+            })),
         }),
         {} as Record<CasePeriodKey, CaseChartBar[]>,
     );
@@ -1717,36 +1307,14 @@ const buildConversationByPeriodFromFilterStats = (
         {} as Record<ConversationPeriodKey, ConversationPeriodData>,
     );
 
-const demoConversationByScope: Record<ScopeKey, Record<ConversationPeriodKey, ConversationPeriodData>> = {
-    platform: {
-        today: createConversationData([1, 2, 0, 0]),
-        yesterday: createConversationData([1, 1, 1, 0]),
-        thisWeek: createConversationData([2, 5, 3, 0]),
-        total: createConversationData([7, 14, 11, 0]),
-        thisYear: createConversationData([4, 11, 8, 0]),
-        lastYear: createConversationData([5, 9, 6, 1]),
-    },
-    tenant: {
-        today: createConversationData([1, 1, 1, 0]),
-        yesterday: createConversationData([0, 2, 1, 0]),
-        thisWeek: createConversationData([3, 5, 2, 0]),
-        total: createConversationData([6, 10, 8, 1]),
-        thisYear: createConversationData([4, 8, 6, 0]),
-        lastYear: createConversationData([5, 7, 4, 1]),
-    },
-    agency: {
-        today: createConversationData([1, 1, 0, 0]),
-        yesterday: createConversationData([1, 0, 1, 0]),
-        thisWeek: createConversationData([2, 2, 1, 0]),
-        total: createConversationData([3, 4, 3, 0]),
-        thisYear: createConversationData([2, 3, 2, 0]),
-        lastYear: createConversationData([3, 2, 1, 0]),
-    },
+const noSourceMetricOverride: Partial<CardMenuOption> = {
+    value: NO_DATA_LABEL,
+    detail: undefined,
+    trend: undefined,
 };
 
-const applyDemoMetricOverride = <Metric extends StatisticCardDefinition | CardMenuOption>(
+const applyMetricOverride = <Metric extends StatisticCardDefinition | CardMenuOption>(
     metric: Metric,
-    activeScope: ScopeKey,
     metricOverrides: Partial<Record<CardMenuKey, Partial<CardMenuOption>>>,
     metricKey?: CardMenuKey,
 ): Metric => {
@@ -1754,26 +1322,22 @@ const applyDemoMetricOverride = <Metric extends StatisticCardDefinition | CardMe
         return metric;
     }
 
-    const override = {
-        ...demoMetricOverridesByScope[activeScope][metricKey],
-        ...metricOverrides[metricKey],
-    };
+    const override = metricOverrides[metricKey] ?? noSourceMetricOverride;
 
-    return Object.keys(override).length ? { ...metric, ...override } : metric;
+    return { ...metric, ...override };
 };
 
 const getDisplayMetricCard = (
     card: StatisticCardDefinition,
-    activeScope: ScopeKey,
     metricOverrides: Partial<Record<CardMenuKey, Partial<CardMenuOption>>>,
-) => applyDemoMetricOverride(card, activeScope, metricOverrides, defaultMetricKeyByCardKey[card.key]);
+) => applyMetricOverride(card, metricOverrides, defaultMetricKeyByCardKey[card.key]);
 
 const getPersonalizedMetricCard = (
     card: StatisticCardDefinition,
     activeScope: ScopeKey,
     metricOverrides: Partial<Record<CardMenuKey, Partial<CardMenuOption>>>,
 ): StatisticCardDefinition => {
-    const displayCard = getDisplayMetricCard(card, activeScope, metricOverrides);
+    const displayCard = getDisplayMetricCard(card, metricOverrides);
 
     return {
         ...displayCard,
@@ -1782,9 +1346,7 @@ const getPersonalizedMetricCard = (
         menuLabel: 'Meine Kennzahl',
         menuOptions: dashboardMetricOptionsByScope[activeScope]
             .filter((option) => !duplicatedCommunicationMetricKeys.has(option.key))
-            .map((option) =>
-                withMetricMenuDescription(applyDemoMetricOverride(option, activeScope, metricOverrides, option.key)),
-            ),
+            .map((option) => withMetricMenuDescription(applyMetricOverride(option, metricOverrides, option.key))),
     };
 };
 
@@ -1978,79 +1540,6 @@ const dashboardByScope: Record<ScopeKey, ScopeDashboard> = {
                 size: 'small',
             },
         ],
-        caseCharts: {
-            thisWeek: [
-                { day: 'Mo', dateLabel: 'Mo, 9 Jul', value: 1900 },
-                { day: 'Di', dateLabel: 'Di, 10 Jul', value: 2250 },
-                { day: 'Mi', dateLabel: 'Mi, 11 Jul', value: 2250 },
-                { day: 'Do', dateLabel: 'Do, 12 Jul', value: 3150, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 13 Jul', value: 2250 },
-                { day: 'Sa', dateLabel: 'Sa, 14 Jul', value: 2250 },
-                { day: 'So', dateLabel: 'So, 15 Jul', value: 2250 },
-            ],
-            lastWeek: [
-                { day: 'Mo', dateLabel: 'Mo, 2 Jul', value: 1680 },
-                { day: 'Di', dateLabel: 'Di, 3 Jul', value: 2040 },
-                { day: 'Mi', dateLabel: 'Mi, 4 Jul', value: 2180 },
-                { day: 'Do', dateLabel: 'Do, 5 Jul', value: 2460, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 6 Jul', value: 2360 },
-                { day: 'Sa', dateLabel: 'Sa, 7 Jul', value: 1880 },
-                { day: 'So', dateLabel: 'So, 8 Jul', value: 1720 },
-            ],
-            twoWeeksAgo: [
-                { day: 'Mo', dateLabel: 'Mo, 25 Jun', value: 1420 },
-                { day: 'Di', dateLabel: 'Di, 26 Jun', value: 1780 },
-                { day: 'Mi', dateLabel: 'Mi, 27 Jun', value: 1960 },
-                { day: 'Do', dateLabel: 'Do, 28 Jun', value: 2210, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 29 Jun', value: 2060 },
-                { day: 'Sa', dateLabel: 'Sa, 30 Jun', value: 1640 },
-                { day: 'So', dateLabel: 'So, 1 Jul', value: 1510 },
-            ],
-            threeWeeksAgo: [
-                { day: 'Mo', dateLabel: 'Mo, 18 Jun', value: 1320 },
-                { day: 'Di', dateLabel: 'Di, 19 Jun', value: 1650 },
-                { day: 'Mi', dateLabel: 'Mi, 20 Jun', value: 1840 },
-                { day: 'Do', dateLabel: 'Do, 21 Jun', value: 2080, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 22 Jun', value: 1920 },
-                { day: 'Sa', dateLabel: 'Sa, 23 Jun', value: 1520 },
-                { day: 'So', dateLabel: 'So, 24 Jun', value: 1390 },
-            ],
-            fourWeeksAgo: [
-                { day: 'Mo', dateLabel: 'Mo, 11 Jun', value: 1210 },
-                { day: 'Di', dateLabel: 'Di, 12 Jun', value: 1540 },
-                { day: 'Mi', dateLabel: 'Mi, 13 Jun', value: 1710 },
-                { day: 'Do', dateLabel: 'Do, 14 Jun', value: 1940, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 15 Jun', value: 1810 },
-                { day: 'Sa', dateLabel: 'Sa, 16 Jun', value: 1430 },
-                { day: 'So', dateLabel: 'So, 17 Jun', value: 1280 },
-            ],
-        },
-        conversation: {
-            today: {
-                total: '555',
-                segments: createConversationSegments([278, 137, 58, 82]),
-            },
-            yesterday: {
-                total: '486',
-                segments: createConversationSegments([218, 129, 76, 63]),
-            },
-            thisWeek: {
-                total: '3.248',
-                segments: createConversationSegments([1498, 812, 346, 592]),
-            },
-            total: {
-                total: '42.680',
-                segments: createConversationSegments([19840, 10860, 4710, 7270]),
-            },
-            thisYear: {
-                total: '18.420',
-                segments: createConversationSegments([8420, 4690, 2130, 3180]),
-            },
-            lastYear: {
-                total: '31.860',
-                segments: createConversationSegments([14920, 8120, 3460, 5360]),
-            },
-        },
     },
     tenant: {
         topCards: [
@@ -2241,79 +1730,6 @@ const dashboardByScope: Record<ScopeKey, ScopeDashboard> = {
                 size: 'small',
             },
         ],
-        caseCharts: {
-            thisWeek: [
-                { day: 'Mo', dateLabel: 'Mo, 9 Jul', value: 820 },
-                { day: 'Di', dateLabel: 'Di, 10 Jul', value: 1180 },
-                { day: 'Mi', dateLabel: 'Mi, 11 Jul', value: 960 },
-                { day: 'Do', dateLabel: 'Do, 12 Jul', value: 1520, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 13 Jul', value: 1220 },
-                { day: 'Sa', dateLabel: 'Sa, 14 Jul', value: 870 },
-                { day: 'So', dateLabel: 'So, 15 Jul', value: 760 },
-            ],
-            lastWeek: [
-                { day: 'Mo', dateLabel: 'Mo, 2 Jul', value: 690 },
-                { day: 'Di', dateLabel: 'Di, 3 Jul', value: 1040 },
-                { day: 'Mi', dateLabel: 'Mi, 4 Jul', value: 910 },
-                { day: 'Do', dateLabel: 'Do, 5 Jul', value: 1280, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 6 Jul', value: 1160 },
-                { day: 'Sa', dateLabel: 'Sa, 7 Jul', value: 820 },
-                { day: 'So', dateLabel: 'So, 8 Jul', value: 710 },
-            ],
-            twoWeeksAgo: [
-                { day: 'Mo', dateLabel: 'Mo, 25 Jun', value: 610 },
-                { day: 'Di', dateLabel: 'Di, 26 Jun', value: 880 },
-                { day: 'Mi', dateLabel: 'Mi, 27 Jun', value: 830 },
-                { day: 'Do', dateLabel: 'Do, 28 Jun', value: 1090, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 29 Jun', value: 970 },
-                { day: 'Sa', dateLabel: 'Sa, 30 Jun', value: 690 },
-                { day: 'So', dateLabel: 'So, 1 Jul', value: 640 },
-            ],
-            threeWeeksAgo: [
-                { day: 'Mo', dateLabel: 'Mo, 18 Jun', value: 560 },
-                { day: 'Di', dateLabel: 'Di, 19 Jun', value: 820 },
-                { day: 'Mi', dateLabel: 'Mi, 20 Jun', value: 760 },
-                { day: 'Do', dateLabel: 'Do, 21 Jun', value: 1010, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 22 Jun', value: 900 },
-                { day: 'Sa', dateLabel: 'Sa, 23 Jun', value: 650 },
-                { day: 'So', dateLabel: 'So, 24 Jun', value: 590 },
-            ],
-            fourWeeksAgo: [
-                { day: 'Mo', dateLabel: 'Mo, 11 Jun', value: 520 },
-                { day: 'Di', dateLabel: 'Di, 12 Jun', value: 760 },
-                { day: 'Mi', dateLabel: 'Mi, 13 Jun', value: 710 },
-                { day: 'Do', dateLabel: 'Do, 14 Jun', value: 940, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 15 Jun', value: 840 },
-                { day: 'Sa', dateLabel: 'Sa, 16 Jun', value: 610 },
-                { day: 'So', dateLabel: 'So, 17 Jun', value: 550 },
-            ],
-        },
-        conversation: {
-            today: {
-                total: '211',
-                segments: createConversationSegments([96, 58, 24, 33]),
-            },
-            yesterday: {
-                total: '184',
-                segments: createConversationSegments([78, 52, 28, 26]),
-            },
-            thisWeek: {
-                total: '1.238',
-                segments: createConversationSegments([548, 326, 151, 213]),
-            },
-            total: {
-                total: '14.890',
-                segments: createConversationSegments([6520, 3980, 1840, 2550]),
-            },
-            thisYear: {
-                total: '6.940',
-                segments: createConversationSegments([3010, 1840, 870, 1220]),
-            },
-            lastYear: {
-                total: '11.420',
-                segments: createConversationSegments([4980, 3020, 1410, 2010]),
-            },
-        },
     },
     agency: {
         topCards: [
@@ -2504,79 +1920,6 @@ const dashboardByScope: Record<ScopeKey, ScopeDashboard> = {
                 size: 'small',
             },
         ],
-        caseCharts: {
-            thisWeek: [
-                { day: 'Mo', dateLabel: 'Mo, 9 Jul', value: 420 },
-                { day: 'Di', dateLabel: 'Di, 10 Jul', value: 520 },
-                { day: 'Mi', dateLabel: 'Mi, 11 Jul', value: 470 },
-                { day: 'Do', dateLabel: 'Do, 12 Jul', value: 690, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 13 Jul', value: 610 },
-                { day: 'Sa', dateLabel: 'Sa, 14 Jul', value: 430 },
-                { day: 'So', dateLabel: 'So, 15 Jul', value: 390 },
-            ],
-            lastWeek: [
-                { day: 'Mo', dateLabel: 'Mo, 2 Jul', value: 360 },
-                { day: 'Di', dateLabel: 'Di, 3 Jul', value: 480 },
-                { day: 'Mi', dateLabel: 'Mi, 4 Jul', value: 430 },
-                { day: 'Do', dateLabel: 'Do, 5 Jul', value: 590, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 6 Jul', value: 540 },
-                { day: 'Sa', dateLabel: 'Sa, 7 Jul', value: 380 },
-                { day: 'So', dateLabel: 'So, 8 Jul', value: 340 },
-            ],
-            twoWeeksAgo: [
-                { day: 'Mo', dateLabel: 'Mo, 25 Jun', value: 310 },
-                { day: 'Di', dateLabel: 'Di, 26 Jun', value: 410 },
-                { day: 'Mi', dateLabel: 'Mi, 27 Jun', value: 390 },
-                { day: 'Do', dateLabel: 'Do, 28 Jun', value: 520, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 29 Jun', value: 470 },
-                { day: 'Sa', dateLabel: 'Sa, 30 Jun', value: 330 },
-                { day: 'So', dateLabel: 'So, 1 Jul', value: 300 },
-            ],
-            threeWeeksAgo: [
-                { day: 'Mo', dateLabel: 'Mo, 18 Jun', value: 290 },
-                { day: 'Di', dateLabel: 'Di, 19 Jun', value: 380 },
-                { day: 'Mi', dateLabel: 'Mi, 20 Jun', value: 360 },
-                { day: 'Do', dateLabel: 'Do, 21 Jun', value: 480, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 22 Jun', value: 430 },
-                { day: 'Sa', dateLabel: 'Sa, 23 Jun', value: 310 },
-                { day: 'So', dateLabel: 'So, 24 Jun', value: 280 },
-            ],
-            fourWeeksAgo: [
-                { day: 'Mo', dateLabel: 'Mo, 11 Jun', value: 260 },
-                { day: 'Di', dateLabel: 'Di, 12 Jun', value: 350 },
-                { day: 'Mi', dateLabel: 'Mi, 13 Jun', value: 330 },
-                { day: 'Do', dateLabel: 'Do, 14 Jun', value: 440, isDefaultSelected: true },
-                { day: 'Fr', dateLabel: 'Fr, 15 Jun', value: 400 },
-                { day: 'Sa', dateLabel: 'Sa, 16 Jun', value: 290 },
-                { day: 'So', dateLabel: 'So, 17 Jun', value: 260 },
-            ],
-        },
-        conversation: {
-            today: {
-                total: '93',
-                segments: createConversationSegments([38, 25, 14, 16]),
-            },
-            yesterday: {
-                total: '86',
-                segments: createConversationSegments([34, 22, 17, 13]),
-            },
-            thisWeek: {
-                total: '548',
-                segments: createConversationSegments([236, 146, 73, 93]),
-            },
-            total: {
-                total: '6.480',
-                segments: createConversationSegments([2740, 1740, 860, 1140]),
-            },
-            thisYear: {
-                total: '2.840',
-                segments: createConversationSegments([1210, 760, 380, 490]),
-            },
-            lastYear: {
-                total: '4.920',
-                segments: createConversationSegments([2070, 1320, 650, 880]),
-            },
-        },
     },
 };
 
@@ -3220,23 +2563,34 @@ export const Statistic = () => {
     });
     const [selectedCaseDayByScope, setSelectedCaseDayByScope] =
         useState<Record<ScopeKey, string>>(defaultSelectedCaseDayByScope);
+    const { data: statisticData, isError: hasStatisticLoadError } = useStatisticDashboardData();
+    const caseChartDateLabelsByPeriod = useMemo(() => buildCaseChartDateLabels(new Date()), []);
+    const todayDayCode = useMemo(() => getTodayDayCode(new Date()), []);
     const dashboard = dashboardByScope[activeScope];
-    const availableFilterTargets = filterTargetsByScope[activeScope];
+    const availableFilterTargets = statisticData.targetsByScope[activeScope];
     const selectedFilterTargetIds = selectedFilterTargetIdsByScope[activeScope] || [];
     const filterSearch = filterSearchByScope[activeScope];
     const visibleFilterTargetIds = selectedFilterTargetIds.filter((targetId) =>
         availableFilterTargets.some((target) => target.id === targetId),
     );
     const effectiveStatisticTargetIds = useMemo(
-        () => getEffectiveStatisticTargetIds(activeScope, selectedFilterTargetIds),
-        [activeScope, selectedFilterTargetIds],
+        () => getEffectiveStatisticTargetIds(activeScope, selectedFilterTargetIds, statisticData),
+        [activeScope, selectedFilterTargetIds, statisticData],
     );
     const filteredStats = useMemo(
-        () => aggregateFilterTargetStatistics(effectiveStatisticTargetIds),
-        [effectiveStatisticTargetIds],
+        () => aggregateFilterTargetStatistics(effectiveStatisticTargetIds, statisticData.statisticsById),
+        [effectiveStatisticTargetIds, statisticData.statisticsById],
+    );
+    const suppressedSelectedTargetCount = useMemo(
+        () =>
+            effectiveStatisticTargetIds.filter((targetId) => statisticData.statisticsById[targetId]?.suppressed).length,
+        [effectiveStatisticTargetIds, statisticData.statisticsById],
     );
     const metricOverrides = useMemo(() => buildMetricOverridesFromFilterStats(filteredStats), [filteredStats]);
-    const filteredCaseCharts = useMemo(() => buildCaseChartsFromFilterStats(filteredStats), [filteredStats]);
+    const filteredCaseCharts = useMemo(
+        () => buildCaseChartsFromFilterStats(filteredStats, caseChartDateLabelsByPeriod, todayDayCode),
+        [caseChartDateLabelsByPeriod, filteredStats, todayDayCode],
+    );
     const filteredConversationByPeriod = useMemo(
         () => buildConversationByPeriodFromFilterStats(filteredStats),
         [filteredStats],
@@ -3244,10 +2598,8 @@ export const Statistic = () => {
     const selectedCasePeriod = selectedCasePeriodByScope[activeScope];
     const selectedConversationPeriod = selectedConversationPeriodByScope[activeScope];
     const selectedConversationSegment = selectedConversationSegmentByScope[activeScope];
-    const caseChart = filteredCaseCharts[selectedCasePeriod] || demoCaseChartsByScope[activeScope][selectedCasePeriod];
-    const conversationData =
-        filteredConversationByPeriod[selectedConversationPeriod] ||
-        demoConversationByScope[activeScope][selectedConversationPeriod];
+    const caseChart = filteredCaseCharts[selectedCasePeriod];
+    const conversationData = filteredConversationByPeriod[selectedConversationPeriod];
     const selectedConversationSegmentLabel = conversationData.segments.some(
         (segment) => segment.label === selectedConversationSegment,
     )
@@ -3413,6 +2765,24 @@ export const Statistic = () => {
                     )}
 
                     <div key={activeScope} className="statisticDashboard__animatedContent">
+                        {hasStatisticLoadError && (
+                            <p className="statisticDashboard__notice statisticDashboard__notice--error" role="alert">
+                                {translateDashboardKey(
+                                    translate,
+                                    'statistic.dashboard.loadError',
+                                    'Statistikdaten konnten nicht geladen werden.',
+                                )}
+                            </p>
+                        )}
+                        {suppressedSelectedTargetCount > 0 && (
+                            <p className="statisticDashboard__notice statisticDashboard__notice--info">
+                                {translateDashboardKey(
+                                    translate,
+                                    'statistic.dashboard.suppressedNotice',
+                                    'Für Bereiche mit weniger als zwei Beratenden werden aus Datenschutzgründen keine Statistiken angezeigt.',
+                                )}
+                            </p>
+                        )}
                         <div className="statisticDashboard__summaryGrid">
                             {dashboard.topCards.map((card) => (
                                 <StatisticCard
@@ -3435,7 +2805,7 @@ export const Statistic = () => {
                                 <StatisticCard
                                     key={card.key}
                                     card={localizeStatisticCard(
-                                        getDisplayMetricCard(card, activeScope, metricOverrides),
+                                        getDisplayMetricCard(card, metricOverrides),
                                         translate,
                                         locale,
                                     )}

--- a/src/pages/Statistic/statisticDashboardData.test.ts
+++ b/src/pages/Statistic/statisticDashboardData.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import type {
+    AdminDashboardStatisticsResponse,
+    AdminDashboardTarget,
+} from '../../api/statistic/getDashboardStatistics';
+import {
+    buildCaseChartDateLabels,
+    buildStatisticData,
+    emptyStatisticData,
+    getTodayDayCode,
+    getWeekStart,
+    NO_DATA_LABEL,
+    SUPPRESSED_DETAIL,
+} from './statisticDashboardData';
+
+// Saturday, 11 July 2026 (local time)
+const now = new Date(2026, 6, 11, 12, 0, 0);
+
+const emptyLookups = { agencyNamesById: {}, tenantNamesById: {}, topicNamesById: {} };
+
+const periodCounts = (values: Partial<Record<string, number>> = {}) => ({
+    today: values.today ?? 0,
+    yesterday: values.yesterday ?? 0,
+    thisWeek: values.thisWeek ?? 0,
+    total: values.total ?? 0,
+    thisYear: values.thisYear ?? 0,
+    lastYear: values.lastYear ?? 0,
+});
+
+const agencyTarget = (overrides: Partial<AdminDashboardTarget> = {}): AdminDashboardTarget => ({
+    targetType: 'AGENCY',
+    tenantId: 5,
+    agencyId: 11,
+    counselorCount: 3,
+    suppressed: false,
+    metrics: {
+        enquiriesCurrentMonth: 4,
+        enquiriesPreviousMonth: 2,
+        activeCases: 7,
+        activeConversationsToday: 1,
+        groupChatsTotal: 2,
+    },
+    dailyNewSessions: [],
+    monthlyTopTopics: [],
+    sessionCountsByPeriod: periodCounts({ today: 1, total: 20 }),
+    groupChatCountsByPeriod: periodCounts({ today: 1, total: 2 }),
+    ...overrides,
+});
+
+const tenantScopeResponse = (targets: AdminDashboardTarget[]): AdminDashboardStatisticsResponse => ({
+    generatedAt: '2026-07-11T10:00:00Z',
+    scope: 'TENANT',
+    targets,
+});
+
+describe('statisticDashboardData', () => {
+    it('returns empty data when no response is available', () => {
+        expect(buildStatisticData(undefined, emptyLookups, now)).toEqual(emptyStatisticData());
+    });
+
+    it('maps tenant scope to a tenant fallback and selectable agency targets', () => {
+        const tenantRow: AdminDashboardTarget = agencyTarget({
+            targetType: 'TENANT',
+            agencyId: null,
+            counselorCount: 4,
+        });
+        const data = buildStatisticData(
+            tenantScopeResponse([tenantRow, agencyTarget(), agencyTarget({ agencyId: 12 })]),
+            {
+                ...emptyLookups,
+                agencyNamesById: { '11': 'U25 Düsseldorf' },
+            },
+            now,
+        );
+
+        expect(data.fallbackIdsByScope.tenant).toEqual(['tenant-5']);
+        expect(data.targetsByScope.tenant.map((target) => target.id)).toEqual(['agency-11', 'agency-12']);
+        expect(data.fallbackIdsByScope.agency).toEqual(['agency-11', 'agency-12']);
+        expect(data.targetsByScope.tenant[0].label).toBe('U25 Düsseldorf');
+        // unresolved names fall back to the id
+        expect(data.targetsByScope.tenant[1].label).toBe('Beratungsstelle 12');
+        expect(data.statisticsById['tenant-5'].metrics.cases).toBe(7);
+        expect(data.statisticsById['agency-11'].metrics.oneToOne).toBe(4);
+        expect(data.statisticsById['agency-11'].enquiriesPreviousMonth).toBe(2);
+    });
+
+    it('marks suppressed targets and hides all counselling metrics', () => {
+        const suppressed = agencyTarget({
+            agencyId: 12,
+            counselorCount: 1,
+            suppressed: true,
+            metrics: null,
+            sessionCountsByPeriod: null,
+            groupChatCountsByPeriod: null,
+        });
+        const data = buildStatisticData(tenantScopeResponse([suppressed]), emptyLookups, now);
+
+        const stats = data.statisticsById['agency-12'];
+        expect(stats.suppressed).toBe(true);
+        expect(stats.metrics.cases).toBeNull();
+        expect(stats.metrics.oneToOne).toBeNull();
+        expect(stats.metrics.counselors).toBe(1);
+        expect(stats.metrics.topTopic.label).toBe(NO_DATA_LABEL);
+        expect(data.targetsByScope.agency[0].detail).toBe(SUPPRESSED_DETAIL);
+    });
+
+    it('buckets daily session counts into calendar weeks', () => {
+        const target = agencyTarget({
+            dailyNewSessions: [
+                { date: '2026-07-06', count: 2 }, // Monday of the current week
+                { date: '2026-07-11', count: 3 }, // Saturday (today)
+                { date: '2026-07-01', count: 1 }, // Wednesday of last week
+            ],
+        });
+        const data = buildStatisticData(tenantScopeResponse([target]), emptyLookups, now);
+
+        const { caseCharts } = data.statisticsById['agency-11'];
+        expect(caseCharts.thisWeek).toEqual([2, 0, 0, 0, 0, 3, 0]);
+        expect(caseCharts.lastWeek).toEqual([0, 0, 1, 0, 0, 0, 0]);
+        expect(caseCharts.fourWeeksAgo).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    });
+
+    it('maps conversation donut values to sessions and group chats per period', () => {
+        const target = agencyTarget({
+            sessionCountsByPeriod: periodCounts({ today: 3, total: 40 }),
+            groupChatCountsByPeriod: periodCounts({ today: 1, total: 5 }),
+        });
+        const data = buildStatisticData(tenantScopeResponse([target]), emptyLookups, now);
+
+        const { conversation } = data.statisticsById['agency-11'];
+        expect(conversation.today).toEqual([3, 0, 1, 0]);
+        expect(conversation.total).toEqual([40, 0, 5, 0]);
+    });
+
+    it('resolves monthly top topics by calendar month with topic names', () => {
+        const target = agencyTarget({
+            monthlyTopTopics: [
+                { month: '2026-07', topicId: 100, sessionCount: 3, sharePercent: 75 },
+                { month: '2026-06', topicId: 200, sessionCount: 2, sharePercent: 50 },
+            ],
+        });
+        const data = buildStatisticData(
+            tenantScopeResponse([target]),
+            { ...emptyLookups, topicNamesById: { '100': 'Schulden' } },
+            now,
+        );
+
+        const { metrics } = data.statisticsById['agency-11'];
+        expect(metrics.topTopic).toEqual({ label: 'Schulden', share: 75 });
+        expect(metrics.previousMonth).toEqual({ label: '#200', share: 50 });
+        expect(metrics.twoMonthsAgo.label).toBe(NO_DATA_LABEL);
+    });
+
+    it('feeds platform and tenant scope with tenant rows for platform admins', () => {
+        const response: AdminDashboardStatisticsResponse = {
+            generatedAt: '2026-07-11T10:00:00Z',
+            scope: 'PLATFORM',
+            targets: [
+                agencyTarget({ targetType: 'TENANT', tenantId: 1, agencyId: null, counselorCount: 5 }),
+                agencyTarget({ targetType: 'TENANT', tenantId: 2, agencyId: null, counselorCount: 3 }),
+            ],
+        };
+        const data = buildStatisticData(response, { ...emptyLookups, tenantNamesById: { '1': 'Caritas NRW' } }, now);
+
+        expect(data.targetsByScope.platform.map((target) => target.id)).toEqual(['tenant-1', 'tenant-2']);
+        expect(data.targetsByScope.tenant.map((target) => target.id)).toEqual(['tenant-1', 'tenant-2']);
+        expect(data.fallbackIdsByScope.platform).toEqual(['tenant-1', 'tenant-2']);
+        expect(data.targetsByScope.platform[0].label).toBe('Caritas NRW');
+        expect(data.targetsByScope.platform[1].label).toBe('Träger 2');
+    });
+
+    it('computes week starts and day codes', () => {
+        expect(getWeekStart(now).getDate()).toBe(6); // Monday, 6 July 2026
+        expect(getTodayDayCode(now)).toBe('Sa');
+
+        const labels = buildCaseChartDateLabels(now);
+        expect(labels.thisWeek[0]).toMatch(/^Mo, 6 Jul/);
+        expect(labels.lastWeek[0]).toMatch(/^Mo, 29 Jun/);
+    });
+});

--- a/src/pages/Statistic/statisticDashboardData.test.ts
+++ b/src/pages/Statistic/statisticDashboardData.test.ts
@@ -169,6 +169,15 @@ describe('statisticDashboardData', () => {
         expect(data.targetsByScope.platform[1].label).toBe('Träger 2');
     });
 
+    it('passes the suppressionDisabled flag through from the backend', () => {
+        const withFlag = { ...tenantScopeResponse([agencyTarget()]), suppressionDisabled: true };
+
+        expect(buildStatisticData(withFlag, emptyLookups, now).suppressionDisabled).toBe(true);
+        expect(buildStatisticData(tenantScopeResponse([agencyTarget()]), emptyLookups, now).suppressionDisabled).toBe(
+            false,
+        );
+    });
+
     it('computes week starts and day codes', () => {
         expect(getWeekStart(now).getDate()).toBe(6); // Monday, 6 July 2026
         expect(getTodayDayCode(now)).toBe('Sa');

--- a/src/pages/Statistic/statisticDashboardData.ts
+++ b/src/pages/Statistic/statisticDashboardData.ts
@@ -1,0 +1,383 @@
+import type {
+    AdminDashboardPeriodCounts,
+    AdminDashboardStatisticsResponse,
+    AdminDashboardTarget,
+} from '../../api/statistic/getDashboardStatistics';
+import type { CasePeriodKey, ConversationPeriodKey, ScopeKey } from './types';
+
+/**
+ * Pure mapping from the UserService admin statistics response to the dashboard data
+ * shapes. All numbers shown on the statistics dashboard originate here — there is no
+ * mock data anymore. Metrics without an application-layer data source (messages, video
+ * calls, voice messages, phone calls, live chat) are represented as `null` and rendered
+ * as "Keine Daten".
+ */
+
+export type FilterTargetType = 'Träger' | 'Beratungsstelle';
+
+export interface FilterTarget {
+    id: string;
+    label: string;
+    type: FilterTargetType;
+    detail: string;
+}
+
+export interface TopicStatistic {
+    label: string;
+    share: number;
+}
+
+export type MetricValue = number | null;
+
+export interface FilterTargetMetricStats {
+    activeAgencies: MetricValue;
+    activeConversations: MetricValue;
+    cases: MetricValue;
+    conversationsTotal: MetricValue;
+    counselors: MetricValue;
+    groups: MetricValue;
+    liveChat: MetricValue;
+    messagesCounselors: MetricValue;
+    messagesSeekers: MetricValue;
+    oneToOne: MetricValue;
+    phoneCalls: MetricValue;
+    textMessagesTotal: MetricValue;
+    videoCalls: MetricValue;
+    voiceMessages: MetricValue;
+    topTopic: TopicStatistic;
+    previousMonth: TopicStatistic;
+    twoMonthsAgo: TopicStatistic;
+    threeMonthsAgo: TopicStatistic;
+}
+
+export type ConversationValues = [number, number, number, number];
+
+export interface FilterTargetStatistics {
+    suppressed: boolean;
+    enquiriesPreviousMonth: MetricValue;
+    caseCharts: Record<CasePeriodKey, number[]>;
+    conversation: Record<ConversationPeriodKey, ConversationValues>;
+    metrics: FilterTargetMetricStats;
+}
+
+export interface StatisticData {
+    targetsByScope: Record<ScopeKey, FilterTarget[]>;
+    fallbackIdsByScope: Record<ScopeKey, string[]>;
+    statisticsById: Record<string, FilterTargetStatistics>;
+}
+
+export interface StatisticNameLookups {
+    agencyNamesById: Record<string, string>;
+    tenantNamesById: Record<string, string>;
+    topicNamesById: Record<string, string>;
+}
+
+export const NO_DATA_LABEL = 'Keine Daten';
+export const SUPPRESSED_DETAIL = 'Statistik unterdrückt';
+
+const noDataTopic = (): TopicStatistic => ({ label: NO_DATA_LABEL, share: 0 });
+
+export const casePeriodOrder: CasePeriodKey[] = [
+    'thisWeek',
+    'lastWeek',
+    'twoWeeksAgo',
+    'threeWeeksAgo',
+    'fourWeeksAgo',
+];
+
+const conversationPeriodOrder: ConversationPeriodKey[] = [
+    'today',
+    'yesterday',
+    'thisWeek',
+    'total',
+    'thisYear',
+    'lastYear',
+];
+
+export const tenantTargetId = (tenantId: number) => `tenant-${tenantId}`;
+export const agencyTargetId = (agencyId: number) => `agency-${agencyId}`;
+
+/* ---------- date helpers ---------- */
+
+const dayInMs = 24 * 60 * 60 * 1000;
+
+/** Monday 00:00 (local time) of the week containing the given date. */
+export const getWeekStart = (now: Date): Date => {
+    const date = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const weekday = (date.getDay() + 6) % 7; // Monday = 0
+
+    return new Date(date.getTime() - weekday * dayInMs);
+};
+
+export const getWeekStartsByPeriod = (now: Date): Record<CasePeriodKey, Date> => {
+    const currentWeekStart = getWeekStart(now);
+    const weekStartMinusWeeks = (weeks: number) => new Date(currentWeekStart.getTime() - weeks * 7 * dayInMs);
+
+    return {
+        thisWeek: currentWeekStart,
+        lastWeek: weekStartMinusWeeks(1),
+        twoWeeksAgo: weekStartMinusWeeks(2),
+        threeWeeksAgo: weekStartMinusWeeks(3),
+        fourWeeksAgo: weekStartMinusWeeks(4),
+    };
+};
+
+const toIsoDate = (date: Date) =>
+    `${date.getFullYear()}-${`${date.getMonth() + 1}`.padStart(2, '0')}-${`${date.getDate()}`.padStart(2, '0')}`;
+
+export const caseChartDayCodes = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+
+/** Real date labels per period, e.g. "Do, 9 Jul" (day code is translated at render time). */
+export const buildCaseChartDateLabels = (now: Date): Record<CasePeriodKey, string[]> => {
+    const weekStarts = getWeekStartsByPeriod(now);
+    const monthFormatter = new Intl.DateTimeFormat('de-DE', { month: 'short' });
+
+    return casePeriodOrder.reduce(
+        (labels, periodKey) => ({
+            ...labels,
+            [periodKey]: caseChartDayCodes.map((dayCode, index) => {
+                const date = new Date(weekStarts[periodKey].getTime() + index * dayInMs);
+                const monthShort = monthFormatter.format(date).replace('.', '');
+
+                return `${dayCode}, ${date.getDate()} ${monthShort}`;
+            }),
+        }),
+        {} as Record<CasePeriodKey, string[]>,
+    );
+};
+
+/** German two-letter code of today's weekday, used as default-selected chart bar. */
+export const getTodayDayCode = (now: Date): string => caseChartDayCodes[(now.getDay() + 6) % 7];
+
+const buildCaseChartValues = (
+    dailyNewSessions: AdminDashboardTarget['dailyNewSessions'],
+    now: Date,
+): Record<CasePeriodKey, number[]> => {
+    const weekStarts = getWeekStartsByPeriod(now);
+    const countsByDate: Record<string, number> = {};
+    dailyNewSessions.forEach(({ date, count }) => {
+        countsByDate[date] = (countsByDate[date] || 0) + count;
+    });
+
+    return casePeriodOrder.reduce(
+        (charts, periodKey) => ({
+            ...charts,
+            [periodKey]: caseChartDayCodes.map((unusedDayCode, index) => {
+                const date = new Date(weekStarts[periodKey].getTime() + index * dayInMs);
+
+                return countsByDate[toIsoDate(date)] || 0;
+            }),
+        }),
+        {} as Record<CasePeriodKey, number[]>,
+    );
+};
+
+const emptyCaseCharts = (): Record<CasePeriodKey, number[]> =>
+    casePeriodOrder.reduce(
+        (charts, periodKey) => ({ ...charts, [periodKey]: [0, 0, 0, 0, 0, 0, 0] }),
+        {} as Record<CasePeriodKey, number[]>,
+    );
+
+/* ---------- statistics mapping ---------- */
+
+const isoMonth = (date: Date) => `${date.getFullYear()}-${`${date.getMonth() + 1}`.padStart(2, '0')}`;
+
+const monthKeyWithOffset = (now: Date, monthsBack: number) =>
+    isoMonth(new Date(now.getFullYear(), now.getMonth() - monthsBack, 1));
+
+const buildTopicStatistic = (
+    target: AdminDashboardTarget,
+    monthKey: string,
+    topicNamesById: Record<string, string>,
+): TopicStatistic => {
+    const monthlyTopic = target.monthlyTopTopics.find((topic) => topic.month === monthKey);
+
+    if (!monthlyTopic || monthlyTopic.topicId === null) {
+        return noDataTopic();
+    }
+
+    return {
+        label: topicNamesById[`${monthlyTopic.topicId}`] || `#${monthlyTopic.topicId}`,
+        share: monthlyTopic.sharePercent,
+    };
+};
+
+const buildConversationValues = (
+    sessionCounts: AdminDashboardPeriodCounts | null,
+    chatCounts: AdminDashboardPeriodCounts | null,
+): Record<ConversationPeriodKey, ConversationValues> =>
+    conversationPeriodOrder.reduce(
+        (conversation, periodKey) => ({
+            ...conversation,
+            // segments: [Nähe (1:1), Live, Gesprächskreise, Interna] — Live and Interna
+            // have no application-layer data source yet
+            [periodKey]: [sessionCounts?.[periodKey] || 0, 0, chatCounts?.[periodKey] || 0, 0],
+        }),
+        {} as Record<ConversationPeriodKey, ConversationValues>,
+    );
+
+const buildTargetStatistics = (
+    target: AdminDashboardTarget,
+    agencyRowCount: number,
+    topicNamesById: Record<string, string>,
+    now: Date,
+): FilterTargetStatistics => {
+    if (target.suppressed) {
+        return {
+            suppressed: true,
+            enquiriesPreviousMonth: null,
+            caseCharts: emptyCaseCharts(),
+            conversation: buildConversationValues(null, null),
+            metrics: {
+                activeAgencies: null,
+                activeConversations: null,
+                cases: null,
+                conversationsTotal: null,
+                counselors: target.counselorCount,
+                groups: null,
+                liveChat: null,
+                messagesCounselors: null,
+                messagesSeekers: null,
+                oneToOne: null,
+                phoneCalls: null,
+                textMessagesTotal: null,
+                videoCalls: null,
+                voiceMessages: null,
+                topTopic: noDataTopic(),
+                previousMonth: noDataTopic(),
+                twoMonthsAgo: noDataTopic(),
+                threeMonthsAgo: noDataTopic(),
+            },
+        };
+    }
+
+    return {
+        suppressed: false,
+        enquiriesPreviousMonth: target.metrics?.enquiriesPreviousMonth ?? null,
+        caseCharts: buildCaseChartValues(target.dailyNewSessions, now),
+        conversation: buildConversationValues(target.sessionCountsByPeriod, target.groupChatCountsByPeriod),
+        metrics: {
+            activeAgencies: target.targetType === 'TENANT' ? agencyRowCount || null : 1,
+            activeConversations: target.metrics?.activeConversationsToday ?? null,
+            cases: target.metrics?.activeCases ?? null,
+            conversationsTotal: target.sessionCountsByPeriod?.total ?? null,
+            counselors: target.counselorCount,
+            groups: target.groupChatCountsByPeriod?.total ?? null,
+            liveChat: null,
+            messagesCounselors: null,
+            messagesSeekers: null,
+            oneToOne: target.metrics?.enquiriesCurrentMonth ?? null,
+            phoneCalls: null,
+            textMessagesTotal: null,
+            videoCalls: null,
+            voiceMessages: null,
+            topTopic: buildTopicStatistic(target, monthKeyWithOffset(now, 0), topicNamesById),
+            previousMonth: buildTopicStatistic(target, monthKeyWithOffset(now, 1), topicNamesById),
+            twoMonthsAgo: buildTopicStatistic(target, monthKeyWithOffset(now, 2), topicNamesById),
+            threeMonthsAgo: buildTopicStatistic(target, monthKeyWithOffset(now, 3), topicNamesById),
+        },
+    };
+};
+
+/* ---------- target mapping ---------- */
+
+const buildFilterTarget = (target: AdminDashboardTarget, lookups: StatisticNameLookups): FilterTarget | null => {
+    if (target.targetType === 'TENANT' && target.tenantId !== null) {
+        return {
+            id: tenantTargetId(target.tenantId),
+            label: lookups.tenantNamesById[`${target.tenantId}`] || `Träger ${target.tenantId}`,
+            type: 'Träger',
+            detail: target.suppressed ? SUPPRESSED_DETAIL : '',
+        };
+    }
+    if (target.targetType === 'AGENCY' && target.agencyId !== null) {
+        const tenantName = target.tenantId !== null ? lookups.tenantNamesById[`${target.tenantId}`] : undefined;
+
+        return {
+            id: agencyTargetId(target.agencyId),
+            label: lookups.agencyNamesById[`${target.agencyId}`] || `Beratungsstelle ${target.agencyId}`,
+            type: 'Beratungsstelle',
+            detail: target.suppressed ? SUPPRESSED_DETAIL : tenantName || '',
+        };
+    }
+
+    return null;
+};
+
+export const emptyStatisticData = (): StatisticData => ({
+    targetsByScope: { platform: [], tenant: [], agency: [] },
+    fallbackIdsByScope: { platform: [], tenant: [], agency: [] },
+    statisticsById: {},
+});
+
+export const buildStatisticData = (
+    response: AdminDashboardStatisticsResponse | undefined,
+    lookups: StatisticNameLookups,
+    now: Date = new Date(),
+): StatisticData => {
+    if (!response) {
+        return emptyStatisticData();
+    }
+
+    const tenantRows = response.targets.filter((target) => target.targetType === 'TENANT');
+    const agencyRows = response.targets.filter((target) => target.targetType === 'AGENCY');
+
+    const statisticsById: Record<string, FilterTargetStatistics> = {};
+    const targetIdsInOrder: string[] = [];
+    response.targets.forEach((target) => {
+        const filterTarget = buildFilterTarget(target, lookups);
+
+        if (filterTarget) {
+            statisticsById[filterTarget.id] = buildTargetStatistics(
+                target,
+                agencyRows.length,
+                lookups.topicNamesById,
+                now,
+            );
+            targetIdsInOrder.push(filterTarget.id);
+        }
+    });
+
+    const tenantTargets = tenantRows
+        .map((target) => buildFilterTarget(target, lookups))
+        .filter((target): target is FilterTarget => Boolean(target));
+    const agencyTargets = agencyRows
+        .map((target) => buildFilterTarget(target, lookups))
+        .filter((target): target is FilterTarget => Boolean(target));
+
+    if (response.scope === 'PLATFORM') {
+        return {
+            targetsByScope: { platform: tenantTargets, tenant: tenantTargets, agency: [] },
+            fallbackIdsByScope: {
+                platform: tenantTargets.map((target) => target.id),
+                tenant: tenantTargets.map((target) => target.id),
+                agency: [],
+            },
+            statisticsById,
+        };
+    }
+
+    if (response.scope === 'TENANT') {
+        const tenantFallback = tenantTargets.length ? [tenantTargets[0].id] : agencyTargets.map((target) => target.id);
+
+        return {
+            targetsByScope: { platform: [], tenant: agencyTargets, agency: agencyTargets },
+            fallbackIdsByScope: {
+                platform: [],
+                tenant: tenantFallback,
+                agency: agencyTargets.map((target) => target.id),
+            },
+            statisticsById,
+        };
+    }
+
+    return {
+        targetsByScope: { platform: [], tenant: [], agency: agencyTargets },
+        fallbackIdsByScope: {
+            platform: [],
+            tenant: [],
+            agency: agencyTargets.map((target) => target.id),
+        },
+        statisticsById,
+    };
+};

--- a/src/pages/Statistic/statisticDashboardData.ts
+++ b/src/pages/Statistic/statisticDashboardData.ts
@@ -64,6 +64,8 @@ export interface StatisticData {
     targetsByScope: Record<ScopeKey, FilterTarget[]>;
     fallbackIdsByScope: Record<ScopeKey, string[]>;
     statisticsById: Record<string, FilterTargetStatistics>;
+    /** True when the backend skipped small-cell suppression (test environments only). */
+    suppressionDisabled: boolean;
 }
 
 export interface StatisticNameLookups {
@@ -308,6 +310,7 @@ export const emptyStatisticData = (): StatisticData => ({
     targetsByScope: { platform: [], tenant: [], agency: [] },
     fallbackIdsByScope: { platform: [], tenant: [], agency: [] },
     statisticsById: {},
+    suppressionDisabled: false,
 });
 
 export const buildStatisticData = (
@@ -345,6 +348,8 @@ export const buildStatisticData = (
         .map((target) => buildFilterTarget(target, lookups))
         .filter((target): target is FilterTarget => Boolean(target));
 
+    const suppressionDisabled = Boolean(response.suppressionDisabled);
+
     if (response.scope === 'PLATFORM') {
         return {
             targetsByScope: { platform: tenantTargets, tenant: tenantTargets, agency: [] },
@@ -354,6 +359,7 @@ export const buildStatisticData = (
                 agency: [],
             },
             statisticsById,
+            suppressionDisabled,
         };
     }
 
@@ -368,6 +374,7 @@ export const buildStatisticData = (
                 agency: agencyTargets.map((target) => target.id),
             },
             statisticsById,
+            suppressionDisabled,
         };
     }
 
@@ -379,5 +386,6 @@ export const buildStatisticData = (
             agency: agencyTargets.map((target) => target.id),
         },
         statisticsById,
+        suppressionDisabled,
     };
 };

--- a/src/pages/Statistic/types.ts
+++ b/src/pages/Statistic/types.ts
@@ -102,8 +102,6 @@ export interface DonutRenderSegment {
 export interface ScopeDashboard {
     topCards: StatisticCardDefinition[];
     communicationCards: StatisticCardDefinition[];
-    caseCharts: Record<CasePeriodKey, CaseChartBar[]>;
-    conversation: Record<ConversationPeriodKey, ConversationPeriodData>;
 }
 
 export interface PeriodOption<OptionKey extends string> {

--- a/src/pages/Statistic/useStatisticDashboardData.hook.ts
+++ b/src/pages/Statistic/useStatisticDashboardData.hook.ts
@@ -1,0 +1,90 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import getAgencyData from '../../api/agency/getAgencyData';
+import getDashboardStatistics from '../../api/statistic/getDashboardStatistics';
+import { searchTenantData } from '../../api/tenant/searchTenantData';
+import getTopicData from '../../api/topic/getTopicData';
+import { buildStatisticData, emptyStatisticData, StatisticData } from './statisticDashboardData';
+
+const NAME_LOOKUP_PAGE_SIZE = 500;
+
+interface StatisticDashboardDataResult {
+    data: StatisticData;
+    isLoading: boolean;
+    isError: boolean;
+}
+
+/**
+ * Loads the real statistics for the admin dashboard and resolves display names for
+ * tenants, agencies and topics via the existing admin APIs. Name lookups are best
+ * effort — when a lookup fails, ids are shown as fallback labels instead.
+ */
+export const useStatisticDashboardData = (): StatisticDashboardDataResult => {
+    const dashboardQuery = useQuery({
+        queryKey: ['ADMIN_STATISTICS_DASHBOARD'],
+        queryFn: () => getDashboardStatistics(),
+        staleTime: 60 * 1000,
+    });
+
+    const hasAgencyTargets = Boolean(dashboardQuery.data?.targets.some((target) => target.targetType === 'AGENCY'));
+    const isPlatformScope = dashboardQuery.data?.scope === 'PLATFORM';
+
+    const agenciesQuery = useQuery({
+        queryKey: ['ADMIN_STATISTICS_AGENCY_NAMES'],
+        queryFn: () => getAgencyData({ current: 1, pageSize: NAME_LOOKUP_PAGE_SIZE }),
+        enabled: hasAgencyTargets,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+
+    const tenantsQuery = useQuery({
+        queryKey: ['ADMIN_STATISTICS_TENANT_NAMES'],
+        queryFn: () => searchTenantData({ page: 1, perPage: NAME_LOOKUP_PAGE_SIZE }),
+        enabled: isPlatformScope,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+
+    const topicsQuery = useQuery({
+        queryKey: ['ADMIN_STATISTICS_TOPIC_NAMES'],
+        queryFn: () => getTopicData({ current: 1, pageSize: NAME_LOOKUP_PAGE_SIZE }),
+        enabled: Boolean(dashboardQuery.data),
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+
+    const data = useMemo(() => {
+        if (!dashboardQuery.data) {
+            return emptyStatisticData();
+        }
+
+        const agencyNamesById: Record<string, string> = {};
+        (agenciesQuery.data?.data || []).forEach((agency) => {
+            if (agency.id !== null && agency.id !== undefined) {
+                agencyNamesById[`${agency.id}`] = agency.name;
+            }
+        });
+
+        const tenantNamesById: Record<string, string> = {};
+        (tenantsQuery.data?.data || []).forEach((tenant: { id?: number | string | null; name?: string }) => {
+            if (tenant.id !== null && tenant.id !== undefined && tenant.name) {
+                tenantNamesById[`${tenant.id}`] = tenant.name;
+            }
+        });
+
+        const topicNamesById: Record<string, string> = {};
+        (topicsQuery.data?.data || []).forEach((topic) => {
+            if (topic.id !== null && topic.id !== undefined && topic.name) {
+                topicNamesById[`${topic.id}`] = topic.name;
+            }
+        });
+
+        return buildStatisticData(dashboardQuery.data, { agencyNamesById, tenantNamesById, topicNamesById });
+    }, [dashboardQuery.data, agenciesQuery.data, tenantsQuery.data, topicsQuery.data]);
+
+    return {
+        data,
+        isLoading: dashboardQuery.isLoading,
+        isError: dashboardQuery.isError,
+    };
+};

--- a/src/styles/components/statistic.less
+++ b/src/styles/components/statistic.less
@@ -231,6 +231,11 @@
     color: #33475b;
 }
 
+.statisticDashboard__notice--warning {
+    background: #fdf3e3;
+    color: #7a4d05;
+}
+
 @keyframes statisticScopeIn {
     from {
         opacity: 0;

--- a/src/styles/components/statistic.less
+++ b/src/styles/components/statistic.less
@@ -213,6 +213,24 @@
     transform-origin: top center;
 }
 
+.statisticDashboard__notice {
+    padding: 10px 14px;
+    margin: 0 0 16px;
+    border-radius: 12px;
+    font-size: 14px;
+    line-height: 20px;
+}
+
+.statisticDashboard__notice--error {
+    background: #fdecea;
+    color: #8a1c12;
+}
+
+.statisticDashboard__notice--info {
+    background: #eef3f8;
+    color: #33475b;
+}
+
 @keyframes statisticScopeIn {
     from {
         opacity: 0;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { configDefaults, defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import svgrPlugin from 'vite-plugin-svgr';
 import { fileURLToPath } from 'node:url';
 
 const reactJsxRuntime = fileURLToPath(new URL('./node_modules/react/jsx-runtime.js', import.meta.url));
@@ -7,7 +8,18 @@ const reactJsxDevRuntime = fileURLToPath(new URL('./node_modules/react/jsx-dev-r
 
 // https://vitest.dev/config/
 export default defineConfig({
-    plugins: [react()],
+    plugins: [
+        react(),
+        // Mirror the production svgr setup so components importing
+        // `{ ReactComponent }` from .svg files are renderable in tests.
+        svgrPlugin({
+            include: '**/*.svg',
+            svgrOptions: {
+                exportType: 'named',
+                namedExport: 'ReactComponent',
+            },
+        }),
+    ],
     resolve: {
         alias: {
             'react/jsx-dev-runtime': reactJsxDevRuntime,


### PR DESCRIPTION
## Problem

The statistics dashboard rendered hardcoded demo data only (fake tenants "Caritas NRW", fabricated trends, static charts). It must show real, KDG-compliant numbers from the application-layer database.

## What changed

- All dashboard numbers now come from `GET /service/useradmin/statistics/dashboard` (new UserService endpoint: OpenResilienceInitiative/ORISO-UserService#390)
- New data hook resolves tenant/agency/topic display names via existing admin APIs; filter targets are the caller's real tenants/agencies
- Metrics without an app-layer source (messages, video/voice/phone, live chat) show "Keine Daten" instead of fabricated numbers; trend badges only where a real comparison exists (enquiries vs. previous month, topic shares)
- KDG small-cell suppression: targets with <2 counsellors are excluded from aggregation, with a privacy notice
- Removed ~1,900 lines of mock data; chart date labels computed from the real calendar; error notice on load failure

## Verification

- `npm run test` — 505/505 green (incl. new transform tests + page smoke test rendering real API values)
- `npx tsc --noEmit`, `npm run build`, eslint/prettier on changed files — green
- Not yet verified against a live backend (needs the UserService PR deployed); page smoke test covers the full component tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)