### PR TITLE
fix(admin): reject invalid tenant favicon URLs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { useUserPermissions } from './hooks/useUserPermission';
 import { PermissionAction } from './enums/PermissionAction';
 import { Resource } from './enums/Resource';
 import { getDefaultSettingsPath } from './constants/settingsTabs';
+import { getSafeFaviconUrl } from './utils/getSafeFaviconUrl';
 import { ReleaseToggle } from './enums/ReleaseToggle';
 import { useReleasesToggle } from './hooks/useReleasesToggle.hook';
 import { usePublicTenantData } from './hooks/usePublicTenantData.hook';
@@ -92,7 +93,7 @@ export const App = () => {
 
     // Apply tenant favicon when appearance config is available
     useEffect(() => {
-        const favicon = publicTenantData?.theming?.favicon;
+        const favicon = getSafeFaviconUrl(publicTenantData?.theming?.favicon);
         if (!favicon) return;
         const link = document.querySelector<HTMLLinkElement>("link[rel='icon']");
         if (link) {

--- a/src/utils/getSafeFaviconUrl.test.ts
+++ b/src/utils/getSafeFaviconUrl.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSafeFaviconUrl } from './getSafeFaviconUrl';
+
+describe('getSafeFaviconUrl', () => {
+    it.each([
+        '/admin/favicon.ico',
+        'https://assets.example.test/branding/favicon.png',
+        'data:image/png;base64,iVBORw0KGgo=',
+        'data:image/svg+xml,%3Csvg%20/%3E',
+    ])('keeps a valid favicon URL (%s)', (favicon) => {
+        expect(getSafeFaviconUrl(favicon)).toBe(favicon);
+    });
+
+    it.each([
+        '',
+        'data:image;base64,broken',
+        'data:text/plain;base64,not-an-image',
+        ['java', 'script:alert(1)'].join(''),
+    ])('rejects an invalid favicon URL (%s)', (favicon) => {
+        expect(getSafeFaviconUrl(favicon)).toBeUndefined();
+    });
+});

--- a/src/utils/getSafeFaviconUrl.ts
+++ b/src/utils/getSafeFaviconUrl.ts
@@ -1,0 +1,15 @@
+const VALID_DATA_IMAGE_URL = /^data:image\/[a-z0-9.+-]+(?:;[^,]*)?,/i;
+
+export const getSafeFaviconUrl = (favicon?: string): string | undefined => {
+    if (!favicon) return undefined;
+
+    try {
+        const url = new URL(favicon, window.location.origin);
+        if (url.protocol === 'http:' || url.protocol === 'https:') return favicon;
+        if (url.protocol === 'data:' && VALID_DATA_IMAGE_URL.test(favicon)) return favicon;
+    } catch {
+        return undefined;
+    }
+
+    return undefined;
+};


### PR DESCRIPTION
Closes OpenResilienceInitiative/ORISO-Admin#301

Parent: OpenResilienceInitiative/ORISO-Helm#66

## What changed

- Validate tenant favicon URLs before replacing `link[rel=icon]`.
- Accept HTTP(S) and valid `data:image/*` URLs.
- Ignore malformed, non-image, and script URLs.

## Why

During Pre-Dev login verification the browser emitted `ERR_INVALID_URL` because a malformed tenant favicon data URL was applied unconditionally. This warning is independent of the repaired authentication failure.

## Verification

- `npm test -- --run src/utils/getSafeFaviconUrl.test.ts` — 8 cases pass.
- `npm run build` passes.