### PR TITLE
fix(profile): responsive Col breakpoints for user profile cards

### DIFF
--- a/src/pages/Profile/UserProfile.tsx
+++ b/src/pages/Profile/UserProfile.tsx
@@ -17,7 +17,7 @@ export const UserProfile = () => {
             <Page.Title titleKey="profile.title" subTitleKey="profile.title.text" />
 
             <Row gutter={[24, 24]}>
-                <Col span={12} md={6}>
+                <Col xs={24} sm={24} md={12} lg={8} xl={6}>
                     {!hasRole(UserRole.TenantAdmin) && <PrivateData />}
                     <LanguageSettings />
                     <PasswordChange />
@@ -25,7 +25,7 @@ export const UserProfile = () => {
                 </Col>
 
                 {/* 2FA disabled - Keycloak extension not implemented */}
-                {/* <Col span={12} md={6}>
+                {/* <Col xs={24} sm={24} md={12} lg={8} xl={6}>
                     <Card titleKey="twoFactorAuth.title" subTitleKey="twoFactorAuth.subtitle">
                         <TwoFactorAuth />
                     </Card>


### PR DESCRIPTION
Extracted from the stale `fix/profile-cards-layout` branch (old #362).

Keeps **only** the responsive `Col` change on `UserProfile.tsx` (`xs/sm/md/lg/xl`), which is genuinely missing from `pre-dev`. The SCSS half of the original branch (`Card/styles.module.scss`) was **dropped** — it was built against a horizontal card-title layout that the centered-card redesign already merged to pre-dev replaced, so those rules are obsolete.

Fresh branch off current `pre-dev`; 2-line change. Supersedes #362.