### PR TITLE
fix: statistics name lookups must not redirect to access-denied on 403

### DIFF
--- a/src/pages/Statistic.test.tsx
+++ b/src/pages/Statistic.test.tsx
@@ -10,11 +10,12 @@ vi.mock('../api/statistic/getDashboardStatistics', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../api/statistic/getDashboardStatistics')>();
     return { ...actual, default: vi.fn() };
 });
-vi.mock('../api/agency/getAgencyData', () => ({ default: vi.fn().mockResolvedValue({ total: 0, data: [] }) }));
-vi.mock('../api/tenant/searchTenantData', () => ({
-    searchTenantData: vi.fn().mockResolvedValue({ total: 0, data: [] }),
-}));
-vi.mock('../api/topic/getTopicData', () => ({ default: vi.fn().mockResolvedValue({ total: 0, data: [] }) }));
+// The name lookups (agencies/tenants/topics) go through fetchData directly; mock it
+// so tests can simulate per-endpoint failures such as a 403 on /service/topicadmin.
+vi.mock('../api/fetchData', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../api/fetchData')>();
+    return { ...actual, fetchData: vi.fn() };
+});
 vi.mock('../hooks/useUserRoles.hook', () => ({
     useUserRoles: () => ({
         roles: [UserRole.TenantAdmin],
@@ -26,11 +27,13 @@ vi.mock('../hooks/useUserRoles.hook', () => ({
     }),
 }));
 
+import { fetchData } from '../api/fetchData';
 import getDashboardStatistics from '../api/statistic/getDashboardStatistics';
 import i18n from '../i18n';
 import { Statistic } from './Statistic';
 
 const dashboardMock = vi.mocked(getDashboardStatistics);
+const fetchDataMock = vi.mocked(fetchData);
 
 const periodCounts = (total: number) => ({
     today: 0,
@@ -78,6 +81,9 @@ const renderStatistic = () => {
 
 beforeEach(() => {
     dashboardMock.mockReset();
+    fetchDataMock.mockReset();
+    // default: all name lookups succeed with empty result sets
+    fetchDataMock.mockResolvedValue({ total: 0, _embedded: [] });
     window.localStorage.clear();
     // jsdom has no matchMedia; report prefers-reduced-motion so animated
     // counter values render their final numbers synchronously.
@@ -113,6 +119,29 @@ describe('Statistic page', () => {
         // legacy mock numbers must be gone
         expect(screen.queryByText('312')).toBeNull();
         expect(screen.queryByText('Caritas NRW')).toBeNull();
+    });
+
+    it('still renders dashboard data when a name lookup fails with 403', async () => {
+        dashboardMock.mockResolvedValue(response);
+        // simulate the Pre-Dev incident: /service/topicadmin denies access
+        fetchDataMock.mockImplementation(({ url }: { url: string }) => {
+            if (url.includes('topicadmin')) {
+                return Promise.reject(new Error('API call error: 403 Forbidden'));
+            }
+            return Promise.resolve({ total: 0, _embedded: [] });
+        });
+
+        renderStatistic();
+
+        // dashboard data still renders
+        await waitFor(() => expect(screen.getAllByText('12').length).toBeGreaterThan(0));
+        // and the lookup failure did not trigger the access-denied redirect
+        expect(window.location.href).not.toContain('access-denied');
+        // regression guard: lookups must bypass the shared responseHandling
+        // (any truthy responseHandling makes fetchData hard-redirect on 403)
+        const topicCall = fetchDataMock.mock.calls.find(([props]) => props.url.includes('topicadmin'));
+        expect(topicCall).toBeDefined();
+        expect(topicCall?.[0].responseHandling).toBeUndefined();
     });
 
     it('shows a warning banner when small-cell suppression is disabled', async () => {

--- a/src/pages/Statistic/useStatisticDashboardData.hook.ts
+++ b/src/pages/Statistic/useStatisticDashboardData.hook.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import getAgencyData from '../../api/agency/getAgencyData';
+import { FETCH_METHODS, fetchData } from '../../api/fetchData';
 import getDashboardStatistics from '../../api/statistic/getDashboardStatistics';
-import { searchTenantData } from '../../api/tenant/searchTenantData';
-import getTopicData from '../../api/topic/getTopicData';
+import { agencyEndpointBase, tenantAdminEndpoint, topicAdminEndpoint } from '../../appConfig';
+import removeEmbedded from '../../utils/removeEmbedded';
 import { buildStatisticData, emptyStatisticData, StatisticData } from './statisticDashboardData';
 
 const NAME_LOOKUP_PAGE_SIZE = 500;
@@ -15,9 +15,56 @@ interface StatisticDashboardDataResult {
 }
 
 /**
+ * Name lookups are best effort and must NEVER break the dashboard. The shared api
+ * modules (getAgencyData, searchTenantData, getTopicData) call fetchData with a
+ * `responseHandling` option, which hard-redirects to /admin/access-denied on 403 —
+ * that killed the whole statistics page when e.g. the topicadmin endpoint denied
+ * access even though the dashboard data itself had loaded fine.
+ *
+ * We therefore call fetchData WITHOUT `responseHandling` here: a 403 (or any other
+ * failure) rejects locally, is swallowed, and the dashboard falls back to showing
+ * raw ids instead of display names.
+ */
+const fetchNameLookup = async (url: string): Promise<Record<string, string>> => {
+    try {
+        const result = await fetchData({
+            url,
+            method: FETCH_METHODS.GET,
+            skipAuth: false,
+        });
+        const rows: Array<{ id?: number | string | null; name?: string }> = Array.isArray(result)
+            ? result
+            : removeEmbedded(result || {})?.data || [];
+
+        const namesById: Record<string, string> = {};
+        rows.forEach((row) => {
+            if (row && row.id !== null && row.id !== undefined && row.name) {
+                namesById[`${row.id}`] = row.name;
+            }
+        });
+
+        return namesById;
+    } catch {
+        return {};
+    }
+};
+
+const listQuery = `page=1&perPage=${NAME_LOOKUP_PAGE_SIZE}&order=ASC&field=NAME`;
+
+const fetchAgencyNames = () => fetchNameLookup(`${agencyEndpointBase}/?q=${encodeURIComponent('*')}&${listQuery}`);
+
+const fetchTenantNames = () =>
+    fetchNameLookup(
+        `${tenantAdminEndpoint}/search?page=1&perPage=${NAME_LOOKUP_PAGE_SIZE}&query=&field=NAME&order=ASC`,
+    );
+
+const fetchTopicNames = () => fetchNameLookup(`${topicAdminEndpoint}/?${listQuery}`);
+
+/**
  * Loads the real statistics for the admin dashboard and resolves display names for
- * tenants, agencies and topics via the existing admin APIs. Name lookups are best
- * effort — when a lookup fails, ids are shown as fallback labels instead.
+ * tenants, agencies and topics. Name lookups are non-fatal — when a lookup fails,
+ * ids are shown as fallback labels instead. Only a failure of the dashboard endpoint
+ * itself surfaces as an error state.
  */
 export const useStatisticDashboardData = (): StatisticDashboardDataResult => {
     const dashboardQuery = useQuery({
@@ -31,7 +78,7 @@ export const useStatisticDashboardData = (): StatisticDashboardDataResult => {
 
     const agenciesQuery = useQuery({
         queryKey: ['ADMIN_STATISTICS_AGENCY_NAMES'],
-        queryFn: () => getAgencyData({ current: 1, pageSize: NAME_LOOKUP_PAGE_SIZE }),
+        queryFn: fetchAgencyNames,
         enabled: hasAgencyTargets,
         staleTime: 5 * 60 * 1000,
         retry: false,
@@ -39,7 +86,7 @@ export const useStatisticDashboardData = (): StatisticDashboardDataResult => {
 
     const tenantsQuery = useQuery({
         queryKey: ['ADMIN_STATISTICS_TENANT_NAMES'],
-        queryFn: () => searchTenantData({ page: 1, perPage: NAME_LOOKUP_PAGE_SIZE }),
+        queryFn: fetchTenantNames,
         enabled: isPlatformScope,
         staleTime: 5 * 60 * 1000,
         retry: false,
@@ -47,7 +94,7 @@ export const useStatisticDashboardData = (): StatisticDashboardDataResult => {
 
     const topicsQuery = useQuery({
         queryKey: ['ADMIN_STATISTICS_TOPIC_NAMES'],
-        queryFn: () => getTopicData({ current: 1, pageSize: NAME_LOOKUP_PAGE_SIZE }),
+        queryFn: fetchTopicNames,
         enabled: Boolean(dashboardQuery.data),
         staleTime: 5 * 60 * 1000,
         retry: false,
@@ -58,28 +105,11 @@ export const useStatisticDashboardData = (): StatisticDashboardDataResult => {
             return emptyStatisticData();
         }
 
-        const agencyNamesById: Record<string, string> = {};
-        (agenciesQuery.data?.data || []).forEach((agency) => {
-            if (agency.id !== null && agency.id !== undefined) {
-                agencyNamesById[`${agency.id}`] = agency.name;
-            }
+        return buildStatisticData(dashboardQuery.data, {
+            agencyNamesById: agenciesQuery.data || {},
+            tenantNamesById: tenantsQuery.data || {},
+            topicNamesById: topicsQuery.data || {},
         });
-
-        const tenantNamesById: Record<string, string> = {};
-        (tenantsQuery.data?.data || []).forEach((tenant: { id?: number | string | null; name?: string }) => {
-            if (tenant.id !== null && tenant.id !== undefined && tenant.name) {
-                tenantNamesById[`${tenant.id}`] = tenant.name;
-            }
-        });
-
-        const topicNamesById: Record<string, string> = {};
-        (topicsQuery.data?.data || []).forEach((topic) => {
-            if (topic.id !== null && topic.id !== undefined && topic.name) {
-                topicNamesById[`${topic.id}`] = topic.name;
-            }
-        });
-
-        return buildStatisticData(dashboardQuery.data, { agencyNamesById, tenantNamesById, topicNamesById });
     }, [dashboardQuery.data, agenciesQuery.data, tenantsQuery.data, topicsQuery.data]);
 
     return {


### PR DESCRIPTION
## Problem

Pre-Dev E2E (platform admin): `/admin/statistic` loaded and `GET /service/useradmin/statistics/dashboard` returned 200, but a `403` from the secondary topic-name lookup (`GET /service/topicadmin/...`) redirected the whole page to `/admin/access-denied`. `fetchData` hard-redirects on 403 whenever `responseHandling` is set — and all shared lookup modules set it.

## What changed

- Statistics hook performs the three name lookups (agencies, tenants, topics) via `fetchData` **without** `responseHandling`: a 403 rejects locally, is swallowed, and labels fall back to raw ids
- Only a failure of the dashboard endpoint itself surfaces as the page-level error state
- Shared `fetchData` and the shared api modules are unchanged (other pages keep their redirect semantics)
- Regression test: topicadmin 403 → dashboard still renders, no access-denied navigation, lookups assert no `responseHandling`

## Verification

- `npm run test` — 509/509 green (incl. new 403 regression test)
- `npx tsc --noEmit`, eslint/prettier on changed files — green

Follow-up (separate question, not fixed here): why the platform admin gets 403 on `/service/topicadmin` on Pre-Dev (likely tenant-context requirement in ConsultingTypeService).

🤖 Generated with [Claude Code](https://claude.com/claude-code)