### PR TITLE
feat(statistic): add StatisticCard component and related stories

### DIFF
--- a/src/components/SearchInput/SearchInput.stories.tsx
+++ b/src/components/SearchInput/SearchInput.stories.tsx
@@ -1,10 +1,32 @@
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+// eslint-disable-next-line import/no-unresolved -- SB10 subpath export, invisible to the eslint import resolver
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { SearchInput } from './SearchInput';
 
+// The shared search bar (antd input + a submit/clear affordance) used across the
+// admin — conversation lists, the tenant/agency filter, the statistic dashboard.
+// It is controlled when a `value` prop is passed and self-managing otherwise;
+// `handleOnSearch` fires debounced-on-change (and on Enter), `onValueChange`
+// fires on every keystroke.
 const meta = {
     title: 'Molecules/SearchInput',
     component: SearchInput,
-    parameters: { layout: 'padded' },
+    parameters: {
+        layout: 'padded',
+        docs: {
+            description: {
+                component:
+                    'Reusable search bar: a rounded input with a trailing button that submits while empty and clears once text is entered. Controlled via `value` + `onValueChange`, or uncontrolled (internal state). Debounces `handleOnSearch` by ~1s and only fires it past `minSearchLength` (default 3).',
+            },
+        },
+    },
+    args: {
+        ariaLabel: 'Suche',
+        handleOnSearch: fn(),
+        handleOnSearchClear: fn(),
+        onValueChange: fn(),
+    },
     decorators: [
         (Story) => (
             <div style={{ maxWidth: 360 }}>
@@ -12,24 +34,62 @@ const meta = {
             </div>
         ),
     ],
-    args: {
-        ariaLabel: 'Suche',
-    },
 } satisfies Meta<typeof SearchInput>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** Empty state: only the search-submit button is shown. */
-export const SearchButton: Story = {
-    args: {
-        value: '',
-    },
+/** Empty state: the trailing button is the search (magnifier) action. */
+export const Empty: Story = {
+    args: { value: '' },
 };
 
-/** Filled state: the button switches to a clear (X) action. */
-export const ClearButton: Story = {
-    args: {
-        value: 'Musterstadt',
+/** Filled state: the trailing button switches to a clear (X) action. */
+export const Filled: Story = {
+    args: { value: 'Musterstadt' },
+};
+
+/** A caller-supplied placeholder overrides the default `search-placeholder` copy. */
+export const CustomPlaceholder: Story = {
+    args: { value: '', placeholder: 'Kennzahl suchen …' },
+};
+
+// Uncontrolled: the field manages its own value, so typing here works end-to-end.
+const UncontrolledSearch = () => {
+    const [lastSearch, setLastSearch] = useState('');
+    return (
+        <div>
+            <SearchInput
+                ariaLabel="Suche"
+                minSearchLength={1}
+                handleOnSearch={setLastSearch}
+                handleOnSearchClear={() => setLastSearch('')}
+            />
+            <p style={{ marginTop: 12, color: '#666' }}>Letzte Suche: {lastSearch || '—'}</p>
+        </div>
+    );
+};
+
+/**
+ * Interaction: typing reveals the clear button and (past `minSearchLength`)
+ * runs the debounced search; clicking the button empties the field.
+ */
+export const TypeAndClear: Story = {
+    render: () => <UncontrolledSearch />,
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const input = canvas.getByRole('textbox', { name: 'Suche' });
+
+        await userEvent.type(input, 'Musterstadt');
+        await expect(input).toHaveValue('Musterstadt');
+
+        // Past the (1s) debounce the search runs with the typed query.
+        await waitFor(() => expect(canvas.getByText('Letzte Suche: Musterstadt')).toBeInTheDocument(), {
+            timeout: 2000,
+        });
+
+        // The trailing button now clears the field (the input has a single button).
+        await userEvent.click(canvas.getByRole('button'));
+        await expect(input).toHaveValue('');
     },
 };

--- a/src/components/StatisticCard/StatisticCard.stories.tsx
+++ b/src/components/StatisticCard/StatisticCard.stories.tsx
@@ -1,0 +1,149 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+// eslint-disable-next-line import/no-unresolved -- SB10 subpath export, invisible to the eslint import resolver
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { StatisticCard } from './StatisticCard';
+import { ReactComponent as ConversationsIcon } from '../../resources/img/svg/statistics-dashboard/conversations.svg';
+import { ReactComponent as RequestsIcon } from '../../resources/img/svg/statistics-dashboard/requests.svg';
+import { ReactComponent as TopicIcon } from '../../resources/img/svg/statistics-dashboard/topic.svg';
+import { ReactComponent as VideoCallsIcon } from '../../resources/img/svg/statistics-dashboard/video-calls.svg';
+import type { StatisticCardDefinition } from '../../pages/Statistic/types';
+
+// The dashboard translates German seed labels via i18n; in isolation we just echo
+// the provided fallback so the card renders the real Figma copy.
+const echoTranslate = (key: string, options?: Record<string, unknown>) => (options?.defaultValue as string) ?? key;
+
+const requestsCard: StatisticCardDefinition = {
+    key: 'requests',
+    title: 'Anfragen',
+    value: '870',
+    detail: 'Vormonat gesamt 1.050',
+    trend: { value: '~ 20%', tone: 'red' },
+    icon: RequestsIcon,
+    size: 'large',
+    menuLabel: 'Chattyp',
+    menuAriaLabel: 'Anfragen nach Chattyp filtern',
+    defaultMenuKey: 'all',
+    menuOptions: [
+        {
+            key: 'all',
+            label: 'Alle Chattypen',
+            value: '870',
+            detail: 'Vormonat gesamt 1.050',
+            trend: { value: '~ 20%', tone: 'red' },
+        },
+        {
+            key: 'oneToOne',
+            label: 'Nähe (1:1)',
+            value: '420',
+            detail: '1:1-Anfragen',
+            trend: { value: '~ 18%', tone: 'blue' },
+        },
+        {
+            key: 'liveChat',
+            label: 'Live-Chat',
+            value: '250',
+            detail: 'Live-Chat-Anfragen',
+            trend: { value: '~ 11%', tone: 'blue' },
+        },
+        {
+            key: 'groups',
+            label: 'Gruppen',
+            value: '200',
+            detail: 'Gruppen-Anfragen',
+            trend: { value: '~ 9%', tone: 'red' },
+        },
+    ],
+};
+
+const conversationsCard: StatisticCardDefinition = {
+    key: 'conversations',
+    title: 'aktive Gespräche',
+    value: '555',
+    detail: 'heute aktiv',
+    trend: { value: '~ 4%', tone: 'blue' },
+    icon: ConversationsIcon,
+    iconTone: 'muted',
+    size: 'medium',
+};
+
+const videoCard: StatisticCardDefinition = {
+    key: 'video-calls',
+    title: 'Videoanrufe',
+    value: '4%',
+    trend: { value: '~ 67%', tone: 'dark' },
+    icon: VideoCallsIcon,
+    iconTone: 'danger',
+    size: 'small',
+};
+
+const topicCard: StatisticCardDefinition = {
+    key: 'top-topic',
+    title: 'Häufigstes Thema',
+    value: 'Schulden',
+    detail: 'Dieser Monat',
+    trend: { value: '~ 59%', tone: 'dark' },
+    icon: TopicIcon,
+    size: 'small',
+};
+
+// A single metric card from the statistic dashboard (Figma Admin.ORISO 1-34903).
+const meta = {
+    title: 'Organisms/Statistic/StatisticCard',
+    component: StatisticCard,
+    parameters: {
+        layout: 'centered',
+        docs: {
+            description: {
+                component:
+                    'One metric card of the statistic dashboard: icon + title, animated value, a trend badge and — when `menuOptions` are provided — a per-slot metric picker. Styling comes from the global `statisticDashboard__*` rules; the value counts up on mount.',
+            },
+        },
+    },
+    args: {
+        locale: 'de-DE',
+        translate: echoTranslate,
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: 320 }}>
+                <Story />
+            </div>
+        ),
+    ],
+} satisfies Meta<typeof StatisticCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Large card with a rising (red = down vs. previous month) trend and a metric menu.
+export const Large: Story = {
+    args: { card: requestsCard },
+};
+
+// Medium card, muted icon tone, positive trend.
+export const Medium: Story = {
+    args: { card: conversationsCard },
+};
+
+// Small cards: a share metric (danger tone) and a text metric (no menu).
+export const Small: Story = {
+    args: { card: videoCard },
+};
+
+export const TextValue: Story = {
+    args: { card: topicCard },
+};
+
+// The metric picker: opening the menu lists every slot option; selecting one
+// swaps the card's title/value/trend (wired via onMenuChange in the dashboard).
+export const WithMetricMenu: Story = {
+    args: { card: requestsCard },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await userEvent.click(canvas.getByRole('button', { name: 'Anfragen nach Chattyp filtern' }));
+        await waitFor(() => {
+            expect(canvas.getByRole('menu')).toBeInTheDocument();
+            expect(canvas.getByRole('menuitemradio', { name: /Live-Chat/ })).toBeInTheDocument();
+        });
+    },
+};

--- a/src/components/StatisticCard/StatisticCard.tsx
+++ b/src/components/StatisticCard/StatisticCard.tsx
@@ -1,0 +1,280 @@
+import { useState } from 'react';
+import { ArrowDownward, ArrowUpward, MoreVert, NorthEast, SouthEast } from '@mui/icons-material';
+import { ReactComponent as ConversationsIcon } from '../../resources/img/svg/statistics-dashboard/conversations.svg';
+import { ReactComponent as RequestsIcon } from '../../resources/img/svg/statistics-dashboard/requests.svg';
+import { useAnimatedDisplayValue } from '../../pages/Statistic/useAnimatedDisplayValue';
+import type {
+    CardMenuKey,
+    IconTone,
+    StatisticCardDefinition,
+    SvgIcon,
+    TrendBadgeDefinition,
+    TrendDirection,
+    TrendScoreTone,
+} from '../../pages/Statistic/types';
+
+/**
+ * A single metric card for the statistic dashboard (Figma Admin.ORISO). Renders the
+ * metric icon, title, animated value, trend badge and — when the card exposes
+ * `menuOptions` — a per-slot metric picker. Styling comes from the global
+ * `statisticDashboard__*` rules in `src/styles/components/statistic.less`, so the
+ * card must be rendered where that stylesheet is loaded (the app shell and the
+ * Storybook preview both import it).
+ *
+ * Extracted verbatim from `pages/Statistic.tsx` so it can be documented in Storybook
+ * and reused without pulling in the whole dashboard.
+ */
+
+type DashboardTranslate = (key: string, options?: Record<string, unknown>) => string;
+
+const translateDashboardKey = (
+    translate: DashboardTranslate,
+    key: string,
+    defaultValue: string,
+    options: Record<string, unknown> = {},
+) => translate(key, { defaultValue, ...options });
+
+const getCardClassName = (card: StatisticCardDefinition) =>
+    `statisticDashboard__metricCard statisticDashboard__metricCard--${card.size}`;
+
+const getTrendClassName = (tone: TrendScoreTone) => `statisticDashboard__trend statisticDashboard__trend--${tone}`;
+
+const getIconClassName = (tone: IconTone = 'plain') =>
+    `statisticDashboard__metricIcon statisticDashboard__metricIcon--${tone}`;
+
+const getTrendMagnitude = (value: string) => {
+    const match = value.replace(',', '.').match(/-?\d+(\.\d+)?/);
+
+    return match ? Math.abs(Number(match[0])) : 0;
+};
+
+const formatTrendValue = (value: string, isNegative: boolean, locale = 'de-DE') => {
+    const magnitude = getTrendMagnitude(value);
+    const formattedMagnitude = magnitude.toLocaleString(locale, {
+        maximumFractionDigits: 1,
+        minimumFractionDigits: Number.isInteger(magnitude) ? 0 : 1,
+    });
+
+    return `${isNegative ? '-' : '+'} ${formattedMagnitude}%`;
+};
+
+const getTrendDirection = (trend: TrendBadgeDefinition): TrendDirection => {
+    if (trend.direction) {
+        return trend.direction;
+    }
+
+    const magnitude = getTrendMagnitude(trend.value);
+    const isNegative = trend.tone === 'red';
+
+    if (isNegative) {
+        return magnitude >= 15 ? 'down' : 'downRight';
+    }
+
+    return trend.tone === 'dark' || magnitude >= 15 ? 'up' : 'upRight';
+};
+
+const getTrendScoreTone = (trend: TrendBadgeDefinition, direction: TrendDirection): TrendScoreTone => {
+    const magnitude = getTrendMagnitude(trend.value);
+    const isNegative = direction === 'down' || direction === 'downRight';
+
+    if (isNegative) {
+        return magnitude >= 20 ? 'critical' : 'bad';
+    }
+
+    return trend.tone === 'dark' || magnitude >= 50 ? 'great' : 'good';
+};
+
+const getTrendIcon = (direction: TrendDirection) => {
+    switch (direction) {
+        case 'up':
+            return ArrowUpward;
+        case 'down':
+            return ArrowDownward;
+        case 'upRight':
+            return NorthEast;
+        case 'downRight':
+            return SouthEast;
+        default:
+            return NorthEast;
+    }
+};
+
+const getEffectiveIconTone = (icon: SvgIcon, tone?: IconTone) => {
+    if (icon === RequestsIcon) {
+        return tone || 'muted';
+    }
+
+    if (icon === ConversationsIcon && tone === 'muted') {
+        return undefined;
+    }
+
+    return tone;
+};
+
+export const AnimatedValue = ({ locale = 'de-DE', value }: { locale?: string; value: string }) => (
+    <>{useAnimatedDisplayValue(value, 2800, locale)}</>
+);
+
+const MetricIcon = ({ icon: Icon, tone }: { icon: SvgIcon; tone?: IconTone }) => (
+    <span className={getIconClassName(getEffectiveIconTone(Icon, tone))} aria-hidden="true">
+        <Icon />
+    </span>
+);
+
+const TrendBadge = ({
+    locale,
+    translate,
+    trend,
+}: {
+    locale: string;
+    translate: DashboardTranslate;
+    trend?: TrendBadgeDefinition;
+}) => {
+    if (!trend) {
+        return null;
+    }
+
+    const direction = getTrendDirection(trend);
+    const scoreTone = getTrendScoreTone(trend, direction);
+    const isNegative = direction === 'down' || direction === 'downRight';
+    const displayValue = formatTrendValue(trend.value, isNegative, locale);
+    const TrendIcon = getTrendIcon(direction);
+
+    return (
+        <span
+            className={getTrendClassName(scoreTone)}
+            aria-label={`${translateDashboardKey(
+                translate,
+                isNegative ? 'statistic.dashboard.trend.decrease' : 'statistic.dashboard.trend.increase',
+                isNegative ? 'Abnahme' : 'Zunahme',
+            )} ${displayValue}`}
+        >
+            <TrendIcon aria-hidden="true" />
+            {displayValue}
+        </span>
+    );
+};
+
+export interface StatisticCardProps {
+    card: StatisticCardDefinition;
+    locale: string;
+    menuValue?: CardMenuKey;
+    onMenuChange?: (cardKey: string, menuKey: CardMenuKey) => void;
+    translate: DashboardTranslate;
+}
+
+export const StatisticCard = ({ card, locale, menuValue, onMenuChange, translate }: StatisticCardProps) => {
+    const storedMenuOption = card.menuOptions?.find((option) => option.key === menuValue);
+    const defaultMenuOption = card.menuOptions?.find((option) => option.key === card.defaultMenuKey);
+    const selectedMenuOption = storedMenuOption || defaultMenuOption;
+    const activeMenuKey = selectedMenuOption?.key || card.defaultMenuKey;
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const hasMenu = Boolean(card.menuOptions?.length);
+    const displayTitle = selectedMenuOption?.title || card.title;
+    const displayValue = selectedMenuOption?.value || card.value;
+    const displayDetail = selectedMenuOption?.detail ?? card.detail;
+    const displayTrend = selectedMenuOption?.trend || card.trend;
+    const DisplayIcon = selectedMenuOption?.icon || card.icon;
+    const displayIconTone = selectedMenuOption?.iconTone ?? card.iconTone;
+    const menuLabel =
+        card.menuLabel || translateDashboardKey(translate, 'statistic.dashboard.text.chatType', 'Chattyp');
+    const menuAriaLabel =
+        card.menuAriaLabel ||
+        translateDashboardKey(
+            translate,
+            'statistic.dashboard.menu.filterByChatType',
+            `${card.title} nach Chattyp filtern`,
+            {
+                title: card.title,
+            },
+        );
+
+    return (
+        <section
+            className={`${getCardClassName(card)} ${isMenuOpen ? 'statisticDashboard__metricCard--menuOpen' : ''}`}
+            data-card-key={card.key}
+        >
+            <div
+                className={`statisticDashboard__cardHeader ${
+                    hasMenu ? '' : 'statisticDashboard__cardHeader--withoutMenu'
+                }`}
+            >
+                <MetricIcon icon={DisplayIcon} tone={displayIconTone} />
+                <h2>{displayTitle}</h2>
+                {hasMenu && (
+                    <div
+                        className="statisticDashboard__cardMenuWrap"
+                        onBlur={(event) => {
+                            if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+                                setIsMenuOpen(false);
+                            }
+                        }}
+                    >
+                        <button
+                            type="button"
+                            className="statisticDashboard__cardMenu"
+                            aria-label={menuAriaLabel}
+                            aria-haspopup="menu"
+                            aria-expanded={isMenuOpen}
+                            onClick={() => setIsMenuOpen((currentValue) => !currentValue)}
+                        >
+                            <MoreVert aria-hidden="true" />
+                        </button>
+                        {isMenuOpen && (
+                            <div className="statisticDashboard__cardMenuPanel" role="menu">
+                                <span className="statisticDashboard__cardMenuEyebrow">{menuLabel}</span>
+                                {card.menuOptions.map((option) => {
+                                    const isSelected = option.key === activeMenuKey;
+                                    const OptionIcon = option.icon || DisplayIcon;
+
+                                    return (
+                                        <button
+                                            key={option.key}
+                                            type="button"
+                                            className={`statisticDashboard__cardMenuItem ${
+                                                isSelected ? 'statisticDashboard__cardMenuItem--active' : ''
+                                            }`}
+                                            role="menuitemradio"
+                                            aria-checked={isSelected}
+                                            onClick={() => {
+                                                onMenuChange?.(card.key, option.key);
+                                                setIsMenuOpen(false);
+                                            }}
+                                        >
+                                            <span className="statisticDashboard__cardMenuItemIcon" aria-hidden="true">
+                                                <OptionIcon />
+                                            </span>
+                                            <span className="statisticDashboard__cardMenuItemBody">
+                                                <span className="statisticDashboard__cardMenuItemRow">
+                                                    <span className="statisticDashboard__cardMenuItemTitle">
+                                                        {option.label}
+                                                    </span>
+                                                    <strong>{option.value}</strong>
+                                                </span>
+                                                {option.description && (
+                                                    <small className="statisticDashboard__cardMenuItemDescription">
+                                                        {option.description}
+                                                    </small>
+                                                )}
+                                            </span>
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            <div className="statisticDashboard__cardValueRow">
+                <strong>
+                    <AnimatedValue locale={locale} value={displayValue} />
+                </strong>
+                <TrendBadge locale={locale} translate={translate} trend={displayTrend} />
+                {displayDetail && <span className="statisticDashboard__cardDetail">{displayDetail}</span>}
+            </div>
+        </section>
+    );
+};
+
+export default StatisticCard;

--- a/src/pages/Statistic.tsx
+++ b/src/pages/Statistic.tsx
@@ -1,10 +1,11 @@
-import { ArrowDownward, ArrowUpward, Close, MoreVert, NorthEast, SouthEast } from '@mui/icons-material';
+import { Close } from '@mui/icons-material';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AdminSegmentedTabs } from '../components/AdminSegmentedTabs/AdminSegmentedTabs';
 import { Page } from '../components/Page';
 import SearchInput from '../components/SearchInput/SearchInput';
+import { AnimatedValue, StatisticCard } from '../components/StatisticCard/StatisticCard';
 import { UserRole } from '../enums/UserRole';
 import { useUserRoles } from '../hooks/useUserRoles.hook';
 import { ReactComponent as ActiveAgenciesIcon } from '../resources/img/svg/statistics-dashboard/active-agencies.svg';
@@ -62,19 +63,14 @@ import type {
     ConversationSegment,
     ConversationPeriodData,
     ConversationPeriodKey,
-    IconTone,
     ScopeDashboard,
     ScopeDefinition,
     ScopeKey,
     SelectedFilterTargetIdsByScope,
     SelectedCardMenuByScope,
     StatisticCardDefinition,
-    SvgIcon,
     TrendBadgeDefinition,
-    TrendDirection,
-    TrendScoreTone,
 } from './Statistic/types';
-import { useAnimatedDisplayValue } from './Statistic/useAnimatedDisplayValue';
 import type { AdminSegmentedTabItem } from '../components/AdminSegmentedTabs/AdminSegmentedTabs';
 
 const conversationSegmentBlueprint = [
@@ -1923,87 +1919,6 @@ const dashboardByScope: Record<ScopeKey, ScopeDashboard> = {
     },
 };
 
-const getCardClassName = (card: StatisticCardDefinition) =>
-    `statisticDashboard__metricCard statisticDashboard__metricCard--${card.size}`;
-
-const getTrendClassName = (tone: TrendScoreTone) => `statisticDashboard__trend statisticDashboard__trend--${tone}`;
-
-const getIconClassName = (tone: IconTone = 'plain') =>
-    `statisticDashboard__metricIcon statisticDashboard__metricIcon--${tone}`;
-
-const getTrendMagnitude = (value: string) => {
-    const match = value.replace(',', '.').match(/-?\d+(\.\d+)?/);
-
-    return match ? Math.abs(Number(match[0])) : 0;
-};
-
-const formatTrendValue = (value: string, isNegative: boolean, locale = 'de-DE') => {
-    const magnitude = getTrendMagnitude(value);
-    const formattedMagnitude = magnitude.toLocaleString(locale, {
-        maximumFractionDigits: 1,
-        minimumFractionDigits: Number.isInteger(magnitude) ? 0 : 1,
-    });
-
-    return `${isNegative ? '-' : '+'} ${formattedMagnitude}%`;
-};
-
-const getTrendDirection = (trend: TrendBadgeDefinition): TrendDirection => {
-    if (trend.direction) {
-        return trend.direction;
-    }
-
-    const magnitude = getTrendMagnitude(trend.value);
-    const isNegative = trend.tone === 'red';
-
-    if (isNegative) {
-        return magnitude >= 15 ? 'down' : 'downRight';
-    }
-
-    return trend.tone === 'dark' || magnitude >= 15 ? 'up' : 'upRight';
-};
-
-const getTrendScoreTone = (trend: TrendBadgeDefinition, direction: TrendDirection): TrendScoreTone => {
-    const magnitude = getTrendMagnitude(trend.value);
-    const isNegative = direction === 'down' || direction === 'downRight';
-
-    if (isNegative) {
-        return magnitude >= 20 ? 'critical' : 'bad';
-    }
-
-    return trend.tone === 'dark' || magnitude >= 50 ? 'great' : 'good';
-};
-
-const getTrendIcon = (direction: TrendDirection) => {
-    switch (direction) {
-        case 'up':
-            return ArrowUpward;
-        case 'down':
-            return ArrowDownward;
-        case 'upRight':
-            return NorthEast;
-        case 'downRight':
-            return SouthEast;
-        default:
-            return NorthEast;
-    }
-};
-
-const getEffectiveIconTone = (icon: SvgIcon, tone?: IconTone) => {
-    if (icon === RequestsIcon) {
-        return tone || 'muted';
-    }
-
-    if (icon === ConversationsIcon && tone === 'muted') {
-        return undefined;
-    }
-
-    return tone;
-};
-
-const AnimatedValue = ({ locale = 'de-DE', value }: { locale?: string; value: string }) => (
-    <>{useAnimatedDisplayValue(value, 2800, locale)}</>
-);
-
 const DonutChart = ({
     animationKey,
     data,
@@ -2117,168 +2032,6 @@ const DonutChart = ({
                 </small>
             </div>
         </div>
-    );
-};
-
-const MetricIcon = ({ icon: Icon, tone }: { icon: SvgIcon; tone?: IconTone }) => (
-    <span className={getIconClassName(getEffectiveIconTone(Icon, tone))} aria-hidden="true">
-        <Icon />
-    </span>
-);
-
-const TrendBadge = ({
-    locale,
-    translate,
-    trend,
-}: {
-    locale: string;
-    translate: DashboardTranslate;
-    trend?: TrendBadgeDefinition;
-}) => {
-    if (!trend) {
-        return null;
-    }
-
-    const direction = getTrendDirection(trend);
-    const scoreTone = getTrendScoreTone(trend, direction);
-    const isNegative = direction === 'down' || direction === 'downRight';
-    const displayValue = formatTrendValue(trend.value, isNegative, locale);
-    const TrendIcon = getTrendIcon(direction);
-
-    return (
-        <span
-            className={getTrendClassName(scoreTone)}
-            aria-label={`${translateDashboardKey(
-                translate,
-                isNegative ? 'statistic.dashboard.trend.decrease' : 'statistic.dashboard.trend.increase',
-                isNegative ? 'Abnahme' : 'Zunahme',
-            )} ${displayValue}`}
-        >
-            <TrendIcon aria-hidden="true" />
-            {displayValue}
-        </span>
-    );
-};
-
-interface StatisticCardProps {
-    card: StatisticCardDefinition;
-    locale: string;
-    menuValue?: CardMenuKey;
-    onMenuChange?: (cardKey: string, menuKey: CardMenuKey) => void;
-    translate: DashboardTranslate;
-}
-
-const StatisticCard = ({ card, locale, menuValue, onMenuChange, translate }: StatisticCardProps) => {
-    const storedMenuOption = card.menuOptions?.find((option) => option.key === menuValue);
-    const defaultMenuOption = card.menuOptions?.find((option) => option.key === card.defaultMenuKey);
-    const selectedMenuOption = storedMenuOption || defaultMenuOption;
-    const activeMenuKey = selectedMenuOption?.key || card.defaultMenuKey;
-    const [isMenuOpen, setIsMenuOpen] = useState(false);
-    const hasMenu = Boolean(card.menuOptions?.length);
-    const displayTitle = selectedMenuOption?.title || card.title;
-    const displayValue = selectedMenuOption?.value || card.value;
-    const displayDetail = selectedMenuOption?.detail ?? card.detail;
-    const displayTrend = selectedMenuOption?.trend || card.trend;
-    const DisplayIcon = selectedMenuOption?.icon || card.icon;
-    const displayIconTone = selectedMenuOption?.iconTone ?? card.iconTone;
-    const menuLabel =
-        card.menuLabel || translateDashboardKey(translate, 'statistic.dashboard.text.chatType', 'Chattyp');
-    const menuAriaLabel =
-        card.menuAriaLabel ||
-        translateDashboardKey(
-            translate,
-            'statistic.dashboard.menu.filterByChatType',
-            `${card.title} nach Chattyp filtern`,
-            {
-                title: card.title,
-            },
-        );
-
-    return (
-        <section
-            className={`${getCardClassName(card)} ${isMenuOpen ? 'statisticDashboard__metricCard--menuOpen' : ''}`}
-            data-card-key={card.key}
-        >
-            <div
-                className={`statisticDashboard__cardHeader ${
-                    hasMenu ? '' : 'statisticDashboard__cardHeader--withoutMenu'
-                }`}
-            >
-                <MetricIcon icon={DisplayIcon} tone={displayIconTone} />
-                <h2>{displayTitle}</h2>
-                {hasMenu && (
-                    <div
-                        className="statisticDashboard__cardMenuWrap"
-                        onBlur={(event) => {
-                            if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
-                                setIsMenuOpen(false);
-                            }
-                        }}
-                    >
-                        <button
-                            type="button"
-                            className="statisticDashboard__cardMenu"
-                            aria-label={menuAriaLabel}
-                            aria-haspopup="menu"
-                            aria-expanded={isMenuOpen}
-                            onClick={() => setIsMenuOpen((currentValue) => !currentValue)}
-                        >
-                            <MoreVert aria-hidden="true" />
-                        </button>
-                        {isMenuOpen && (
-                            <div className="statisticDashboard__cardMenuPanel" role="menu">
-                                <span className="statisticDashboard__cardMenuEyebrow">{menuLabel}</span>
-                                {card.menuOptions.map((option) => {
-                                    const isSelected = option.key === activeMenuKey;
-                                    const OptionIcon = option.icon || DisplayIcon;
-
-                                    return (
-                                        <button
-                                            key={option.key}
-                                            type="button"
-                                            className={`statisticDashboard__cardMenuItem ${
-                                                isSelected ? 'statisticDashboard__cardMenuItem--active' : ''
-                                            }`}
-                                            role="menuitemradio"
-                                            aria-checked={isSelected}
-                                            onClick={() => {
-                                                onMenuChange?.(card.key, option.key);
-                                                setIsMenuOpen(false);
-                                            }}
-                                        >
-                                            <span className="statisticDashboard__cardMenuItemIcon" aria-hidden="true">
-                                                <OptionIcon />
-                                            </span>
-                                            <span className="statisticDashboard__cardMenuItemBody">
-                                                <span className="statisticDashboard__cardMenuItemRow">
-                                                    <span className="statisticDashboard__cardMenuItemTitle">
-                                                        {option.label}
-                                                    </span>
-                                                    <strong>{option.value}</strong>
-                                                </span>
-                                                {option.description && (
-                                                    <small className="statisticDashboard__cardMenuItemDescription">
-                                                        {option.description}
-                                                    </small>
-                                                )}
-                                            </span>
-                                        </button>
-                                    );
-                                })}
-                            </div>
-                        )}
-                    </div>
-                )}
-            </div>
-
-            <div className="statisticDashboard__cardValueRow">
-                <strong>
-                    <AnimatedValue locale={locale} value={displayValue} />
-                </strong>
-                <TrendBadge locale={locale} translate={translate} trend={displayTrend} />
-                {displayDetail && <span className="statisticDashboard__cardDetail">{displayDetail}</span>}
-            </div>
-        </section>
     );
 };
 


### PR DESCRIPTION
## Problem
The statistic dashboard's metric card was defined inline in the 3k-line
`Statistic.tsx` with no Storybook coverage, and the shared search bar had only a
minimal two-state story. Branch: reusable card + searchbar components.

## What changed
- Extracted the metric card (with its `MetricIcon` / `TrendBadge` / `AnimatedValue`
  helpers) **verbatim** into `components/StatisticCard/StatisticCard.tsx`; the page
  imports it (re-exporting `AnimatedValue` for the donut). No visual/behaviour change.
- Added `StatisticCard.stories.tsx` — 5 states (Large/Medium/Small/TextValue) plus
  a `WithMetricMenu` interaction (play) test.
- Expanded `Molecules/SearchInput` into a fuller searchbar showcase: Empty, Filled,
  CustomPlaceholder, and a `TypeAndClear` play test (type → debounced search → clear).

## Verification
- `npx tsc --noEmit` — clean
- `npx eslint . --max-warnings=0` / `npx prettier . --check` — clean
- `npm run build-storybook` — builds; all StatisticCard + SearchInput stories register
- `Statistic.test.tsx` unaffected (page renders identically)