### PR TITLE
fix(test): polyfill Web Storage so jsdom localStorage tests pass

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -17,6 +17,49 @@ if (typeof window !== 'undefined') {
         })),
     });
 
+    // jsdom (v23) does not implement Web Storage, so `window.localStorage` /
+    // `sessionStorage` are undefined. Provide a minimal in-memory Storage so tests
+    // can read/write/clear without each hand-rolling its own stub. Defined as
+    // configurable + writable so tests that need a spy can still override it
+    // (`vi.stubGlobal('localStorage', …)` or `Object.defineProperty`).
+    class MemoryStorage implements Storage {
+        private store = new Map<string, string>();
+
+        get length(): number {
+            return this.store.size;
+        }
+
+        clear(): void {
+            this.store.clear();
+        }
+
+        getItem(key: string): string | null {
+            return this.store.has(key) ? (this.store.get(key) as string) : null;
+        }
+
+        key(index: number): string | null {
+            return Array.from(this.store.keys())[index] ?? null;
+        }
+
+        removeItem(key: string): void {
+            this.store.delete(key);
+        }
+
+        setItem(key: string, value: string): void {
+            this.store.set(key, String(value));
+        }
+    }
+
+    (['localStorage', 'sessionStorage'] as const).forEach((name) => {
+        if (!window[name]) {
+            Object.defineProperty(window, name, {
+                configurable: true,
+                writable: true,
+                value: new MemoryStorage(),
+            });
+        }
+    });
+
     // antd/rc-util call getComputedStyle with a pseudo-element to measure scrollbars.
     const originalGetComputedStyle = window.getComputedStyle.bind(window);
     window.getComputedStyle = ((element: Element, pseudoElt?: string | null) => {


### PR DESCRIPTION
## Problem
All 6 tests in `src/pages/Statistic.test.tsx` fail on clean `pre-dev` with `TypeError: Cannot read properties of undefined (reading 'clear')` at `window.localStorage.clear()`. Root cause: **jsdom 23 does not implement Web Storage**, so `window.localStorage`/`sessionStorage` are `undefined` in the test environment (confirmed: a probe test logs `typeof window.localStorage === 'undefined'` even with a valid `http://localhost:3000/` origin). The file was added in #295 already calling `localStorage.clear()`, so it never passed here. Two other tests already worked around this by hand-rolling their own stub.

## What changed
- Add a minimal in-memory `Storage` polyfill for `localStorage` + `sessionStorage` to the shared `src/test/setup.ts` — the same "jsdom doesn't implement X → polyfill" pattern already used there for `matchMedia`/`getComputedStyle`.
- Defined `configurable` + `writable` so tests that need a spy can still override it (`vi.stubGlobal` / `Object.defineProperty`).

## Verification
- `npx vitest run src/pages/Statistic.test.tsx` → 6 passed.
- `language.test.ts` + `accessSessionLocalStorage.test.ts` (both override localStorage) → still pass.
- `npm run test` → **635 passed** (was 629 + these 6). `eslint`/`prettier`/`build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)