### PR TITLE
test: make agency-create tenant-guard test deterministic

### DIFF
--- a/src/pages/Agency/Edit/index.test.tsx
+++ b/src/pages/Agency/Edit/index.test.tsx
@@ -204,12 +204,22 @@ describe('AgencyPageEdit create flow', () => {
     it('does not submit a new agency without a selected tenant', async () => {
         renderWithClient(<AgencyPageEdit />);
 
+        // Wait for the tenant assignment field before interacting — clicking
+        // Speichern earlier races the async tenant-options fetch and the
+        // required rule may not be registered yet when the form validates.
+        expect(await screen.findByText('Trägerzuordnung')).toBeInTheDocument();
+
         fireEvent.change(screen.getByLabelText('Name *'), { target: { value: 'Neue Beratungsstelle' } });
         fireEvent.change(screen.getByLabelText('PLZ *'), { target: { value: '86161' } });
         fireEvent.change(screen.getByLabelText('Stadt *'), { target: { value: 'Augsburg' } });
         fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
 
-        expect(await screen.findByText('Bitte füllen Sie das markierte Feld aus.')).toBeInTheDocument();
+        // Generous timeout: the error surfaces via antd async validation plus a
+        // notification render; the 1s findBy default is too tight on loaded CI
+        // runners (observed flake in run 29576826138).
+        expect(
+            await screen.findByText('Bitte füllen Sie das markierte Feld aus.', undefined, { timeout: 5000 }),
+        ).toBeInTheDocument();
         expect(mocks.mutate).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Problem

`AgencyPageEdit create flow > does not submit a new agency without a selected tenant` failed once in CI (run 29576826138, 2026-07-17) with a `findByText` timeout and passed on plain rerun (#371). The test interacts synchronously right after render while the form still resolves async layers (tenant options, antd validation, notification render) and then waits on testing-library's tight 1s default.

## Changes

- Await the "Trägerzuordnung" field before firing events — the click can no longer race the tenant field mount / required-rule registration.
- Explicit 5s timeout on the error-text `findByText` (assertions unchanged: error text shown, `mutate` not called).

## Verification

- 30 consecutive runs of the file green, incl. 4-lane parallel stress (`npx vitest run … --retry=0`).
- Full suite: 746/746 green; eslint + prettier clean.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)
