### PR TITLE
Fix broken/overlapping cards on the profile page (/admin/profil)

### DIFF
--- a/src/components/Card/styles.module.scss
+++ b/src/components/Card/styles.module.scss
@@ -50,7 +50,9 @@
 
 .cardTitle {
     display: flex;
+    align-items: flex-start;
     justify-content: space-between;
+    gap: 8px;
     margin-bottom: 24px;
 
     &.hasSubtitle {
@@ -66,10 +68,12 @@
 
 .titleContainer {
     display: flex;
+    min-width: 0;
     gap: 8px;
 
     .title {
         margin-bottom: 0;
+        overflow-wrap: anywhere;
     }
 }
 

--- a/src/pages/Profile/UserProfile.tsx
+++ b/src/pages/Profile/UserProfile.tsx
@@ -17,7 +17,7 @@ export const UserProfile = () => {
             <Page.Title titleKey="profile.title" subTitleKey="profile.title.text" />
 
             <Row gutter={[24, 24]}>
-                <Col span={12} md={6}>
+                <Col xs={24} sm={24} md={12} lg={8} xl={6}>
                     {!hasRole(UserRole.TenantAdmin) && <PrivateData />}
                     <LanguageSettings />
                     <PasswordChange />
@@ -25,7 +25,7 @@ export const UserProfile = () => {
                 </Col>
 
                 {/* 2FA disabled - Keycloak extension not implemented */}
-                {/* <Col span={12} md={6}>
+                {/* <Col xs={24} sm={24} md={12} lg={8} xl={6}>
                     <Card titleKey="twoFactorAuth.title" subTitleKey="twoFactorAuth.subtitle">
                         <TwoFactorAuth />
                     </Card>


### PR DESCRIPTION
**Problem**
The profile page rendered cards squished into a narrow left strip with the "Password" title overlapping the "Change" edit button. The single card column was sized md={6} (a quarter width) — a leftover from a two-column layout whose second column (2FA) is commented out — and the card header had no wrap guard.

**What changed**
- UserProfile: column now responsive xs={24} sm={24} md={12} lg={8} xl={6} (full → quarter width across breakpoints).
- Applied the same spans to the commented-out 2FA column for consistency.
- Card header: added gap + align-items: flex-start to .cardTitle.
- .titleContainer: added min-width: 0 + overflow-wrap: anywhere so the title wraps within its box instead of colliding with the edit button.

**Verification**

- npx prettier --check on changed files — pass.
- npx eslint --max-warnings=0 on UserProfile.tsx — pass.
