### PR TITLE
feat(permissions): editable per-language case-handover notification templates

### DIFF
--- a/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/CaseHandoverCard.stories.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/CaseHandoverCard.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+// eslint-disable-next-line import/no-unresolved -- exports-map subpath the eslint node resolver can't see (resolves for tsc/Vite)
+import { expect, fn, userEvent, within } from 'storybook/test';
 import { CaseHandoverCardView } from './CaseHandoverCardView';
 import type { CaseHandoverReasonPolicy } from '../../../../../types/caseHandoverReasonPolicy';
 
@@ -38,6 +40,10 @@ const policies: CaseHandoverReasonPolicy[] = [
         enabled: true,
         displayOrder: 40,
         policyAuthority: 'platform-admin-default-case-handover-policy',
+        clientNotificationTemplates: {
+            de: 'Deine bisherige Berater:in ist leider erkrankt. Damit du nicht warten musst, hat {{newAdvisor}} deinen Fall übernommen.',
+            en: "Your previous counsellor is unfortunately ill. So you don't have to wait, {{newAdvisor}} has taken over your case.",
+        },
     },
     {
         code: 'COUNSELLOR_LEFT',
@@ -63,6 +69,7 @@ const meta = {
     args: {
         onModuleEnabledChange: () => undefined,
         onClientConsentChange: () => undefined,
+        onNotificationTemplateChange: () => undefined,
     },
     decorators: [
         (Story) => (
@@ -77,9 +84,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /** Platform admin editing the case-handover ("Fallübernahme") policy: master
- *  toggle + per-reason client-consent toggles are live; advisor consent,
- *  opt-out message, notification templates and footer actions are visible but
- *  disabled until their backend lands (disable, don't hide). */
+ *  toggle, per-reason client-consent toggles and the per-language notification
+ *  templates are live; advisor consent, opt-out message and footer actions
+ *  remain disabled until their backend lands (disable, don't hide). */
 export const Editable: Story = {
     args: {
         policies,
@@ -107,6 +114,28 @@ export const ModuleDisabled: Story = {
         isLoading: false,
         canEdit: true,
         moduleEnabled: false,
+    },
+};
+
+/** Per-reason, per-language template editing: stored backend value wins over the
+ *  sample copy; edits commit on blur via onNotificationTemplateChange. */
+export const TemplateEditing: Story = {
+    args: {
+        policies,
+        isLoading: false,
+        canEdit: true,
+        moduleEnabled: true,
+        onNotificationTemplateChange: fn(),
+    },
+    play: async ({ canvasElement, args }) => {
+        const canvas = within(canvasElement);
+        await userEvent.click(canvas.getByRole('tab', { name: /krank|ill/i }));
+        const input = canvas.getByTestId('case-handover-template-input') as HTMLTextAreaElement;
+        await expect(input.value).toContain('{{newAdvisor}}');
+        await userEvent.clear(input);
+        await userEvent.type(input, 'Neuer Text für die Übergabe.');
+        await userEvent.tab();
+        await expect(args.onNotificationTemplateChange).toHaveBeenCalled();
     },
 };
 

--- a/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/CaseHandoverCard.test.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/CaseHandoverCard.test.tsx
@@ -118,6 +118,24 @@ describe('CaseHandoverCard', () => {
         });
     });
 
+    it('persists an edited notification template on blur (PUT payload carries the language map)', async () => {
+        const user = userEvent.setup();
+        render(<CaseHandoverCard />);
+
+        await user.click(screen.getByRole('tab', { name: 'Counsellor is ill' }));
+        const input = screen.getByTestId('case-handover-template-input');
+        await user.clear(input);
+        await user.type(input, 'Eigener Uebergabetext.');
+        await user.tab();
+
+        await waitFor(() => {
+            expect(mocks.mutate).toHaveBeenCalled();
+        });
+        const payload = mocks.mutate.mock.calls.at(-1)?.[0];
+        const illPolicy = payload.find((policy: { code: string }) => policy.code === 'COUNSELLOR_IS_ILL');
+        expect(illPolicy.clientNotificationTemplates).toEqual({ de: 'Eigener Uebergabetext.' });
+    });
+
     it('shows the legal-violation placeholder tab with disabled consent controls and no persistence', async () => {
         const user = userEvent.setup();
         render(<CaseHandoverCard />);

--- a/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/CaseHandoverCardView.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/CaseHandoverCardView.tsx
@@ -8,7 +8,7 @@ import type { CaseHandoverReasonPolicy } from '../../../../../types/caseHandover
 import {
     buildDisplayReasons,
     DisplayReason,
-    getNotificationTemplateSample,
+    getNotificationTemplate,
     isAdvisorConsentImplicit,
     NOTIFICATION_LANGUAGES,
     NotificationLanguage,
@@ -33,6 +33,7 @@ export type CaseHandoverCardViewProps = {
     moduleEnabled: boolean;
     onModuleEnabledChange: (enabled: boolean) => void;
     onClientConsentChange: (code: string, clientConsentRequired: boolean) => void;
+    onNotificationTemplateChange: (code: string, language: NotificationLanguage, text: string) => void;
 };
 
 const ConfigureIcon = () => (
@@ -60,6 +61,7 @@ export const CaseHandoverCardView = ({
     moduleEnabled,
     onModuleEnabledChange,
     onClientConsentChange,
+    onNotificationTemplateChange,
 }: CaseHandoverCardViewProps) => {
     const { t, i18n } = useTranslation();
     const displayReasons = useMemo(() => buildDisplayReasons(policies), [policies]);
@@ -71,6 +73,8 @@ export const CaseHandoverCardView = ({
             ? (baseLanguage as NotificationLanguage)
             : 'de';
     });
+
+    const [templateDrafts, setTemplateDrafts] = useState<Record<string, string>>({});
 
     const activeReason: DisplayReason | null =
         displayReasons.find((reason) => reason.code === activeReasonCode) ?? displayReasons[0] ?? null;
@@ -244,16 +248,60 @@ export const CaseHandoverCardView = ({
                         })}
                     </div>
 
-                    <Tooltip title={comingSoon}>
-                        <div className={styles.notificationField} aria-disabled tabIndex={0}>
-                            <span className={styles.notificationFieldLabel}>
-                                {t('tenants.permissions.card.caseHandover.systemNotification')}
-                            </span>
-                            <p className={styles.notificationFieldText}>
-                                {activeReason ? getNotificationTemplateSample(activeReason.code, activeLanguage) : ''}
-                            </p>
-                        </div>
-                    </Tooltip>
+                    {activeReason &&
+                        (() => {
+                            const draftKey = `${activeReason.code}|${activeLanguage}`;
+                            const storedTemplate = getNotificationTemplate(
+                                activePolicy,
+                                activeReason.code,
+                                activeLanguage,
+                            );
+                            const value = templateDrafts[draftKey] ?? storedTemplate;
+                            const editable =
+                                canEdit && moduleEnabled && !activeReason.isPlaceholder && Boolean(activePolicy);
+                            const commitDraft = () => {
+                                const draft = templateDrafts[draftKey];
+                                if (draft === undefined || draft.trim() === storedTemplate.trim()) {
+                                    return;
+                                }
+                                onNotificationTemplateChange(activeReason.code, activeLanguage, draft);
+                                setTemplateDrafts((drafts) => {
+                                    const next = { ...drafts };
+                                    delete next[draftKey];
+                                    return next;
+                                });
+                            };
+                            const fieldLabel = `${t('tenants.permissions.card.caseHandover.systemNotification')} (${t(
+                                `tenants.permissions.card.caseHandover.language.${activeLanguage}`,
+                            )})`;
+                            return (
+                                <div className={styles.notificationField}>
+                                    <span className={styles.notificationFieldLabel}>
+                                        {t('tenants.permissions.card.caseHandover.systemNotification')}
+                                    </span>
+                                    <textarea
+                                        className={styles.notificationFieldInput}
+                                        value={value}
+                                        rows={3}
+                                        disabled={!editable}
+                                        aria-label={fieldLabel}
+                                        data-testid="case-handover-template-input"
+                                        onChange={(event) =>
+                                            setTemplateDrafts((drafts) => ({
+                                                ...drafts,
+                                                [draftKey]: event.target.value,
+                                            }))
+                                        }
+                                        onBlur={commitDraft}
+                                    />
+                                    <p className={styles.notificationFieldHint}>
+                                        {t('tenants.permissions.card.caseHandover.templateHint', {
+                                            newAdvisor: '{{newAdvisor}}',
+                                        })}
+                                    </p>
+                                </div>
+                            );
+                        })()}
 
                     <p className={styles.enforceHint}>{t('tenants.permissions.card.caseHandover.enforceHint')}</p>
 

--- a/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/caseHandoverCardUtils.test.ts
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/caseHandoverCardUtils.test.ts
@@ -10,6 +10,8 @@ import {
     NOTIFICATION_LANGUAGES,
     NOTIFICATION_TEMPLATE_SAMPLES,
     sortPoliciesByDisplayOrder,
+    applyNotificationTemplate,
+    getNotificationTemplate,
 } from './caseHandoverCardUtils';
 import type { CaseHandoverReasonPolicy } from '../../../../../types/caseHandoverReasonPolicy';
 
@@ -65,6 +67,31 @@ describe('caseHandoverCardUtils', () => {
     it('advisor consent is implicit only for advice requests', () => {
         expect(isAdvisorConsentImplicit('COUNSELLOR_ASKED_FOR_ADVICE')).toBe(true);
         expect(isAdvisorConsentImplicit('COUNSELLOR_IS_ILL')).toBe(false);
+    });
+
+    it('prefers the stored backend template over the sample', () => {
+        const stored = policy({
+            code: 'COUNSELLOR_IS_ILL',
+            clientNotificationTemplates: { de: 'Eigener Text mit {{newAdvisor}}.' },
+        });
+        expect(getNotificationTemplate(stored, 'COUNSELLOR_IS_ILL', 'de')).toEqual('Eigener Text mit {{newAdvisor}}.');
+        // missing language falls back to the sample copy
+        expect(getNotificationTemplate(stored, 'COUNSELLOR_IS_ILL', 'en')).toEqual(
+            getNotificationTemplateSample('COUNSELLOR_IS_ILL', 'en'),
+        );
+        expect(getNotificationTemplate(null, 'COUNSELLOR_IS_ILL', 'de')).toEqual(
+            getNotificationTemplateSample('COUNSELLOR_IS_ILL', 'de'),
+        );
+    });
+
+    it('writes, trims and clears per-language templates on the matching reason only', () => {
+        const policies = [policy({ code: 'A' }), policy({ code: 'B' })];
+        const written = applyNotificationTemplate(policies, 'A', 'de', '  Neuer Text  ');
+        expect(written[0].clientNotificationTemplates).toEqual({ de: 'Neuer Text' });
+        expect(written[1].clientNotificationTemplates).toBeUndefined();
+
+        const cleared = applyNotificationTemplate(written, 'A', 'de', '   ');
+        expect(cleared[0].clientNotificationTemplates).toBeNull();
     });
 
     it('provides a notification sample for every seeded reason in every language', () => {

--- a/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/caseHandoverCardUtils.ts
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/caseHandoverCardUtils.ts
@@ -107,3 +107,34 @@ export const NOTIFICATION_TEMPLATE_SAMPLES: Record<string, Partial<Record<Notifi
 
 export const getNotificationTemplateSample = (code: string, language: NotificationLanguage) =>
     NOTIFICATION_TEMPLATE_SAMPLES[code]?.[language] ?? '';
+
+/** Effective template: backend-stored value first, sample copy as fallback. */
+export const getNotificationTemplate = (
+    policy: CaseHandoverReasonPolicy | null,
+    code: string,
+    language: NotificationLanguage,
+) => policy?.clientNotificationTemplates?.[language] ?? getNotificationTemplateSample(code, language);
+
+/** Writes one language's template on the given reason; blank text clears the override. */
+export const applyNotificationTemplate = (
+    policies: CaseHandoverReasonPolicy[],
+    code: string,
+    language: NotificationLanguage,
+    text: string,
+) =>
+    policies.map((policy) => {
+        if (policy.code !== code) {
+            return policy;
+        }
+        const templates = { ...(policy.clientNotificationTemplates ?? {}) };
+        const trimmed = text.trim();
+        if (trimmed) {
+            templates[language] = trimmed;
+        } else {
+            delete templates[language];
+        }
+        return {
+            ...policy,
+            clientNotificationTemplates: Object.keys(templates).length ? templates : null,
+        };
+    });

--- a/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/index.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/index.tsx
@@ -9,7 +9,13 @@ import { useUserPermissions } from '../../../../../hooks/useUserPermission';
 import { useUserRoles } from '../../../../../hooks/useUserRoles.hook';
 import { canEditCaseHandoverReasonPolicies } from '../../../../../constants/caseHandoverAccess';
 import type { CaseHandoverReasonPolicy } from '../../../../../types/caseHandoverReasonPolicy';
-import { applyClientConsent, applyModuleEnabled, isHandoverModuleEnabled } from './caseHandoverCardUtils';
+import {
+    applyClientConsent,
+    applyModuleEnabled,
+    applyNotificationTemplate,
+    isHandoverModuleEnabled,
+    NotificationLanguage,
+} from './caseHandoverCardUtils';
 import { CaseHandoverCardView } from './CaseHandoverCardView';
 
 /** Container: wires the platform case-handover reason policies (UserService)
@@ -66,6 +72,12 @@ export const CaseHandoverCard = () => {
         [persist, policies],
     );
 
+    const handleNotificationTemplateChange = useCallback(
+        (code: string, language: NotificationLanguage, text: string) =>
+            persist(applyNotificationTemplate(policies, code, language, text)),
+        [persist, policies],
+    );
+
     if (isError) {
         return <Alert type="error" message={t('error.loading')} showIcon data-testid="case-handover-card-error" />;
     }
@@ -78,6 +90,7 @@ export const CaseHandoverCard = () => {
             moduleEnabled={moduleEnabled}
             onModuleEnabledChange={handleModuleEnabledChange}
             onClientConsentChange={handleClientConsentChange}
+            onNotificationTemplateChange={handleNotificationTemplateChange}
         />
     );
 };

--- a/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/styles.module.scss
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/CaseHandoverCard/styles.module.scss
@@ -161,6 +161,38 @@
     line-height: 16px;
 }
 
+.notificationFieldInput {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    resize: vertical;
+    color: var(--admin-form-field-text, var(--m3-on-surface, #1b1b1c));
+    font-family: inherit;
+    font-size: 15px;
+    letter-spacing: 0.3px;
+    line-height: 22px;
+    overflow-wrap: anywhere;
+
+    &:focus-visible {
+        outline: 2px solid var(--m3-primary, #a5000a);
+        outline-offset: 2px;
+    }
+
+    &:disabled {
+        color: var(--admin-form-muted-text, var(--m3-on-surface-variant, #444748));
+        cursor: not-allowed;
+    }
+}
+
+.notificationFieldHint {
+    margin: 6px 0 0;
+    color: var(--admin-form-muted-text, var(--m3-on-surface-variant, #444748));
+    font-size: 12px;
+    line-height: 16px;
+}
+
 .notificationFieldText {
     margin: 0;
     color: var(--admin-form-field-text, var(--m3-on-surface, #1b1b1c));

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -855,6 +855,7 @@
     "tenants.permissions.card.caseHandover.consentClient": "Zustimmung Ratsuchende*r",
     "tenants.permissions.card.caseHandover.consentAdvisor": "Zustimmung Berater*in",
     "tenants.permissions.card.caseHandover.systemNotification": "Systembenachrichtigung",
+    "tenants.permissions.card.caseHandover.templateHint": "Dieser Text wird der Klient:in bei einer Fallübergabe angezeigt. {{newAdvisor}} wird durch den Namen der neuen Berater:in ersetzt. Änderungen werden beim Verlassen des Feldes gespeichert.",
     "tenants.permissions.card.caseHandover.enforceHint": "Ausgewählte Optionen verhindern, dass niedrigere Rollen Funktionen ausblenden können.",
     "tenants.permissions.card.caseHandover.configure": "Konfigurieren",
     "tenants.permissions.card.caseHandover.enforce": "Aktivierte Auswahl erzwingen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1222,6 +1222,7 @@
     "tenants.permissions.card.caseHandover.consentClient": "Consent from advice seeker",
     "tenants.permissions.card.caseHandover.consentAdvisor": "Consent from advisor",
     "tenants.permissions.card.caseHandover.systemNotification": "System notification",
+    "tenants.permissions.card.caseHandover.templateHint": "This text is shown to the client when the case is handed over. {{newAdvisor}} is replaced with the new counsellor's name. Changes are saved when you leave the field.",
     "tenants.permissions.card.caseHandover.enforceHint": "Selected options prevent lower roles from hiding functions.",
     "tenants.permissions.card.caseHandover.configure": "Configure",
     "tenants.permissions.card.caseHandover.enforce": "Enforce activated selections",

--- a/src/types/caseHandoverReasonPolicy.ts
+++ b/src/types/caseHandoverReasonPolicy.ts
@@ -6,4 +6,6 @@ export interface CaseHandoverReasonPolicy {
     enabled: boolean;
     displayOrder: number;
     policyAuthority?: string | null;
+    /** Client-facing system-notification templates per language ({{newAdvisor}} placeholder). */
+    clientNotificationTemplates?: Partial<Record<'de' | 'en' | 'tr' | 'uk', string>> | null;
 }


### PR DESCRIPTION
## Problem

The Case takeover card showed the per-reason/per-language client notification only as a disabled "coming soon" preview with hard-coded sample copy — the Figma Section 06 design expects editable templates, and the backend now stores them (OpenResilienceInitiative/ORISO-UserService#465).

## What changed

- The notification field is an editable textarea per active reason × language chip (de/en/tr/uk); stored backend template wins over the sample copy.
- Edits commit on blur through the existing reason-policies PUT; blank input clears the language override. `{{newAdvisor}}` placeholder documented in a field hint.
- `CaseHandoverReasonPolicy` type gains `clientNotificationTemplates`; new `applyNotificationTemplate` / `getNotificationTemplate` utils.
- Editing disabled while read-only, module off, or on the legal-violation placeholder tab.
- i18n `templateHint` (en/de); `TemplateEditing` interaction story.

## Verification

- `npm run test` — 746/746 green (incl. new RTL blur-commit test asserting the PUT payload and utils tests).
- `npx eslint … --max-warnings=0`, `npx prettier --check` clean.
- Storybook story verified in the browser (edit → blur → callback fires).

Closes #360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
