### PR TITLE
fix(admin): stop tenantadmin GET 500 on theme-settings/legal

### DIFF
--- a/src/components/Tenants/LegalSettings/components/LegalText/LegalText.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalText/LegalText.test.tsx
@@ -14,17 +14,16 @@ const mocks = vi.hoisted(() => ({
     canEdit: true,
 }));
 
-vi.mock('../../../../../hooks/useSingleTenantData', () => ({
-    useSingleTenantData: () => ({
-        data: { content: { imprint: { de: '<p>Impressum DE</p>', en: '<p>Imprint EN</p>' } } },
+vi.mock('../../../../../hooks/useTenantAppearanceFormData', () => ({
+    useTenantAppearanceFormData: () => ({
+        data: {
+            content: { imprint: { de: '<p>Impressum DE</p>', en: '<p>Imprint EN</p>' } },
+            settings: { activeLanguages: ['de', 'en'] },
+        },
         isLoading: false,
+        mutate: mocks.updateTenant,
+        isPending: false,
     }),
-}));
-vi.mock('../../../../../hooks/useTenantAdminData.hook', () => ({
-    useTenantAdminData: () => ({ data: { settings: { activeLanguages: ['de', 'en'] } } }),
-}));
-vi.mock('../../../../../hooks/useTenantAdminDataMutation.hook', () => ({
-    useTenantAdminDataMutation: () => ({ mutate: mocks.updateTenant, isPending: false }),
 }));
 vi.mock('../../../../../hooks/useUserPermission', () => ({
     useUserPermissions: () => ({ can: () => mocks.canEdit }),

--- a/src/components/Tenants/LegalSettings/components/LegalText/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalText/index.tsx
@@ -5,9 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Modal, ModalProps } from '../../../../Modal';
 import { M3RichTextEditor } from '../../../../FormPluginEditor/M3RichTextEditor';
 import FormPluginEditor from '../../../../FormPluginEditor/FormPluginEditor';
-import { useSingleTenantData } from '../../../../../hooks/useSingleTenantData';
-import { useTenantAdminData } from '../../../../../hooks/useTenantAdminData.hook';
-import { useTenantAdminDataMutation } from '../../../../../hooks/useTenantAdminDataMutation.hook';
+import { useTenantAppearanceFormData } from '../../../../../hooks/useTenantAppearanceFormData';
 import styles from './styles.module.scss';
 import { PermissionAction } from '../../../../../enums/PermissionAction';
 import { Resource } from '../../../../../enums/Resource';
@@ -45,27 +43,22 @@ export const LegalText = ({
     const [form] = Form.useForm();
     const { can } = useUserPermissions();
     const canEditLegalText = can(PermissionAction.Update, Resource.LegalText);
-    const { data, isLoading } = useSingleTenantData({ id: tenantId });
-    const { data: tenantData } = useTenantAdminData();
-    const { mutate: updateTenant, isPending } = useTenantAdminDataMutation({ id: tenantId });
+    const { data, isLoading, mutate: updateTenant, isPending } = useTenantAppearanceFormData(`${tenantId}`);
     const [activeLanguage, setActiveLanguage] = useState('de');
     const [formDataContent, setFormData] = useState<Record<string, unknown>>();
     const [modalVisible, setModalVisible] = useState(false);
 
-    const languages = useMemo(
-        () => tenantData?.settings?.activeLanguages || ['de'],
-        [tenantData?.settings?.activeLanguages],
-    );
+    const languages = useMemo(() => data?.settings?.activeLanguages || ['de'], [data?.settings?.activeLanguages]);
 
     const onConfirm = useCallback(() => {
         updateTenant(set(formDataContent, showConfirmationModal.field, false));
         setModalVisible(false);
-    }, [formDataContent]);
+    }, [formDataContent, showConfirmationModal, updateTenant]);
 
     const onCancel = useCallback(() => {
         updateTenant(set(formDataContent, showConfirmationModal.field, true));
         setModalVisible(false);
-    }, [formDataContent]);
+    }, [formDataContent, showConfirmationModal, updateTenant]);
 
     const onFinish = useCallback(
         (formData: Record<string, unknown>) => {

--- a/src/hooks/useTenantAdminData.hook.test.tsx
+++ b/src/hooks/useTenantAdminData.hook.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TenantData } from '../types/tenant';
+
+vi.mock('../api/fetchData', () => ({
+    FETCH_METHODS: { GET: 'GET' },
+    fetchData: vi.fn(),
+}));
+
+vi.mock('../appConfig', () => ({
+    tenantAdminEndpoint: '/service/tenantadmin',
+}));
+
+vi.mock('./useTenantData.hook', () => ({
+    TENANT_DATA_KEY: 'tenant-data',
+    useTenantData: vi.fn(),
+}));
+
+import { fetchData } from '../api/fetchData';
+import { useTenantData } from './useTenantData.hook';
+import { useTenantAdminData } from './useTenantAdminData.hook';
+
+const fetchDataMock = vi.mocked(fetchData);
+const useTenantDataMock = vi.mocked(useTenantData);
+
+const currentTenant = {
+    id: 1,
+    name: 'Current tenant',
+    isSuperAdmin: true,
+    userRoles: [],
+    settings: { activeLanguages: ['de', 'en'] },
+    theming: {
+        logo: 'logo.svg',
+        favicon: 'favicon.ico',
+        primaryColor: '#112233',
+        secondaryColor: null,
+    },
+    content: {
+        impressum: '<p>Impressum</p>',
+        privacy: '<p>Privacy</p>',
+        termsAndConditions: null,
+        claim: 'Claim',
+    },
+} as TenantData;
+
+const createWrapper = () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+};
+
+beforeEach(() => {
+    fetchDataMock.mockReset();
+    useTenantDataMock.mockReset();
+    useTenantDataMock.mockReturnValue({
+        data: currentTenant,
+        isLoading: false,
+    } as never);
+});
+
+describe('useTenantAdminData', () => {
+    it('does not call GET /service/tenantadmin when /service/tenant already provides tenant data', async () => {
+        const { result } = renderHook(() => useTenantAdminData(), { wrapper: createWrapper() });
+
+        await waitFor(() => expect(result.current.data?.id).toBe(1));
+
+        expect(fetchDataMock).not.toHaveBeenCalled();
+        expect(result.current.data?.settings?.activeLanguages).toEqual(['de', 'en']);
+        expect(result.current.data?.content?.impressum?.de).toBe('<p>Impressum</p>');
+    });
+
+    it('does not fetch when tenant id is still unknown', async () => {
+        useTenantDataMock.mockReturnValue({ data: undefined, isLoading: true } as never);
+
+        renderHook(() => useTenantAdminData(), { wrapper: createWrapper() });
+
+        await waitFor(() => expect(fetchDataMock).not.toHaveBeenCalled(), { timeout: 100 });
+    });
+});

--- a/src/hooks/useTenantAdminData.hook.tsx
+++ b/src/hooks/useTenantAdminData.hook.tsx
@@ -1,15 +1,27 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchData, FETCH_METHODS } from '../api/fetchData';
 import { tenantAdminEndpoint } from '../appConfig';
 import { TenantAdminData } from '../types/TenantAdminData';
+import { mapTenantDataToTenantAdminData } from '../utils/mapTenantDataToTenantAdminData';
 import { useTenantData } from './useTenantData.hook';
 
 export const TENANT_ADMIN_DATA_KEY = 'tenant-admin-data';
-export const useTenantAdminData = () => {
-    const { data } = useTenantData();
-    const tenantId = data?.id;
 
-    return useQuery<TenantAdminData>({
+/**
+ * Prefer healthy GET /service/tenant for the signed-in tenant.
+ * GET /service/tenantadmin/{id} still 500s for some tenants on pre-dev; Legal and
+ * other settings surfaces only need tenant-scoped fields already available on /tenant.
+ */
+export const useTenantAdminData = () => {
+    const { data: tenantData, isLoading: isTenantLoading } = useTenantData();
+    const tenantId = tenantData?.id;
+    const seedTenantAdminData = useMemo(
+        () => (tenantData?.id != null ? mapTenantDataToTenantAdminData(tenantData) : undefined),
+        [tenantData],
+    );
+
+    const query = useQuery<TenantAdminData>({
         queryKey: [TENANT_ADMIN_DATA_KEY, tenantId],
         queryFn: async () =>
             fetchData({
@@ -18,7 +30,14 @@ export const useTenantAdminData = () => {
                 skipAuth: false,
                 responseHandling: [],
             }),
-        enabled: tenantId != null,
+        // Skip the broken tenantadmin GET whenever /service/tenant already seeded the payload.
+        enabled: tenantId != null && !seedTenantAdminData,
         staleTime: 60 * 1000,
     });
+
+    return {
+        ...query,
+        data: seedTenantAdminData ?? query.data,
+        isLoading: seedTenantAdminData ? isTenantLoading : query.isLoading,
+    };
 };

--- a/src/hooks/useTenantAppearanceFormData.ts
+++ b/src/hooks/useTenantAppearanceFormData.ts
@@ -32,7 +32,7 @@ export const useTenantAppearanceFormData = (tenantId: string) => {
         enabled: shouldFetchTenantAdmin,
     });
 
-    const { mutate } = useTenantAdminDataMutation({
+    const { mutate, isPending } = useTenantAdminDataMutation({
         id: tenantId,
         seedTenantAdminData,
         prefetchTenantAdminData: !seedTenantAdminData,
@@ -42,5 +42,6 @@ export const useTenantAppearanceFormData = (tenantId: string) => {
         data: (tenantAdminData ?? seedTenantAdminData) as TenantAdminData | undefined,
         isLoading: seedTenantAdminData ? isTenantLoading : isAdminLoading,
         mutate,
+        isPending,
     };
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`/admin/theme-settings/legal` still called `GET /service/tenantadmin/{id}` on load (via `LegalText` and `useTenantAdminData`). That endpoint 500s for some tenants on pre-dev — same backend issue previously worked around for general settings (#322) and global-config (#299).

## Fix
- Seed `useTenantAdminData` from healthy `GET /service/tenant` and skip the broken tenantadmin GET (covers DPA language lists and other callers).
- Wire `LegalText` through `useTenantAppearanceFormData` so imprint/privacy load and save without prefetching tenantadmin.
- Extend that hook to expose `isPending` for the M3 publish state.

## Test plan
- [x] Unit tests for seeded `useTenantAdminData` (no GET)
- [x] Existing `LegalText` tests updated/passing
- [ ] On pre-dev, open `/admin/theme-settings/legal` — no 500 on `GET /service/tenantadmin/1`
- [ ] Imprint/privacy editors load; publish still uses `PUT /service/tenantadmin/{id}`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83f0457f-f626-485a-9cee-97e6edf0481f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83f0457f-f626-485a-9cee-97e6edf0481f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

