### PR TITLE
fix: sticky table pagination sits flush with the viewport bottom

### DIFF
--- a/src/components/ListingTable/styles.module.scss
+++ b/src/components/ListingTable/styles.module.scss
@@ -31,7 +31,12 @@
             z-index: 850;
             left: 0;
             right: 0;
-            bottom: 24px;
+            /* Flush with the viewport bottom: at 24px the table container kept
+               peeking through the gap below the sticky bar on tall pages
+               (owner report 2026-07-18, Logs page). The 24px breathing room
+               still applies once the page is scrolled to its end (wrapper
+               padding takes over when sticky releases). */
+            bottom: 0;
             display: flex;
             width: 100%;
             box-sizing: border-box;

--- a/src/components/ResizableTable/styles.module.scss
+++ b/src/components/ResizableTable/styles.module.scss
@@ -69,7 +69,12 @@
             z-index: 850;
             left: 0;
             right: 0;
-            bottom: 24px;
+            /* Flush with the viewport bottom: at 24px the table container kept
+               peeking through the gap below the sticky bar on tall pages
+               (owner report 2026-07-18, Logs page). The 24px breathing room
+               still applies once the page is scrolled to its end (wrapper
+               padding takes over when sticky releases). */
+            bottom: 0;
             display: flex;
             width: 100%;
             box-sizing: border-box;


### PR DESCRIPTION
## Problem
On tall pages the sticky pagination hovers 24px above the viewport bottom and the rounded table container peeks through the gap below it (Logs page, owner report).

## What changed
- ListingTable + ResizableTable: sticky pagination `bottom: 24px` → `bottom: 0`
- End-of-page spacing is unchanged — the wrapper's `padding-bottom: 24px` applies once sticky releases

## Verification
- Reproduced in Storybook (UserManagement story, 520px viewport, forced tall body): 602px container overhang visible below the bar before, gap 0 and nothing visible after
- Screenshot comparison in the story; pure CSS change, no JS/test impact

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated table pagination bars to sit flush with the bottom of the viewport when scrolling, eliminating the unnecessary gap on long pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->