### PR TITLE
OBS-P3: report client errors to SigNoz via new endpoint

### DIFF
--- a/src/api/reportClientError.ts
+++ b/src/api/reportClientError.ts
@@ -1,0 +1,59 @@
+import { errorReportEndpoint } from '../appConfig';
+
+export type ErrorReportSeverity = 'error' | 'warn';
+
+export interface ClientErrorReport {
+    message: string;
+    stack?: string;
+    url?: string;
+    correlationId?: string;
+    severity?: ErrorReportSeverity;
+}
+
+type ErrorReportBody = {
+    source: 'admin';
+    message: string;
+    stack?: string;
+    url: string;
+    userAgent?: string;
+    correlationId?: string;
+    severity: ErrorReportSeverity;
+};
+
+const currentUrl = (fallback?: string): string =>
+    fallback || (typeof window !== 'undefined' && window.location?.href) || '';
+
+const currentUserAgent = (): string | undefined => (typeof navigator !== 'undefined' ? navigator.userAgent : undefined);
+
+const noop = () => undefined;
+
+/**
+ * Best-effort, fire-and-forget report of a client-side crash to UserService's
+ * unauthenticated OBS-P3 error-intake endpoint (ORISO-Helm#62), which logs it
+ * through its existing structured logger for SigNoz.
+ *
+ * Must never throw or reject: this is telemetry, called from error-handling
+ * paths (e.g. `ErrorBoundary.componentDidCatch`) that must not themselves be
+ * able to fail.
+ */
+export const reportClientError = (report: ClientErrorReport): void => {
+    try {
+        const body: ErrorReportBody = {
+            source: 'admin',
+            message: report.message || 'Unknown admin error',
+            stack: report.stack,
+            url: currentUrl(report.url),
+            userAgent: currentUserAgent(),
+            correlationId: report.correlationId,
+            severity: report.severity ?? 'error',
+        };
+
+        fetch(errorReportEndpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        }).catch(noop); // Network failure reporting the error -- ignore, best-effort only.
+    } catch {
+        // Never let error reporting itself throw.
+    }
+};

--- a/src/appConfig.ts
+++ b/src/appConfig.ts
@@ -26,6 +26,9 @@ export const consultantsHasAgencyEndpoint = (agencyId: string) =>
     `${userServiceURL}/service/useradmin/agencies/${agencyId}/consultants`;
 export const consultingTypeEndpoint = `${consultingTypeServiceURL}/service/consultingtypes`;
 export const counselorEndpoint = `${userServiceURL}/service/useradmin/consultants`;
+// Unauthenticated client error intake (OBS-P3, ORISO-Helm#62): logs into
+// SigNoz via UserService's existing structured logger.
+export const errorReportEndpoint = `${userServiceURL}/service/error-reports`;
 export const agencyAdminEndpoint = `${userServiceURL}/service/useradmin/agencyadmins`;
 export const grantConsultantIdentityEndpoint = (adminId: string) =>
     `${userServiceURL}/service/useradmin/admins/${adminId}/grant-consultant-identity`;

--- a/src/components/ErrorBoundary/index.test.tsx
+++ b/src/components/ErrorBoundary/index.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ErrorBoundary } from './index';
+import { reportClientError } from '../../api/reportClientError';
 
 vi.mock('i18next', () => ({
     default: { t: (key: string) => key },
+}));
+
+vi.mock('../../api/reportClientError', () => ({
+    reportClientError: vi.fn(),
 }));
 
 const Bomb = ({ shouldThrow }: { shouldThrow: boolean }) => {
@@ -21,6 +26,7 @@ describe('ErrorBoundary', () => {
 
     afterEach(() => {
         vi.restoreAllMocks();
+        vi.mocked(reportClientError).mockClear();
     });
 
     it('renders children when nothing throws', () => {
@@ -43,6 +49,21 @@ describe('ErrorBoundary', () => {
         expect(screen.getByRole('alert')).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'errorBoundary.reload' })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'errorBoundary.toLogin' })).toHaveAttribute('href', '/admin/login');
+    });
+
+    it('reports the caught error to the OBS-P3 error intake (best-effort)', () => {
+        render(
+            <ErrorBoundary scope="page">
+                <Bomb shouldThrow />
+            </ErrorBoundary>,
+        );
+
+        expect(reportClientError).toHaveBeenCalledTimes(1);
+        expect(reportClientError).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: '[page] boom',
+            }),
+        );
     });
 
     it('resets the error state when a reset key changes (route navigation)', () => {

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -1,6 +1,7 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import i18next from 'i18next';
 import routePathNames from '../../appConfig';
+import { reportClientError } from '../../api/reportClientError';
 
 interface ErrorBoundaryProps {
     children: ReactNode;
@@ -50,6 +51,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         const { scope = 'app' } = this.props;
         // eslint-disable-next-line no-console
         console.error(`[ErrorBoundary:${scope}]`, error, errorInfo.componentStack);
+
+        reportClientError({
+            message: `[${scope}] ${error.message}`,
+            stack: error.stack || errorInfo.componentStack || undefined,
+        });
     }
 
     render() {


### PR DESCRIPTION
## Problem
Admin already has an `ErrorBoundary` (app-level in `index.tsx`, page-level in `App.tsx`, per this repo's `CLAUDE.md`), but a caught render error only ever hit `console.error` -- nothing left the browser, so crashes were invisible outside a dev's own console.

## What changed
- `src/api/reportClientError.ts`: fire-and-forget POST of `{ source: "admin", message, stack, url, userAgent, correlationId, severity }` to UserService's new unauthenticated OBS-P3 error-intake endpoint. Never throws/rejects (own try/catch plus a swallowed `fetch().catch()`), since a crash reporter must not itself become a new crash.
- `src/appConfig.ts`: adds `errorReportEndpoint` (`${userServiceOrigin}/service/error-reports`), following the existing endpoint-constant convention in this file.
- `src/components/ErrorBoundary/index.tsx`: `componentDidCatch` now also calls `reportClientError`, tagging the message with the boundary's `scope` (`app`/`page`). Fallback UI unchanged (reload / back-to-login), console logging unchanged.

No new component was introduced -- the existing `ErrorBoundary` already covered app- and page-level crashes, so this only wires reporting into it.

## Verification
- `npx tsc --noEmit` clean.
- `npx eslint <changed files> --max-warnings=0` clean; `npx prettier --check` clean.
- `npx vitest run`: 521 tests / 110 files green, including a new assertion that `componentDidCatch` calls `reportClientError` with the scoped message.

Part of ORISO-Helm#62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)