### PR TITLE
feat: shared Modal renders the standard M3 basic dialog anatomy

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ReactComponent as ScheduleIcon } from '../../resources/img/svg/oriso/schedule_24px.svg';
 import { Modal } from './index';
 
+/**
+ * Standard M3 basic dialog (Design-System M3_ORISO, node 60942-12062):
+ * surface-container-high sheet, optional hero icon, centered headline-small
+ * title, body-medium text, divider and right-aligned M3 text buttons.
+ */
 const meta = {
     title: 'Organisms/Modal',
     component: Modal,
@@ -17,6 +23,31 @@ export const Confirmation: Story = {
         contentKey: 'subSlogan',
         okLabelKey: 'save',
         cancelLabelKey: 'cancel',
+        onConfirm: () => {},
+        onClose: () => {},
+    },
+};
+
+/** Full M3 anatomy: 32px hero icon above the centered title, divider, text buttons. */
+export const WithHeroIcon: Story = {
+    args: {
+        titleKey: 'slogan',
+        contentKey: 'subSlogan',
+        okLabelKey: 'save',
+        cancelLabelKey: 'cancel',
+        icon: <ScheduleIcon />,
+        onConfirm: () => {},
+        onClose: () => {},
+    },
+};
+
+/** Without divider (short informational dialogs). */
+export const WithoutDivider: Story = {
+    args: {
+        titleKey: 'slogan',
+        contentKey: 'subSlogan',
+        okLabelKey: 'save',
+        showDivider: false,
         onConfirm: () => {},
         onClose: () => {},
     },

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,6 +1,5 @@
 import { Modal as AntModal } from 'antd';
 import { useTranslation } from 'react-i18next';
-import Title from 'antd/lib/typography/Title';
 import { ReactNode } from 'react';
 import styles from './styles.module.scss';
 
@@ -14,10 +13,24 @@ export interface ModalProps {
     children?: ReactNode;
     onConfirm?: () => void;
     onClose?: () => void;
+    /** Custom footer content; replaces the standard text-button actions. */
     footer?: ReactNode;
     width?: number | string;
+    /** Optional 32px hero icon centered above the title (M3 basic dialog). */
+    icon?: ReactNode;
+    /** Full-width divider between content and actions. Defaults to true. */
+    showDivider?: boolean;
+    /** Disables the confirm text button (e.g. while submitting). */
+    confirmDisabled?: boolean;
 }
 
+/**
+ * Standard M3 basic dialog (Design-System M3_ORISO, node 60942-12062).
+ * Renders the house anatomy — hero icon, centered headline-small title,
+ * body-medium content, divider and right-aligned M3 text buttons — so every
+ * confirm/delete dialog across the admin looks identical. Pass `footer` only
+ * for genuinely custom action rows.
+ */
 export const Modal = ({
     titleKey,
     titleKeyOptions,
@@ -30,27 +43,63 @@ export const Modal = ({
     contentKeyOptions,
     footer,
     width,
+    icon,
+    showDivider = true,
+    confirmDisabled = false,
 }: ModalProps) => {
     const { t } = useTranslation();
+
+    const hasStandardActions = Boolean(cancelLabelKey || okLabelKey);
+
+    const standardActions = hasStandardActions ? (
+        <div className={styles.actions}>
+            {cancelLabelKey && (
+                <button type="button" className={styles.actionButton} onClick={onClose}>
+                    {t(cancelLabelKey)}
+                </button>
+            )}
+            {okLabelKey && (
+                <button type="button" className={styles.actionButton} disabled={confirmDisabled} onClick={onConfirm}>
+                    {t(okLabelKey)}
+                </button>
+            )}
+        </div>
+    ) : null;
+
+    const resolvedFooter = footer ?? standardActions;
 
     return (
         <AntModal
             className={styles.modal}
             styles={{
                 mask: { background: 'rgba(255, 255, 255, 0.8)', backdropFilter: 'blur(4px)' },
-                content: { borderRadius: 28 },
             }}
-            title={<Title level={2}>{titleKey ? t(titleKey, titleKeyOptions) : null}</Title>}
+            title={
+                titleKey ? (
+                    <div className={styles.titleBlock}>
+                        {icon && (
+                            <span className={styles.heroIcon} aria-hidden>
+                                {icon}
+                            </span>
+                        )}
+                        <div className={styles.title}>{t(titleKey, titleKeyOptions)}</div>
+                    </div>
+                ) : null
+            }
             open
             destroyOnClose
             centered
             maskClosable
             keyboard
             onCancel={onClose}
-            onOk={onConfirm}
-            cancelText={cancelLabelKey && t(cancelLabelKey)}
-            okText={okLabelKey && t(okLabelKey)}
-            footer={footer}
+            footer={
+                resolvedFooter ? (
+                    <>
+                        {showDivider && <div className={styles.divider} aria-hidden />}
+                        {resolvedFooter}
+                    </>
+                ) : null
+            }
             width={width}
             afterClose={() => {
                 document.querySelectorAll('.ant-modal-root:empty').forEach((root) => root.remove());

--- a/src/components/Modal/styles.module.scss
+++ b/src/components/Modal/styles.module.scss
@@ -1,47 +1,105 @@
-/* Shared M3 dialog shell. Applied to every delete/confirm dialog that renders
-   through the shared Modal component: rounded 28px surface, centered title and
-   flat M3 text buttons in the footer (brand blue by default, brand red for the
-   destructive/primary confirm action). */
+/* Standard M3 basic dialog (Design-System M3_ORISO, node 60942-12062):
+   surface-container-high sheet with 28px radius, optional 32px hero icon,
+   centered headline-small title (24/32 regular), body-medium supporting text
+   (14/20, +0.25 tracking), full-width divider, right-aligned M3 text buttons
+   (label-large, primary color). Every dialog rendered through the shared
+   Modal component inherits this anatomy. */
 .modal {
     :global {
         .ant-modal-content {
+            min-width: 280px;
+            padding: 0;
             border-radius: 28px;
+            background: var(--m3-surface-container-high, #eae7e8);
         }
 
-        .ant-modal-title {
-            text-align: center;
+        .ant-modal-header {
+            padding: 24px 24px 0;
+            margin: 0;
+            background: transparent;
+        }
+
+        .ant-modal-body {
+            padding: 16px 24px 0;
+            color: var(--m3-on-surface-variant, #444748);
+            font-size: 14px;
+            letter-spacing: 0.25px;
+            line-height: 20px;
         }
 
         .ant-modal-footer {
-            .ant-btn {
-                height: 40px;
-                padding: 0 12px;
-                border: none;
-                background: transparent;
-                box-shadow: none;
-                border-radius: 100px;
-                color: #273270;
-                font-size: 14px;
-                font-weight: 500;
-                letter-spacing: 0.1px;
-                text-transform: none;
-
-                &:not(:disabled):hover,
-                &:not(:disabled):focus {
-                    background: rgba(68, 71, 72, 0.08);
-                    color: #273270;
-                }
-            }
-
-            .ant-btn-primary,
-            .ant-btn-dangerous {
-                color: #a5000a;
-
-                &:not(:disabled):hover,
-                &:not(:disabled):focus {
-                    color: #a5000a;
-                }
-            }
+            padding: 0;
+            margin: 0;
         }
+    }
+}
+
+.titleBlock {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+}
+
+.heroIcon {
+    display: inline-flex;
+    color: var(--m3-secondary, #4c555f);
+
+    svg {
+        width: 32px;
+        height: 32px;
+    }
+}
+
+.title {
+    margin: 0;
+    color: var(--m3-on-surface, #1b1b1c);
+    font-size: 24px;
+    font-weight: 400;
+    letter-spacing: 0;
+    line-height: 32px;
+    text-align: center;
+}
+
+.divider {
+    height: 0;
+    margin-top: 16px;
+    border-top: 1px solid var(--m3-outline-variant, #c4c7c8);
+}
+
+.actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 20px 24px 20px 8px;
+}
+
+.actionButton {
+    height: 40px;
+    padding: 10px 16px;
+    border: 0;
+    border-radius: 100px;
+    background: transparent;
+    color: var(--m3-primary, #a5000a);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 500;
+    letter-spacing: 0.1px;
+    line-height: 20px;
+    transition: background-color 150ms ease;
+
+    &:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--m3-primary, #a5000a) 8%, transparent);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--m3-primary, #a5000a);
+        outline-offset: 2px;
+    }
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.38;
     }
 }

--- a/src/components/Modal/styles.module.scss
+++ b/src/components/Modal/styles.module.scss
@@ -28,6 +28,10 @@
         }
 
         .ant-modal-footer {
+            /* Stack divider above the action row (antd lays footer children inline). */
+            display: flex;
+            flex-direction: column;
+            align-items: stretch;
             padding: 0;
             margin: 0;
         }
@@ -62,6 +66,8 @@
 }
 
 .divider {
+    display: block;
+    width: 100%;
     height: 0;
     margin-top: 16px;
     border-top: 1px solid var(--m3-outline-variant, #c4c7c8);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2261,6 +2261,13 @@
     "@tmcp/session-manager" "^0.2.2"
     esm-env "^1.2.2"
 
+"@tybys/wasm-util@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz"
+  integrity sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@types/aria-query@^5.0.1":
   version "5.0.4"
   resolved "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz"
@@ -8629,6 +8636,11 @@ tslib@^2.0.1:
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@^2.0.3:
+  version "2.8.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+tslib@^2.4.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## Problem
Dialogs through the shared Modal deviated from the design-system standard dialog — oversized bold title, wrong surface, brand-blue cancel button, no hero icon/divider anatomy.

## What changed
- Modal renders the M3 basic dialog per [Figma 60942-12062](https://www.figma.com/design/RTUi1rcrEWECXz8rNFmj7Q/Design-System-M3_ORISO?node-id=60942-12062&m=dev): surface-container-high 28px sheet, optional 32px hero icon, centered headline-small title (24/32), body-medium content, full-width divider, right-aligned M3 text buttons in primary
- okLabelKey/cancelLabelKey now render as standard text buttons (new: `icon`, `showDivider`, `confirmDisabled` props); custom `footer` consumers unchanged
- Colors via M3 CSS vars only

## Verification
- `npx vitest run` consumer suites (Tenants, UserManagement, Links) — 14/14 pass
- tsc/eslint/prettier clean; Storybook stories (Confirmation, WithHeroIcon, WithoutDivider) visually verified against the Figma node

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)