### PR TITLE
ci: format admin release workflow

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,123 +1,122 @@
 name: Release Admin Images
 
 on:
-  push:
-    branches:
-      - "release/admin-*"
+    push:
+        branches:
+            - 'release/admin-*'
 
 env:
-  REGISTRY: ghcr.io
-  ORG: openresilienceinitiative
-  APP_IMAGE_NAME: oriso-admin
-  STORYBOOK_IMAGE_NAME: oriso-admin-storybook
-  RELEASE_PREFIX: release/admin-
+    REGISTRY: ghcr.io
+    ORG: openresilienceinitiative
+    APP_IMAGE_NAME: oriso-admin
+    STORYBOOK_IMAGE_NAME: oriso-admin-storybook
+    RELEASE_PREFIX: release/admin-
 
 permissions:
-  contents: write
-  packages: write
+    contents: write
+    packages: write
 
 jobs:
-  release:
-    name: validate, tag and publish release images
-    if: ${{ github.event.deleted == false }}
-    runs-on: ubuntu-latest
+    release:
+        name: validate, tag and publish release images
+        if: ${{ github.event.deleted == false }}
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout release branch
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+        steps:
+            - name: Checkout release branch
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
 
-      - name: Validate release branch
-        shell: bash
-        run: |
-          set -euo pipefail
+            - name: Validate release branch
+              shell: bash
+              run: |
+                  set -euo pipefail
 
-          BRANCH="${GITHUB_REF_NAME}"
-          VERSION="${BRANCH#${RELEASE_PREFIX}}"
+                  BRANCH="${GITHUB_REF_NAME}"
+                  VERSION="${BRANCH#${RELEASE_PREFIX}}"
 
-          if [[ "${BRANCH}" == "${VERSION}" ]]; then
-            echo "::error::Release branch must match ${RELEASE_PREFIX}<version>, for example ${RELEASE_PREFIX}2.0.1"
-            exit 1
-          fi
+                  if [[ "${BRANCH}" == "${VERSION}" ]]; then
+                    echo "::error::Release branch must match ${RELEASE_PREFIX}<version>, for example ${RELEASE_PREFIX}2.0.1"
+                    exit 1
+                  fi
 
-          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Release version must be semantic version format, for example 2.0.1"
-            exit 1
-          fi
+                  if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "::error::Release version must be semantic version format, for example 2.0.1"
+                    exit 1
+                  fi
 
-          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
-            echo "::error::Tag v${VERSION} already exists. Choose a new version."
-            exit 1
-          fi
+                  if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+                    echo "::error::Tag v${VERSION} already exists. Choose a new version."
+                    exit 1
+                  fi
 
-          echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
-          echo "APP_IMAGE=${REGISTRY}/${ORG}/${APP_IMAGE_NAME}:${VERSION}" >> "${GITHUB_ENV}"
-          echo "STORYBOOK_IMAGE=${REGISTRY}/${ORG}/${STORYBOOK_IMAGE_NAME}:${VERSION}" >> "${GITHUB_ENV}"
+                  echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
+                  echo "APP_IMAGE=${REGISTRY}/${ORG}/${APP_IMAGE_NAME}:${VERSION}" >> "${GITHUB_ENV}"
+                  echo "STORYBOOK_IMAGE=${REGISTRY}/${ORG}/${STORYBOOK_IMAGE_NAME}:${VERSION}" >> "${GITHUB_ENV}"
 
-      - name: Build admin application
-        uses: ./.github/actions/node-build
-        with:
-          node_version: "22.12.0"
+            - name: Build admin application
+              uses: ./.github/actions/node-build
+              with:
+                  node_version: '22.12.0'
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v4
 
-      - name: Login to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Login to GHCR
+              uses: docker/login-action@v4
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push admin image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          tags: ${{ env.APP_IMAGE }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ env.VERSION }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            - name: Build and push admin image
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: Dockerfile
+                  push: true
+                  tags: ${{ env.APP_IMAGE }}
+                  labels: |
+                      org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+                      org.opencontainers.image.revision=${{ github.sha }}
+                      org.opencontainers.image.version=${{ env.VERSION }}
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
 
-      - name: Build and push admin Storybook image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Dockerfile.storybook
-          push: true
-          tags: ${{ env.STORYBOOK_IMAGE }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ env.VERSION }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            - name: Build and push admin Storybook image
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: Dockerfile.storybook
+                  push: true
+                  tags: ${{ env.STORYBOOK_IMAGE }}
+                  labels: |
+                      org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+                      org.opencontainers.image.revision=${{ github.sha }}
+                      org.opencontainers.image.version=${{ env.VERSION }}
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
 
-      - name: Create and push release tag
-        shell: bash
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${VERSION}" -m "Release Admin v${VERSION}"
-          git push origin "v${VERSION}"
+            - name: Create and push release tag
+              shell: bash
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git tag -a "v${VERSION}" -m "Release Admin v${VERSION}"
+                  git push origin "v${VERSION}"
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ env.VERSION }}
-          target_commitish: ${{ github.sha }}
-          name: Admin v${{ env.VERSION }}
-          generate_release_notes: true
-          body: |
-            Docker images:
-            `${{ env.APP_IMAGE }}`
-            `${{ env.STORYBOOK_IMAGE }}`
+            - name: Create GitHub Release
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: v${{ env.VERSION }}
+                  target_commitish: ${{ github.sha }}
+                  name: Admin v${{ env.VERSION }}
+                  generate_release_notes: true
+                  body: |
+                      Docker images:
+                      `${{ env.APP_IMAGE }}`
+                      `${{ env.STORYBOOK_IMAGE }}`
 
-            Source branch:
-            `${{ github.ref_name }}`
-
+                      Source branch:
+                      `${{ github.ref_name }}`


### PR DESCRIPTION
Formats the Admin release workflow with the repository Prettier configuration.\n\nThis is required because the release workflow runs the normal Admin node-build action, which checks formatting for the whole repo before publishing images.\n\nValidation:\n- npx prettier .github/workflows/release-image.yml --check\n- Ruby YAML parse check