### PR TITLE
fix(agency-list): send CREATE_DATE and POST_CODE sort field enum names

### DIFF
--- a/src/pages/Agency/List/agencySort.test.ts
+++ b/src/pages/Agency/List/agencySort.test.ts
@@ -7,9 +7,9 @@ describe('AGENCY_SORT_FIELD_BY_DATA_INDEX', () => {
     it('maps every sortable column to its API sort field', () => {
         expect(AGENCY_SORT_FIELD_BY_DATA_INDEX).toEqual({
             id: 'ID',
-            createDate: 'CREATEDATE',
+            createDate: 'CREATE_DATE',
             name: 'NAME',
-            postcode: 'POSTCODE',
+            postcode: 'POST_CODE',
             city: 'CITY',
             offline: 'OFFLINE',
         });
@@ -28,7 +28,7 @@ describe('getNextAgencyTableState', () => {
             { current: 2, pageSize: 20 },
             { field: 'createDate', order: 'descend' },
         );
-        expect(next).toMatchObject({ current: 2, pageSize: 20, sortBy: 'CREATEDATE', order: 'DESC' });
+        expect(next).toMatchObject({ current: 2, pageSize: 20, sortBy: 'CREATE_DATE', order: 'DESC' });
     });
 
     it('sends server sort for the offline column', () => {
@@ -38,6 +38,15 @@ describe('getNextAgencyTableState', () => {
             { field: 'offline', order: 'ascend' },
         );
         expect(next).toMatchObject({ sortBy: 'OFFLINE', order: 'ASC' });
+    });
+
+    it('sends server sort for the postcode column', () => {
+        const next = getNextAgencyTableState(
+            baseState,
+            { current: 1, pageSize: 10 },
+            { field: 'postcode', order: 'ascend' },
+        );
+        expect(next).toMatchObject({ sortBy: 'POST_CODE', order: 'ASC' });
     });
 
     it('resets to unsorted when the sorter is cleared (third click)', () => {
@@ -68,7 +77,7 @@ describe('getNextAgencyTableState', () => {
 
 describe('getAgencyColumnSortOrder', () => {
     it('returns the arrow direction for the column matching the server sort', () => {
-        const state: TableState = { ...baseState, sortBy: 'CREATEDATE', order: 'DESC' };
+        const state: TableState = { ...baseState, sortBy: 'CREATE_DATE', order: 'DESC' };
         expect(getAgencyColumnSortOrder('createDate', state)).toBe('descend');
         expect(getAgencyColumnSortOrder('id', state)).toBeUndefined();
     });

--- a/src/pages/Agency/List/agencySort.ts
+++ b/src/pages/Agency/List/agencySort.ts
@@ -2,9 +2,9 @@ import { TablePaginationConfig } from 'antd';
 
 export const AGENCY_SORT_FIELD_BY_DATA_INDEX: Record<string, string> = {
     id: 'ID',
-    createDate: 'CREATEDATE',
+    createDate: 'CREATE_DATE',
     name: 'NAME',
-    postcode: 'POSTCODE',
+    postcode: 'POST_CODE',
     city: 'CITY',
     offline: 'OFFLINE',
 };


### PR DESCRIPTION
#### [Issue #319](https://github.com/OpenResilienceInitiative/ORISO-Admin/issues/319)

## Problem

PR #308 switched the agency list to server-side sorting, but `createDate` and `postcode` were mapped to `CREATEDATE` and `POSTCODE`. AgencyService binds the `field` query param via Spring enum constant names (`Enum.valueOf`), so camelCase OpenAPI values like `createDate` map to `CREATE_DATE` and `postCode` to `POST_CODE`. Sending `CREATEDATE`/`POSTCODE` returns 400 and sorting by "Erstellt am" or postcode still fails (Refs #319).

## Changes

- Map `createDate` → `CREATE_DATE` and `postcode` → `POST_CODE` in `agencySort.ts`
- Update `agencySort.test.ts` expectations and add a postcode sort test

## Verification

- `npm run test -- src/pages/Agency/List/agencySort.test.ts` — 11/11 green


#### Problem
<img width="1787" height="547" alt="Screenshot 2026-07-16 144341" src="https://github.com/user-attachments/assets/93a535bb-609f-45fc-ba15-b07e7a650f52" />
<img width="1773" height="600" alt="Screenshot 2026-07-16 144405" src="https://github.com/user-attachments/assets/6fd15f1a-7f2a-4295-9439-ad0b44cb0b43" />

<img width="1638" height="926" alt="Screenshot 2026-07-16 150547" src="https://github.com/user-attachments/assets/31432727-e7a5-461a-9c3a-fb46e8f1f427" />

#### Solution

<img width="1790" height="715" alt="Screenshot 2026-07-16 144350" src="https://github.com/user-attachments/assets/5131f710-e061-4eb9-bc42-e0cae3e122f9" />
<img width="1778" height="781" alt="Screenshot 2026-07-16 144415" src="https://github.com/user-attachments/assets/f3b3007b-fe48-4f83-a5be-2568bb907302" />

#### Create Date Sort
<img width="1500" height="935" alt="Screenshot 2026-07-16 150931" src="https://github.com/user-attachments/assets/48439f1a-5144-4d81-8404-2ba6b6dd9bd6" />

<img width="1496" height="925" alt="image" src="https://github.com/user-attachments/assets/0e098b33-17ae-4355-b7d7-877b772299aa" />

#### Postal Code Sort
<img width="1492" height="928" alt="image" src="https://github.com/user-attachments/assets/fc8bc1c7-4cd1-41bb-999b-7cc6b3925c64" />
<img width="1483" height="927" alt="image" src="https://github.com/user-attachments/assets/3bff644c-9ed1-468c-acb5-5d146503e48d" />
