### PR TITLE
fix(admin): stop tenantadmin GET 500 on theme-settings/general

### DIFF
--- a/src/components/Tenants/GeneralSettings/components/Languages/index.tsx
+++ b/src/components/Tenants/GeneralSettings/components/Languages/index.tsx
@@ -5,8 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { supportedLanguages } from '../../../../../appConfig';
 import { CardEditable } from '../../../../CardEditable';
 import { Modal } from '../../../../Modal';
-import { useSingleTenantData } from '../../../../../hooks/useSingleTenantData';
-import { useTenantAdminDataMutation } from '../../../../../hooks/useTenantAdminDataMutation.hook';
+import { useTenantAppearanceFormData } from '../../../../../hooks/useTenantAppearanceFormData';
 import styles from './styles.module.scss';
 
 const ensureDefaultLanguage = (languages: string[]) => {
@@ -27,9 +26,7 @@ export const Languages = ({ tenantId, readOnly = false }: { tenantId: string; re
     const { t } = useTranslation();
     const [form] = Form.useForm();
     const [modal, setModal] = useState(false);
-    const { data, isLoading } = useSingleTenantData({ id: tenantId });
-
-    const { mutate } = useTenantAdminDataMutation({ id: tenantId });
+    const { data, isLoading, mutate } = useTenantAppearanceFormData(tenantId);
     const options = supportedLanguages.map((language) => ({ value: language, label: t(`language.${language}`) }));
     const activeLanguages = data?.settings?.activeLanguages?.length ? data.settings.activeLanguages : ['de'];
     const initialValues = {

--- a/src/components/Tenants/GeneralSettings/components/LogoAndFavicon/index.tsx
+++ b/src/components/Tenants/GeneralSettings/components/LogoAndFavicon/index.tsx
@@ -5,8 +5,7 @@ import ImageOutlinedIcon from '@mui/icons-material/ImageOutlined';
 import { CardEditable } from '../../../../CardEditable';
 import { FormFileUploaderField } from '../../../../FormFileUploaderField';
 import { usePublicTenantData } from '../../../../../hooks/usePublicTenantData.hook';
-import { useSingleTenantData } from '../../../../../hooks/useSingleTenantData';
-import { useTenantAdminDataMutation } from '../../../../../hooks/useTenantAdminDataMutation.hook';
+import { useTenantAppearanceFormData } from '../../../../../hooks/useTenantAppearanceFormData';
 import { useAppConfigContext } from '../../../../../context/useAppConfig';
 import styles from './styles.module.scss';
 
@@ -15,9 +14,8 @@ const isReadOnlySetting = (meta: Record<string, { readOnly?: boolean }> | undefi
 
 export const LogoAndFavicon = ({ tenantId, readOnly = false }: { tenantId: string; readOnly?: boolean }) => {
     const { t } = useTranslation();
-    const { data, isLoading } = useSingleTenantData({ id: tenantId });
+    const { data, isLoading, mutate } = useTenantAppearanceFormData(tenantId);
     const { data: inheritedData } = usePublicTenantData();
-    const { mutate } = useTenantAdminDataMutation({ id: tenantId });
     const { settings } = useAppConfigContext();
     const logoReadOnly =
         readOnly ||

--- a/src/components/Tenants/GeneralSettings/components/NameAndSlogan/index.tsx
+++ b/src/components/Tenants/GeneralSettings/components/NameAndSlogan/index.tsx
@@ -2,14 +2,12 @@ import { useTranslation } from 'react-i18next';
 import TitleOutlinedIcon from '@mui/icons-material/TitleOutlined';
 import { CardEditable } from '../../../../CardEditable';
 import { FormInputField } from '../../../../FormInputField';
-import { useSingleTenantData } from '../../../../../hooks/useSingleTenantData';
-import { useTenantAdminDataMutation } from '../../../../../hooks/useTenantAdminDataMutation.hook';
+import { useTenantAppearanceFormData } from '../../../../../hooks/useTenantAppearanceFormData';
 import styles from './styles.module.scss';
 
 export const NameAndSlogan = ({ tenantId, readOnly = false }: { tenantId: string; readOnly?: boolean }) => {
     const { t } = useTranslation();
-    const { data, isLoading } = useSingleTenantData({ id: tenantId });
-    const { mutate } = useTenantAdminDataMutation({ id: tenantId });
+    const { data, isLoading, mutate } = useTenantAppearanceFormData(tenantId);
 
     return (
         <CardEditable

--- a/src/components/Tenants/GeneralSettings/components/ThemeBuilder/index.tsx
+++ b/src/components/Tenants/GeneralSettings/components/ThemeBuilder/index.tsx
@@ -7,8 +7,7 @@ import { FormColorSelectorField } from '../../../../FormColorSelectorField';
 import { SideScrollerFooter } from '../../../../SideScrollerFooter';
 import { useAppConfigContext } from '../../../../../context/useAppConfig';
 import { usePublicTenantData } from '../../../../../hooks/usePublicTenantData.hook';
-import { useSingleTenantData } from '../../../../../hooks/useSingleTenantData';
-import { useTenantAdminDataMutation } from '../../../../../hooks/useTenantAdminDataMutation.hook';
+import { useTenantAppearanceFormData } from '../../../../../hooks/useTenantAppearanceFormData';
 import { isReadOnlySetting } from '../../../../../utils/serverSettingsMeta';
 import { computeOrisoPalette } from '../../../../../utils/theme/orisoScheme';
 import {
@@ -339,9 +338,8 @@ export const ThemeBuilder = ({ tenantId, readOnly = false }: ThemeBuilderProps) 
     const { t } = useTranslation();
     const [editorOpen, setEditorOpen] = useState(false);
     const { settings } = useAppConfigContext();
-    const { data, isLoading } = useSingleTenantData({ id: tenantId });
+    const { data, isLoading, mutate } = useTenantAppearanceFormData(tenantId);
     const { data: inheritedData } = usePublicTenantData();
-    const { mutate } = useTenantAdminDataMutation({ id: tenantId });
 
     const locks = {
         accentDark:

--- a/src/components/Tenants/GeneralSettings/components/TypeOfLanguage/index.tsx
+++ b/src/components/Tenants/GeneralSettings/components/TypeOfLanguage/index.tsx
@@ -2,14 +2,12 @@ import { useTranslation } from 'react-i18next';
 import TranslateOutlinedIcon from '@mui/icons-material/TranslateOutlined';
 import { CardEditable } from '../../../../CardEditable';
 import { FormRadioGroupField } from '../../../../FormRadioGroupField';
-import { useSingleTenantData } from '../../../../../hooks/useSingleTenantData';
-import { useTenantAdminDataMutation } from '../../../../../hooks/useTenantAdminDataMutation.hook';
+import { useTenantAppearanceFormData } from '../../../../../hooks/useTenantAppearanceFormData';
 import styles from './styles.module.scss';
 
 export const TypeOfLanguage = ({ tenantId, readOnly = false }: { tenantId: string; readOnly?: boolean }) => {
     const { t } = useTranslation();
-    const { data, isLoading } = useSingleTenantData({ id: tenantId });
-    const { mutate } = useTenantAdminDataMutation({ id: tenantId });
+    const { data, isLoading, mutate } = useTenantAppearanceFormData(tenantId);
 
     return (
         <CardEditable

--- a/src/hooks/useTenantAdminDataMutation.hook.ts
+++ b/src/hooks/useTenantAdminDataMutation.hook.ts
@@ -5,8 +5,9 @@ import { fetchData, FETCH_METHODS } from '../api/fetchData';
 import { tenantAdminEndpoint } from '../appConfig';
 import { TenantAdminData } from '../types/TenantAdminData';
 import { mergeTenantAdminData } from '../utils/mergeTenantAdminData';
-import { useSingleTenantData } from './useSingleTenantData';
+import { useSingleTenantData, TENANT_QUERY_KEY } from './useSingleTenantData';
 import { TENANT_ADMIN_DATA_KEY } from './useTenantAdminData.hook';
+import { TENANT_DATA_KEY } from './useTenantData.hook';
 
 interface TenantAdminDataOptions
     extends UseMutationOptions<Partial<TenantAdminData>, unknown, Partial<TenantAdminData>> {
@@ -47,7 +48,13 @@ export const useTenantAdminDataMutation = ({
         ...options,
         onSuccess: (responseData, updatedData, onMutateResult, context) => {
             const mergeBase = tenantAdminData ?? seedTenantAdminData;
-            queryClient.setQueryData([TENANT_ADMIN_DATA_KEY], mergeTenantAdminData(mergeBase, updatedData));
+            const merged = mergeTenantAdminData(mergeBase, updatedData);
+            queryClient.setQueryData([TENANT_ADMIN_DATA_KEY], merged);
+            if (id != null && id !== '' && id !== 'add') {
+                queryClient.setQueryData([TENANT_QUERY_KEY, Number(id)], merged);
+            }
+            // Appearance cards may seed from /service/tenant — refresh that cache after PUT.
+            queryClient.invalidateQueries({ queryKey: [TENANT_DATA_KEY] });
             notification.success({
                 message: t(successMessageKey),
                 duration: 3,

--- a/src/hooks/useTenantAppearanceFormData.test.tsx
+++ b/src/hooks/useTenantAppearanceFormData.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TenantData } from '../types/tenant';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../api/tenant/getSingleTenantData', () => ({
+    getSingleTenantData: vi.fn(),
+}));
+
+vi.mock('./useTenantData.hook', () => ({
+    TENANT_DATA_KEY: 'tenant-data',
+    useTenantData: vi.fn(),
+}));
+
+import { getSingleTenantData } from '../api/tenant/getSingleTenantData';
+import { useTenantData } from './useTenantData.hook';
+import { useTenantAppearanceFormData } from './useTenantAppearanceFormData';
+
+const getSingleTenantDataMock = vi.mocked(getSingleTenantData);
+const useTenantDataMock = vi.mocked(useTenantData);
+
+const currentTenant = {
+    id: 1,
+    name: 'Current tenant',
+    isSuperAdmin: true,
+    userRoles: [],
+    settings: { activeLanguages: ['de', 'en'] },
+    theming: {
+        logo: 'logo.svg',
+        favicon: 'favicon.ico',
+        primaryColor: '#112233',
+        secondaryColor: null,
+        accent: '#445566',
+    },
+    content: {
+        impressum: null,
+        privacy: null,
+        termsAndConditions: null,
+        claim: 'Claim DE',
+    },
+} as TenantData;
+
+const createWrapper = () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+};
+
+beforeEach(() => {
+    getSingleTenantDataMock.mockReset();
+    useTenantDataMock.mockReset();
+    useTenantDataMock.mockReturnValue({
+        data: currentTenant,
+        isLoading: false,
+    } as never);
+});
+
+describe('useTenantAppearanceFormData', () => {
+    it('does not call GET /service/tenantadmin when editing the current tenant', async () => {
+        const { result } = renderHook(() => useTenantAppearanceFormData('1'), { wrapper: createWrapper() });
+
+        await waitFor(() => expect(result.current.data?.name).toBe('Current tenant'));
+
+        expect(getSingleTenantDataMock).not.toHaveBeenCalled();
+        expect(result.current.data?.theming?.logo).toBe('logo.svg');
+        expect(result.current.data?.content?.claim?.de).toBe('Claim DE');
+    });
+
+    it('still fetches tenantadmin data when editing a different tenant id', async () => {
+        getSingleTenantDataMock.mockResolvedValue({
+            id: 5,
+            name: 'Other tenant',
+            theming: { logo: 'other.svg', favicon: '', primaryColor: '#000' },
+        } as never);
+
+        const { result } = renderHook(() => useTenantAppearanceFormData('5'), { wrapper: createWrapper() });
+
+        await waitFor(() => expect(result.current.data?.name).toBe('Other tenant'));
+
+        expect(getSingleTenantDataMock).toHaveBeenCalledWith('5');
+    });
+});

--- a/src/hooks/useTenantAppearanceFormData.ts
+++ b/src/hooks/useTenantAppearanceFormData.ts
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+import { TenantAdminData } from '../types/TenantAdminData';
+import { mapTenantDataToTenantAdminData } from '../utils/mapTenantDataToTenantAdminData';
+import { useSingleTenantData } from './useSingleTenantData';
+import { useTenantAdminDataMutation } from './useTenantAdminDataMutation.hook';
+import { useTenantData } from './useTenantData.hook';
+
+/**
+ * Appearance / general theme-settings cards need tenantadmin-shaped data, but
+ * GET /service/tenantadmin/{id} currently 500s for some tenants on pre-dev.
+ * When the form targets the signed-in tenant, seed from the healthy
+ * GET /service/tenant path and skip the broken tenantadmin prefetch (same
+ * pattern as GlobalLoginSettingsPage / PR #299).
+ */
+export const useTenantAppearanceFormData = (tenantId: string) => {
+    const { data: tenantData, isLoading: isTenantLoading } = useTenantData();
+    const seedTenantAdminData = useMemo(() => {
+        if (tenantData?.id == null || tenantId === '' || tenantId === 'add') {
+            return undefined;
+        }
+
+        if (String(tenantData.id) !== String(tenantId)) {
+            return undefined;
+        }
+
+        return mapTenantDataToTenantAdminData(tenantData);
+    }, [tenantData, tenantId]);
+
+    const shouldFetchTenantAdmin = !!tenantId && tenantId !== 'add' && !seedTenantAdminData;
+    const { data: tenantAdminData, isLoading: isAdminLoading } = useSingleTenantData({
+        id: tenantId,
+        enabled: shouldFetchTenantAdmin,
+    });
+
+    const { mutate } = useTenantAdminDataMutation({
+        id: tenantId,
+        seedTenantAdminData,
+        prefetchTenantAdminData: !seedTenantAdminData,
+    });
+
+    return {
+        data: (tenantAdminData ?? seedTenantAdminData) as TenantAdminData | undefined,
+        isLoading: seedTenantAdminData ? isTenantLoading : isAdminLoading,
+        mutate,
+    };
+};


### PR DESCRIPTION
Appearance cards were prefetching GET /service/tenantadmin/{id} on load, which still 500s for some tenants on pre-dev. Seed form data from the healthy /service/tenant payload for the current tenant and skip the broken prefetch while keeping PUT saves intact.

# Pull Request

**Click the `Preview` tab and select a PR template:**

- [Default / Generic](?expand=1&template=default.md)
- [Frontend](?expand=1&template=frontend.md)
- [Backend](?expand=1&template=backend.md)
- [Documentation](?expand=1&template=docs.md)
- [Bug Fix](?expand=1&template=bugfix.md)
- [DevOps / Infrastructure](?expand=1&template=devops.md)
- [Architecture / Refactor](?expand=1&template=architecture.md)
- [Hotfix](?expand=1&template=hotfix.md)

---

**⚠️ Please select a template above by clicking on one of the links.**

