### PR TITLE
docs(agent): route Admin integration through pre-dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Context First
 
--   Treat `dev` as the normal integration branch for ORISO Admin feature PRs unless the task says otherwise.
+-   Treat `pre-dev` as the normal integration branch for ORISO Admin feature PRs. `dev` is the stable demo environment behind the human promotion gate.
 -   **Follow `GIT.md` for the full Git/GitHub workflow**: parent issue first (Why/What/Goal, assigned to the ORISO project board), PRs linked in the issue comments, branch pruning and board updates after merge.
 -   Before non-trivial changes, skim `.understand-anything/README.md`, `.understand-anything/ARCHITECTURE.md`, and `.understand-anything/knowledge-graph.json` for fast repo context.
 -   Keep admin behavior aligned with ORISO service contracts and role/permission boundaries.
@@ -26,7 +26,7 @@
 
 ## Review Expectations
 
--   Cursor should compare PRs against `origin/dev` for normal ORISO Admin feature work.
+-   Cursor should compare PRs against `origin/pre-dev` for normal ORISO Admin feature work.
 -   CodeRabbit is optional/manual and should not be treated as the primary automated reviewer.
 -   Automated review should flag missing tests, duplicated admin patterns, unsafe auth/API changes, and mergeability risks.
 -   Only auto-fix issues that are clearly scoped and testable. Leave architectural or ambiguous changes as review comments.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ This file is the **access gate** for AI-assisted work on this repo. Read it firs
 ## Where to look first
 
 1. `.understand-anything/README.md` → entry point to the generated knowledge graph (architecture, onboarding, findings, `knowledge-graph.json`).
-2. `.understand-anything/meta.json` → **check `gitCommitHash` against `origin/dev` before trusting the graph.** If it is more than a few dozen commits behind, treat the Markdown summaries as orientation only and verify against the code.
-3. `AGENTS.md` → working rules (branch = `dev`, validation commands, review expectations).
+2. `.understand-anything/meta.json` → **check `gitCommitHash` against `origin/pre-dev` before trusting the graph.** If it is more than a few dozen commits behind, treat the Markdown summaries as orientation only and verify against the code.
+3. `AGENTS.md` → working rules (integration branch = `pre-dev`, stable demo = `dev`, validation commands, review expectations).
 4. `GIT.md` → Git/GitHub workflow: issue-first PRs, ORISO project board, cross-repo issue anchoring, post-merge hygiene.
 5. `docs/` → feature-specific task docs.
 

--- a/GIT.md
+++ b/GIT.md
@@ -28,18 +28,25 @@ Many changes span repositories (admin UI + backend service + deployment). The pa
 
 ## 3. Branches
 
--   `dev` is the integration branch; `main` is release. Never commit to either directly.
--   Branch from current `origin/dev`: `feat/<topic>`, `fix/<topic>`, `chore/<topic>`, `docs/<topic>`.
--   Follow-up work after your PR merged: start a **fresh branch from `origin/dev`** — never stack commits on an already-merged branch.
+-   `pre-dev` is the integration branch; `dev` is the stable demo environment and human gate; `main` is release. Never commit directly to any of them.
+-   Branch from current `origin/pre-dev`: `feat/<topic>`, `fix/<topic>`, `chore/<topic>`, `docs/<topic>`.
+-   Follow-up work after your PR merged: start a **fresh branch from `origin/pre-dev`** — never stack commits on an already-merged branch.
+-   Force-push on `pre-dev` is allowed only when needed for integration testing before promotion review begins. Force-push is prohibited on `dev` and `main`; after promotion review starts it is also prohibited on `pre-dev`. On your own feature branch it is allowed only before review starts; after review starts, add normal commits.
 
 ## 4. Pull requests
 
--   Target `dev`. One concern per PR; link counterpart PRs in other repos.
+-   Target `pre-dev`. One concern per PR; link counterpart PRs in other repos.
 -   Description ≤ ~150 words: Problem (1–2 sentences) · Changes (3–6 bullets) · Verification (commands, one line each). No diff narration — AI reviewers re-read the body on every push, so keep it cheap.
 -   Reference the parent issue (see §2).
 -   Run the repo's validation gates before pushing (this repo: `npm run test`, `npx eslint . --max-warnings=0`, `npx prettier . --check`, `npm run build` — see `AGENTS.md`).
 
-## 5. After a PR is merged to `dev`
+## 5. Human promotion gate: `pre-dev` → `dev`
+
+Feature PRs integrate into `pre-dev`. Promotion to the stable `dev` demo environment requires successful automated checks, a current PreDev E2E artifact, no unresolved migration or rule conflict, a short understandable change summary, and explicit human approval. Do not force-push after review begins.
+
+Production promotion remains a separate gate after `dev`.
+
+## 6. After a PR is merged to `pre-dev`
 
 1. **Prune branches** — on your machine and any other environment you work from:
     ```bash


### PR DESCRIPTION
Problem: Admin repository guidance still routes feature PRs through dev.\n\nChanges:\n- make pre-dev the normal integration target\n- document the human pre-dev to dev promotion gate\n- align review and pruning guidance\n\nVerification:\n- documentation-only diff reviewed against current project rules\n\nCloses #358