### PR TITLE
feat(tour): Admin/M3 Joyride adapter and Storybook matrix (TOUR-02)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "react-device-detect": "^2.2.2",
         "react-dom": "^19.2.7",
         "react-i18next": "^11.15.4",
+        "react-joyride": "^3.2.0",
         "react-resizable": "^3.0.4",
         "react-router": "^7.18.1",
         "react-router-dom": "^7.18.1",
@@ -2948,6 +2949,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@figspec/components": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@figspec/components/-/components-2.1.0.tgz",
@@ -2967,6 +2984,83 @@
       },
       "peerDependencies": {
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz",
+      "integrity": "sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/hooks": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz",
+      "integrity": "sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.4.1"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19"
+      }
+    },
+    "node_modules/@gilbarbara/types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz",
+      "integrity": "sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.1.0"
+      }
+    },
+    "node_modules/@gilbarbara/types/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -11976,6 +12070,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz",
+      "integrity": "sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==",
+      "license": "MIT"
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -15907,11 +16007,43 @@
         }
       }
     },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/react-joyride": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-3.2.0.tgz",
+      "integrity": "sha512-UrA/XWdWElMLNnjZt2eWmPFmpHl1IZ2CeI9XhS+PuEVvfqHMD9U4tavCq1csDAGVoj0YEGfaCDmhZwgNc9yE2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/deepmerge": "^3.2.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@gilbarbara/deep-equal": "^0.4.1",
+        "@gilbarbara/hooks": "^0.11.0",
+        "@gilbarbara/types": "^0.2.2",
+        "is-lite": "^2.0.0",
+        "react-innertext": "^1.1.5",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19",
+        "react-dom": "16.8 - 19"
+      }
     },
     "node_modules/react-resizable": {
       "version": "3.2.0",
@@ -16784,6 +16916,12 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
+      "license": "MIT"
+    },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
@@ -16792,6 +16930,12 @@
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-device-detect": "^2.2.2",
     "react-dom": "^19.2.7",
     "react-i18next": "^11.15.4",
+    "react-joyride": "^3.2.0",
     "react-resizable": "^3.0.4",
     "react-router": "^7.18.1",
     "react-router-dom": "^7.18.1",

--- a/src/components/productTour/ProductTourAdapter.stories.tsx
+++ b/src/components/productTour/ProductTourAdapter.stories.tsx
@@ -1,0 +1,303 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect, useState } from 'react';
+import { ProductTourAdapter } from './ProductTourAdapter';
+import { ProductTourTooltip } from './ProductTourTooltip';
+import { adminDemoTour } from './tourDefinitions';
+import type { TourDefinition, TourEvent, TourPlacement, TourStep } from './types';
+
+const demoTour = (steps: TourStep[]): TourDefinition => ({
+    id: 'storybook-demo-tour',
+    version: 1,
+    surface: 'admin',
+    audiences: ['tenant_admin'],
+    titleKey: 'productTour.adminTour.title',
+    summaryKey: 'productTour.adminTour.summary',
+    steps,
+});
+
+const anchoredStep = (placement: TourPlacement): TourStep => ({
+    id: `demo-${placement}`,
+    target: 'storybook-demo-anchor',
+    placement,
+    titleKey: 'productTour.adminTour.navigation.title',
+    contentKey: 'productTour.adminTour.navigation.content',
+});
+
+const DemoAnchor = () => (
+    <div
+        data-tour-target="storybook-demo-anchor"
+        style={{
+            margin: '40vh auto',
+            width: 280,
+            padding: 16,
+            textAlign: 'center',
+            border: '1px dashed var(--m3-outline, #747878)',
+            borderRadius: 8,
+        }}
+    >
+        Demo target element
+    </div>
+);
+
+const EventLog = ({ events }: { events: { event: TourEvent; stepId?: string }[] }) => (
+    <section
+        aria-label="Tour event log"
+        style={{
+            position: 'fixed',
+            right: 8,
+            bottom: 8,
+            maxWidth: 320,
+            padding: 8,
+            fontSize: 12,
+            background: 'var(--m3-surface, #fff)',
+            border: '1px solid var(--m3-outline, #747878)',
+            borderRadius: 8,
+            zIndex: 100,
+        }}
+    >
+        <strong>Events</strong>
+        <ol style={{ margin: 4, paddingLeft: 18 }}>
+            {events.map((entry, i) => (
+                <li key={i}>
+                    {entry.event}
+                    {entry.stepId ? ` (${entry.stepId})` : ''}
+                </li>
+            ))}
+        </ol>
+    </section>
+);
+
+const TourPlayground = ({
+    tour,
+    paused = false,
+    targetTimeoutMs = 2500,
+    children,
+}: React.PropsWithChildren<{
+    tour: TourDefinition;
+    paused?: boolean;
+    targetTimeoutMs?: number;
+}>) => {
+    const [events, setEvents] = useState<{ event: TourEvent; stepId?: string }[]>([]);
+    return (
+        <div style={{ minHeight: '100vh' }}>
+            {children}
+            <EventLog events={events} />
+            <ProductTourAdapter
+                tour={tour}
+                active
+                paused={paused}
+                targetTimeoutMs={targetTimeoutMs}
+                tooltipComponent={ProductTourTooltip}
+                onEvent={(event, step) => setEvents((prev) => [...prev, { event, stepId: step?.id }])}
+                onTerminalStatus={() => {}}
+            />
+        </div>
+    );
+};
+
+const meta = {
+    title: 'Organisms/ProductTour',
+    component: ProductTourAdapter,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'fullscreen',
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/design/QfsgojtHQzBjbzU3Im9Cet/Admin.ORISO?node-id=899-26642',
+        },
+        docs: {
+            description: {
+                component:
+                    'Controlled React Joyride adapter for the ORISO product-tour contract in the admin console: bounded target waiting, domain events and the Admin/M3 tooltip. No production tour is enabled in this package — the protected-layout story is a review surface only.',
+            },
+        },
+        // The Joyride overlay intentionally dims the page, so contrast is
+        // only meaningful inside the tooltip surface itself.
+        a11y: {
+            config: {
+                rules: [
+                    {
+                        id: 'color-contrast',
+                        selector: '.productTourTooltip, .productTourTooltip *',
+                    },
+                ],
+            },
+        },
+    },
+} satisfies Meta<typeof ProductTourAdapter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CenteredIntroduction: Story = {
+    render: () => (
+        <TourPlayground
+            tour={demoTour([
+                {
+                    id: 'welcome',
+                    target: '',
+                    placement: 'center',
+                    titleKey: 'productTour.adminTour.welcome.title',
+                    contentKey: 'productTour.adminTour.welcome.content',
+                },
+            ])}
+        />
+    ),
+};
+
+export const PlacementTop: Story = {
+    render: () => (
+        <TourPlayground tour={demoTour([anchoredStep('top')])}>
+            <DemoAnchor />
+        </TourPlayground>
+    ),
+};
+
+export const PlacementBottom: Story = {
+    render: () => (
+        <TourPlayground tour={demoTour([anchoredStep('bottom')])}>
+            <DemoAnchor />
+        </TourPlayground>
+    ),
+};
+
+export const PlacementLeft: Story = {
+    render: () => (
+        <TourPlayground tour={demoTour([anchoredStep('left')])}>
+            <DemoAnchor />
+        </TourPlayground>
+    ),
+};
+
+export const PlacementRight: Story = {
+    render: () => (
+        <TourPlayground tour={demoTour([anchoredStep('right')])}>
+            <DemoAnchor />
+        </TourPlayground>
+    ),
+};
+
+export const MissingTarget: Story = {
+    render: () => (
+        <TourPlayground
+            targetTimeoutMs={800}
+            tour={demoTour([
+                {
+                    id: 'welcome',
+                    target: '',
+                    placement: 'center',
+                    titleKey: 'productTour.adminTour.welcome.title',
+                    contentKey: 'productTour.adminTour.welcome.content',
+                },
+                {
+                    id: 'ghost',
+                    target: 'does-not-exist',
+                    titleKey: 'productTour.adminTour.navigation.title',
+                    contentKey: 'productTour.adminTour.navigation.content',
+                },
+                anchoredStep('bottom'),
+            ])}
+        >
+            <DemoAnchor />
+        </TourPlayground>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: "Click next on the intro: the second step's target never appears, so after the bounded wait a target_missing event is logged and the tour continues safely on the third step.",
+            },
+        },
+    },
+};
+
+const LateAnchor = () => {
+    const [visible, setVisible] = useState(false);
+    useEffect(() => {
+        const timer = setTimeout(() => setVisible(true), 1500);
+        return () => clearTimeout(timer);
+    }, []);
+    return visible ? <DemoAnchor /> : null;
+};
+
+export const PendingNavigation: Story = {
+    render: function PendingNavigationStory() {
+        return (
+            <TourPlayground
+                tour={demoTour([
+                    {
+                        id: 'welcome',
+                        target: '',
+                        placement: 'center',
+                        titleKey: 'productTour.adminTour.welcome.title',
+                        contentKey: 'productTour.adminTour.welcome.content',
+                    },
+                    anchoredStep('bottom'),
+                ])}
+            >
+                <LateAnchor />
+            </TourPlayground>
+        );
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: "The second step's target mounts 1.5s late (simulating navigation): after next, the tour stays on the intro until the target is ready — the adapter never positions against a missing element.",
+            },
+        },
+    },
+};
+
+export const PausedByBlockingDialog: Story = {
+    render: () => (
+        <TourPlayground paused tour={demoTour([anchoredStep('bottom')])}>
+            <DemoAnchor />
+            <div
+                role="dialog"
+                aria-label="Blocking dialog placeholder"
+                style={{
+                    position: 'fixed',
+                    inset: '30% 25%',
+                    background: 'var(--m3-surface, #fff)',
+                    border: '2px solid var(--m3-primary, #a5000a)',
+                    borderRadius: 8,
+                    display: 'grid',
+                    placeItems: 'center',
+                    zIndex: 60,
+                }}
+            >
+                A higher-priority dialog pauses the tour.
+            </div>
+        </TourPlayground>
+    ),
+};
+
+export const ProtectedLayoutTour: Story = {
+    render: () => (
+        <TourPlayground tour={adminDemoTour} targetTimeoutMs={4000}>
+            <div style={{ display: 'flex', minHeight: '100vh' }}>
+                <nav
+                    data-tour-target="admin-navigation"
+                    aria-label="Admin navigation mock"
+                    style={{
+                        width: 220,
+                        padding: 16,
+                        borderRight: '1px solid var(--m3-outline, #747878)',
+                    }}
+                >
+                    <p>Mandanten</p>
+                    <p>Beratungsstellen</p>
+                    <p>Berater:innen</p>
+                    <p>Einstellungen</p>
+                </nav>
+                <main style={{ flex: 1, padding: 24 }}>Mock admin content area</main>
+            </div>
+        </TourPlayground>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Representative protected-layout tour (the adminDemoTour definition) against a mocked admin shell. Not enabled in production — adminTours stays empty in this package.',
+            },
+        },
+    },
+};

--- a/src/components/productTour/ProductTourAdapter.stories.tsx
+++ b/src/components/productTour/ProductTourAdapter.stories.tsx
@@ -124,6 +124,12 @@ const meta = {
             },
         },
     },
+    // Every story renders through TourPlayground; these args only satisfy the
+    // component's required props for Storybook's type-level args contract.
+    args: {
+        tour: adminDemoTour,
+        active: true,
+    },
 } satisfies Meta<typeof ProductTourAdapter>;
 
 export default meta;

--- a/src/components/productTour/ProductTourAdapter.test.tsx
+++ b/src/components/productTour/ProductTourAdapter.test.tsx
@@ -6,222 +6,210 @@ import { ProductTourAdapter } from './ProductTourAdapter';
 import type { TourDefinition, TourEvent } from './types';
 
 interface CapturedJoyrideProps {
-	run: boolean;
-	stepIndex: number;
-	steps: any[];
-	onEvent: (data: any) => void;
-	tooltipComponent?: any;
-	locale?: any;
-	disableScrolling?: boolean;
+    run: boolean;
+    stepIndex: number;
+    steps: any[];
+    onEvent: (data: any) => void;
+    tooltipComponent?: any;
+    locale?: any;
+    disableScrolling?: boolean;
 }
 
 let joyrideProps: CapturedJoyrideProps | null = null;
 
 vi.mock('react-joyride', async () => {
-	const actual: any = await vi.importActual('react-joyride');
-	return {
-		...actual,
-		Joyride: (props: any) => {
-			joyrideProps = props;
-			return null;
-		}
-	};
+    const actual: any = await vi.importActual('react-joyride');
+    return {
+        ...actual,
+        Joyride: (props: any) => {
+            joyrideProps = props;
+            return null;
+        },
+    };
 });
 
 const tour: TourDefinition = {
-	id: 'test-tour',
-	version: 1,
-	surface: 'frontend',
-	audiences: ['consultant'],
-	titleKey: 'tour.title',
-	summaryKey: 'tour.summary',
-	steps: [
-		{
-			id: 'intro',
-			target: '',
-			placement: 'center',
-			titleKey: 't0',
-			contentKey: 'c0'
-		},
-		{
-			id: 'second',
-			route: '/second',
-			target: 'second-target',
-			titleKey: 't1',
-			contentKey: 'c1'
-		},
-		{
-			id: 'third',
-			route: '/third',
-			target: 'third-target',
-			titleKey: 't2',
-			contentKey: 'c2'
-		}
-	]
+    id: 'test-tour',
+    version: 1,
+    surface: 'frontend',
+    audiences: ['consultant'],
+    titleKey: 'tour.title',
+    summaryKey: 'tour.summary',
+    steps: [
+        {
+            id: 'intro',
+            target: '',
+            placement: 'center',
+            titleKey: 't0',
+            contentKey: 'c0',
+        },
+        {
+            id: 'second',
+            route: '/second',
+            target: 'second-target',
+            titleKey: 't1',
+            contentKey: 'c1',
+        },
+        {
+            id: 'third',
+            route: '/third',
+            target: 'third-target',
+            titleKey: 't2',
+            contentKey: 'c2',
+        },
+    ],
 };
 
 const LocationProbe = ({ onPath }: { onPath: (path: string) => void }) => {
-	const location = useLocation();
-	onPath(location.pathname + location.search);
-	return null;
+    const location = useLocation();
+    onPath(location.pathname + location.search);
+    return null;
 };
 
-const renderAdapter = (
-	over: Partial<React.ComponentProps<typeof ProductTourAdapter>> = {}
-) => {
-	const events: Array<{ event: TourEvent; stepId?: string }> = [];
-	const paths: string[] = [];
-	const onTerminal = vi.fn(() => Promise.resolve());
-	const utils = render(
-		<MemoryRouter initialEntries={['/']}>
-			<LocationProbe onPath={(p) => paths.push(p)} />
-			<Routes>
-				<Route
-					path="*"
-					element={
-						<ProductTourAdapter
-							tour={tour}
-							active={true}
-							paused={false}
-							targetTimeoutMs={80}
-							onEvent={(event, step) =>
-								events.push({ event, stepId: step?.id })
-							}
-							onTerminalStatus={onTerminal}
-							{...over}
-						/>
-					}
-				/>
-			</Routes>
-		</MemoryRouter>
-	);
-	return { events, paths, onTerminal, ...utils };
+const renderAdapter = (over: Partial<React.ComponentProps<typeof ProductTourAdapter>> = {}) => {
+    const events: Array<{ event: TourEvent; stepId?: string }> = [];
+    const paths: string[] = [];
+    const onTerminal = vi.fn(() => Promise.resolve());
+    const utils = render(
+        <MemoryRouter initialEntries={['/']}>
+            <LocationProbe onPath={(p) => paths.push(p)} />
+            <Routes>
+                <Route
+                    path="*"
+                    element={
+                        <ProductTourAdapter
+                            tour={tour}
+                            active
+                            paused={false}
+                            targetTimeoutMs={80}
+                            onEvent={(event, step) => events.push({ event, stepId: step?.id })}
+                            onTerminalStatus={onTerminal}
+                            {...over}
+                        />
+                    }
+                />
+            </Routes>
+        </MemoryRouter>,
+    );
+    return { events, paths, onTerminal, ...utils };
 };
 
 afterEach(() => {
-	cleanup();
-	joyrideProps = null;
-	document.body.innerHTML = '';
-	vi.clearAllMocks();
+    cleanup();
+    joyrideProps = null;
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
 });
 
 describe('ProductTourAdapter', () => {
-	it('renders joyride in controlled mode with mapped steps', async () => {
-		renderAdapter();
+    it('renders joyride in controlled mode with mapped steps', async () => {
+        renderAdapter();
 
-		await waitFor(() => expect(joyrideProps).not.toBeNull());
-		expect(joyrideProps!.steps).toHaveLength(3);
-		expect(joyrideProps!.steps[0].target).toBe('body');
-		expect(joyrideProps!.stepIndex).toBe(0);
-		expect(joyrideProps!.run).toBe(true);
-	});
+        await waitFor(() => expect(joyrideProps).not.toBeNull());
+        expect(joyrideProps!.steps).toHaveLength(3);
+        expect(joyrideProps!.steps[0].target).toBe('body');
+        expect(joyrideProps!.stepIndex).toBe(0);
+        expect(joyrideProps!.run).toBe(true);
+    });
 
-	it('never scrolls the fixed-viewport app window', async () => {
-		renderAdapter();
+    it('never scrolls the fixed-viewport app window', async () => {
+        renderAdapter();
 
-		await waitFor(() => expect(joyrideProps).not.toBeNull());
-		expect((joyrideProps as any).options.skipScroll).toBe(true);
-	});
+        await waitFor(() => expect(joyrideProps).not.toBeNull());
+        expect((joyrideProps as any).options.skipScroll).toBe(true);
+    });
 
-	it('does not run while paused', async () => {
-		renderAdapter({ paused: true });
+    it('does not run while paused', async () => {
+        renderAdapter({ paused: true });
 
-		await waitFor(() => expect(joyrideProps).not.toBeNull());
-		expect(joyrideProps!.run).toBe(false);
-	});
+        await waitFor(() => expect(joyrideProps).not.toBeNull());
+        expect(joyrideProps!.run).toBe(false);
+    });
 
-	it('navigates to the next step route and advances only once its target exists', async () => {
-		const el = document.createElement('div');
-		el.setAttribute('data-tour-target', 'second-target');
-		document.body.appendChild(el);
+    it('navigates to the next step route and advances only once its target exists', async () => {
+        const el = document.createElement('div');
+        el.setAttribute('data-tour-target', 'second-target');
+        document.body.appendChild(el);
 
-		const { paths } = renderAdapter();
-		await waitFor(() => expect(joyrideProps).not.toBeNull());
+        const { paths } = renderAdapter();
+        await waitFor(() => expect(joyrideProps).not.toBeNull());
 
-		act(() => {
-			joyrideProps!.onEvent({
-				action: 'next',
-				index: 0,
-				status: 'running',
-				type: 'step:after'
-			});
-		});
+        act(() => {
+            joyrideProps!.onEvent({
+                action: 'next',
+                index: 0,
+                status: 'running',
+                type: 'step:after',
+            });
+        });
 
-		await waitFor(() => expect(joyrideProps!.stepIndex).toBe(1));
-		expect(paths).toContain('/second');
-	});
+        await waitFor(() => expect(joyrideProps!.stepIndex).toBe(1));
+        expect(paths).toContain('/second');
+    });
 
-	it('records target_missing and skips ahead when a target never appears', async () => {
-		const el = document.createElement('div');
-		el.setAttribute('data-tour-target', 'third-target');
-		document.body.appendChild(el);
+    it('records target_missing and skips ahead when a target never appears', async () => {
+        const el = document.createElement('div');
+        el.setAttribute('data-tour-target', 'third-target');
+        document.body.appendChild(el);
 
-		const { events, paths } = renderAdapter();
-		await waitFor(() => expect(joyrideProps).not.toBeNull());
+        const { events, paths } = renderAdapter();
+        await waitFor(() => expect(joyrideProps).not.toBeNull());
 
-		// advance to step 1 whose target is missing -> should end on step 2
-		act(() => {
-			joyrideProps!.onEvent({
-				action: 'next',
-				index: 0,
-				status: 'running',
-				type: 'step:after'
-			});
-		});
+        // advance to step 1 whose target is missing -> should end on step 2
+        act(() => {
+            joyrideProps!.onEvent({
+                action: 'next',
+                index: 0,
+                status: 'running',
+                type: 'step:after',
+            });
+        });
 
-		await waitFor(() => expect(joyrideProps!.stepIndex).toBe(2), {
-			timeout: 3000
-		});
-		expect(
-			events.some(
-				(e) => e.event === 'target_missing' && e.stepId === 'second'
-			)
-		).toBe(true);
-		expect(paths).toContain('/third');
-	});
+        await waitFor(() => expect(joyrideProps!.stepIndex).toBe(2), {
+            timeout: 3000,
+        });
+        expect(events.some((e) => e.event === 'target_missing' && e.stepId === 'second')).toBe(true);
+        expect(paths).toContain('/third');
+    });
 
-	it('persists completed through the terminal callback', async () => {
-		const { onTerminal } = renderAdapter();
-		await waitFor(() => expect(joyrideProps).not.toBeNull());
+    it('persists completed through the terminal callback', async () => {
+        const { onTerminal } = renderAdapter();
+        await waitFor(() => expect(joyrideProps).not.toBeNull());
 
-		act(() => {
-			joyrideProps!.onEvent({
-				action: 'next',
-				index: 2,
-				status: 'running',
-				type: 'step:after'
-			});
-		});
+        act(() => {
+            joyrideProps!.onEvent({
+                action: 'next',
+                index: 2,
+                status: 'running',
+                type: 'step:after',
+            });
+        });
 
-		await waitFor(() =>
-			expect(onTerminal).toHaveBeenCalledWith(
-				expect.objectContaining({
-					tourId: 'test-tour',
-					tourVersion: 1,
-					status: 'completed'
-				})
-			)
-		);
-	});
+        await waitFor(() =>
+            expect(onTerminal).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    tourId: 'test-tour',
+                    tourVersion: 1,
+                    status: 'completed',
+                }),
+            ),
+        );
+    });
 
-	it('persists skipped when the user closes the tour mid-way', async () => {
-		const { onTerminal } = renderAdapter();
-		await waitFor(() => expect(joyrideProps).not.toBeNull());
+    it('persists skipped when the user closes the tour mid-way', async () => {
+        const { onTerminal } = renderAdapter();
+        await waitFor(() => expect(joyrideProps).not.toBeNull());
 
-		act(() => {
-			joyrideProps!.onEvent({
-				action: 'close',
-				index: 0,
-				status: 'running',
-				type: 'step:after'
-			});
-		});
+        act(() => {
+            joyrideProps!.onEvent({
+                action: 'close',
+                index: 0,
+                status: 'running',
+                type: 'step:after',
+            });
+        });
 
-		await waitFor(() =>
-			expect(onTerminal).toHaveBeenCalledWith(
-				expect.objectContaining({ status: 'skipped' })
-			)
-		);
-		expect(joyrideProps!.run).toBe(false);
-	});
+        await waitFor(() => expect(onTerminal).toHaveBeenCalledWith(expect.objectContaining({ status: 'skipped' })));
+        expect(joyrideProps!.run).toBe(false);
+    });
 });

--- a/src/components/productTour/ProductTourAdapter.test.tsx
+++ b/src/components/productTour/ProductTourAdapter.test.tsx
@@ -196,6 +196,32 @@ describe('ProductTourAdapter', () => {
         );
     });
 
+    it('waits for a delayed first-step target before running joyride', async () => {
+        const delayedTour: TourDefinition = {
+            ...tour,
+            steps: [
+                {
+                    id: 'late-first',
+                    target: 'late-first-target',
+                    titleKey: 't0',
+                    contentKey: 'c0',
+                },
+            ],
+        };
+        renderAdapter({ tour: delayedTour });
+        await waitFor(() => expect(joyrideProps).not.toBeNull());
+        expect(joyrideProps!.run).toBe(false);
+
+        const el = document.createElement('div');
+        el.setAttribute('data-tour-target', 'late-first-target');
+        document.body.appendChild(el);
+
+        await waitFor(() => expect(joyrideProps!.run).toBe(true), {
+            timeout: 3000,
+        });
+        expect(joyrideProps!.stepIndex).toBe(0);
+    });
+
     it('persists skipped when the user closes the tour mid-way', async () => {
         const { onTerminal } = renderAdapter();
         await waitFor(() => expect(joyrideProps).not.toBeNull());

--- a/src/components/productTour/ProductTourAdapter.test.tsx
+++ b/src/components/productTour/ProductTourAdapter.test.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProductTourAdapter } from './ProductTourAdapter';
+import type { TourDefinition, TourEvent } from './types';
+
+interface CapturedJoyrideProps {
+	run: boolean;
+	stepIndex: number;
+	steps: any[];
+	onEvent: (data: any) => void;
+	tooltipComponent?: any;
+	locale?: any;
+	disableScrolling?: boolean;
+}
+
+let joyrideProps: CapturedJoyrideProps | null = null;
+
+vi.mock('react-joyride', async () => {
+	const actual: any = await vi.importActual('react-joyride');
+	return {
+		...actual,
+		Joyride: (props: any) => {
+			joyrideProps = props;
+			return null;
+		}
+	};
+});
+
+const tour: TourDefinition = {
+	id: 'test-tour',
+	version: 1,
+	surface: 'frontend',
+	audiences: ['consultant'],
+	titleKey: 'tour.title',
+	summaryKey: 'tour.summary',
+	steps: [
+		{
+			id: 'intro',
+			target: '',
+			placement: 'center',
+			titleKey: 't0',
+			contentKey: 'c0'
+		},
+		{
+			id: 'second',
+			route: '/second',
+			target: 'second-target',
+			titleKey: 't1',
+			contentKey: 'c1'
+		},
+		{
+			id: 'third',
+			route: '/third',
+			target: 'third-target',
+			titleKey: 't2',
+			contentKey: 'c2'
+		}
+	]
+};
+
+const LocationProbe = ({ onPath }: { onPath: (path: string) => void }) => {
+	const location = useLocation();
+	onPath(location.pathname + location.search);
+	return null;
+};
+
+const renderAdapter = (
+	over: Partial<React.ComponentProps<typeof ProductTourAdapter>> = {}
+) => {
+	const events: Array<{ event: TourEvent; stepId?: string }> = [];
+	const paths: string[] = [];
+	const onTerminal = vi.fn(() => Promise.resolve());
+	const utils = render(
+		<MemoryRouter initialEntries={['/']}>
+			<LocationProbe onPath={(p) => paths.push(p)} />
+			<Routes>
+				<Route
+					path="*"
+					element={
+						<ProductTourAdapter
+							tour={tour}
+							active={true}
+							paused={false}
+							targetTimeoutMs={80}
+							onEvent={(event, step) =>
+								events.push({ event, stepId: step?.id })
+							}
+							onTerminalStatus={onTerminal}
+							{...over}
+						/>
+					}
+				/>
+			</Routes>
+		</MemoryRouter>
+	);
+	return { events, paths, onTerminal, ...utils };
+};
+
+afterEach(() => {
+	cleanup();
+	joyrideProps = null;
+	document.body.innerHTML = '';
+	vi.clearAllMocks();
+});
+
+describe('ProductTourAdapter', () => {
+	it('renders joyride in controlled mode with mapped steps', async () => {
+		renderAdapter();
+
+		await waitFor(() => expect(joyrideProps).not.toBeNull());
+		expect(joyrideProps!.steps).toHaveLength(3);
+		expect(joyrideProps!.steps[0].target).toBe('body');
+		expect(joyrideProps!.stepIndex).toBe(0);
+		expect(joyrideProps!.run).toBe(true);
+	});
+
+	it('never scrolls the fixed-viewport app window', async () => {
+		renderAdapter();
+
+		await waitFor(() => expect(joyrideProps).not.toBeNull());
+		expect((joyrideProps as any).options.skipScroll).toBe(true);
+	});
+
+	it('does not run while paused', async () => {
+		renderAdapter({ paused: true });
+
+		await waitFor(() => expect(joyrideProps).not.toBeNull());
+		expect(joyrideProps!.run).toBe(false);
+	});
+
+	it('navigates to the next step route and advances only once its target exists', async () => {
+		const el = document.createElement('div');
+		el.setAttribute('data-tour-target', 'second-target');
+		document.body.appendChild(el);
+
+		const { paths } = renderAdapter();
+		await waitFor(() => expect(joyrideProps).not.toBeNull());
+
+		act(() => {
+			joyrideProps!.onEvent({
+				action: 'next',
+				index: 0,
+				status: 'running',
+				type: 'step:after'
+			});
+		});
+
+		await waitFor(() => expect(joyrideProps!.stepIndex).toBe(1));
+		expect(paths).toContain('/second');
+	});
+
+	it('records target_missing and skips ahead when a target never appears', async () => {
+		const el = document.createElement('div');
+		el.setAttribute('data-tour-target', 'third-target');
+		document.body.appendChild(el);
+
+		const { events, paths } = renderAdapter();
+		await waitFor(() => expect(joyrideProps).not.toBeNull());
+
+		// advance to step 1 whose target is missing -> should end on step 2
+		act(() => {
+			joyrideProps!.onEvent({
+				action: 'next',
+				index: 0,
+				status: 'running',
+				type: 'step:after'
+			});
+		});
+
+		await waitFor(() => expect(joyrideProps!.stepIndex).toBe(2), {
+			timeout: 3000
+		});
+		expect(
+			events.some(
+				(e) => e.event === 'target_missing' && e.stepId === 'second'
+			)
+		).toBe(true);
+		expect(paths).toContain('/third');
+	});
+
+	it('persists completed through the terminal callback', async () => {
+		const { onTerminal } = renderAdapter();
+		await waitFor(() => expect(joyrideProps).not.toBeNull());
+
+		act(() => {
+			joyrideProps!.onEvent({
+				action: 'next',
+				index: 2,
+				status: 'running',
+				type: 'step:after'
+			});
+		});
+
+		await waitFor(() =>
+			expect(onTerminal).toHaveBeenCalledWith(
+				expect.objectContaining({
+					tourId: 'test-tour',
+					tourVersion: 1,
+					status: 'completed'
+				})
+			)
+		);
+	});
+
+	it('persists skipped when the user closes the tour mid-way', async () => {
+		const { onTerminal } = renderAdapter();
+		await waitFor(() => expect(joyrideProps).not.toBeNull());
+
+		act(() => {
+			joyrideProps!.onEvent({
+				action: 'close',
+				index: 0,
+				status: 'running',
+				type: 'step:after'
+			});
+		});
+
+		await waitFor(() =>
+			expect(onTerminal).toHaveBeenCalledWith(
+				expect.objectContaining({ status: 'skipped' })
+			)
+		);
+		expect(joyrideProps!.run).toBe(false);
+	});
+});

--- a/src/components/productTour/ProductTourAdapter.tsx
+++ b/src/components/productTour/ProductTourAdapter.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Joyride } from 'react-joyride';
 import type { EventData } from 'react-joyride';
 import { useTranslation } from 'react-i18next';
@@ -44,10 +44,9 @@ export const ProductTourAdapter = ({
     const navigate = useNavigate();
     const location = useLocation();
 
-    const [runState, setRunState] = useState<TourRunState>({
-        ...initialTourRunState,
-        run: true,
-    });
+    // Joyride starts only after the first step's route and target are ready,
+    // so every step follows the same preparation flow.
+    const [runState, setRunState] = useState<TourRunState>(initialTourRunState);
     // The index Joyride actually shows; advanced only after route + target
     // for that step are ready.
     const [readyIndex, setReadyIndex] = useState(0);
@@ -55,11 +54,21 @@ export const ProductTourAdapter = ({
     // (a full-viewport target falls back to a centered tooltip).
     const [placementOverrides, setPlacementOverrides] = useState<Record<number, TourPlacement | undefined>>({});
 
+    // Callback handling reads and writes through this ref so side effects
+    // (events, navigation, persistence) never live inside a React state
+    // updater, which may replay updaters and duplicate them.
+    const runStateRef = useRef<TourRunState>(runState);
     const startedAtRef = useRef<string | undefined>(undefined);
     const terminalReportedRef = useRef(false);
     const prepareTokenRef = useRef(0);
+    const startedPreparingRef = useRef(false);
     const locationRef = useRef(location);
     locationRef.current = location;
+
+    const applyRunState = useCallback((next: TourRunState) => {
+        runStateRef.current = next;
+        setRunState(next);
+    }, []);
 
     const { steps } = tour;
     const joyrideSteps = useMemo(() => {
@@ -101,15 +110,16 @@ export const ProductTourAdapter = ({
 
     /**
      * Makes step `index` presentable: navigates to its route when needed and
-     * waits (bounded) for its target. A missing target is skipped safely; if
-     * no presentable step remains the tour closes without completion.
+     * waits (bounded) for its target. A missing target is skipped safely in
+     * the direction of travel; if no presentable step remains the tour closes
+     * without completion. Resolves true when a step became presentable.
      */
     const prepareStep = useCallback(
-        async (index: number) => {
+        async (index: number, direction: 1 | -1 = 1): Promise<boolean> => {
             prepareTokenRef.current += 1;
             const token = prepareTokenRef.current;
-            /* eslint-disable no-await-in-loop, no-continue -- steps are prepared strictly sequentially; a skipped target falls through to the next step */
-            for (let i = index; i < steps.length; i += 1) {
+            /* eslint-disable no-await-in-loop, no-continue -- steps are prepared strictly sequentially; a skipped target falls through to the neighboring step */
+            for (let i = index; i >= 0 && i < steps.length; i += direction) {
                 const step = steps[i];
                 if (step.route) {
                     const current = locationRef.current.pathname + locationRef.current.search;
@@ -120,7 +130,7 @@ export const ProductTourAdapter = ({
                 if (step.target) {
                     const found = await waitForTarget(tourTargetSelector(step.target), { timeoutMs: targetTimeoutMs });
                     if (prepareTokenRef.current !== token) {
-                        return;
+                        return false;
                     }
                     if (!found) {
                         emit('target_missing', step);
@@ -138,56 +148,71 @@ export const ProductTourAdapter = ({
                     setPlacementOverrides((prev) => (prev[i] === placement ? prev : { ...prev, [i]: placement }));
                 }
                 setReadyIndex(i);
-                setRunState((prev) => ({ ...prev, stepIndex: i }));
-                return;
+                applyRunState({ ...runStateRef.current, stepIndex: i });
+                return true;
             }
             /* eslint-enable no-await-in-loop, no-continue */
             // No presentable step left: close without recording completion.
-            setRunState((prev) => ({ ...prev, run: false }));
+            applyRunState({ ...runStateRef.current, run: false });
+            return false;
         },
-        [emit, navigate, steps, targetTimeoutMs],
+        [applyRunState, emit, navigate, steps, targetTimeoutMs],
     );
+
+    // Gate the initial run: prepare step 0 (route + target) before Joyride
+    // ever positions against the page.
+    useEffect(() => {
+        if (!active || startedPreparingRef.current) {
+            return;
+        }
+        startedPreparingRef.current = true;
+        prepareStep(0).then((prepared) => {
+            if (prepared) {
+                applyRunState({ ...runStateRef.current, run: true });
+            }
+        });
+    }, [active, applyRunState, prepareStep]);
 
     const handleCallback = useCallback(
         (data: EventData) => {
             const stepForIndex = (index: number): TourStep | undefined => steps[index];
 
-            setRunState((prev) => {
-                const { state, events } = reduceTourCallback(
-                    prev,
-                    {
-                        action: data.action,
-                        index: data.index,
-                        status: data.status,
-                        type: data.type,
-                    },
-                    steps.length,
-                );
+            const prev = runStateRef.current;
+            const { state, events } = reduceTourCallback(
+                prev,
+                {
+                    action: data.action,
+                    index: data.index,
+                    status: data.status,
+                    type: data.type,
+                },
+                steps.length,
+            );
 
-                events.forEach((event) => {
-                    if (event === 'tour_started') {
-                        startedAtRef.current = new Date().toISOString();
-                    }
-                    emit(event, stepForIndex(data.index));
-                });
-
-                if (state.status === 'completed' && events.length) {
-                    reportTerminal('completed', stepForIndex(data.index)?.id);
+            events.forEach((event) => {
+                if (event === 'tour_started') {
+                    startedAtRef.current = new Date().toISOString();
                 }
-                if (state.status === 'skipped' && events.includes('tour_skipped')) {
-                    reportTerminal('skipped', stepForIndex(data.index)?.id);
-                }
-
-                if (state.run && state.stepIndex !== prev.stepIndex) {
-                    // Advance asynchronously once route + target are ready.
-                    prepareStep(state.stepIndex);
-                    // Keep showing the previous step until prepared.
-                    return { ...state, stepIndex: prev.stepIndex };
-                }
-                return state;
+                emit(event, stepForIndex(data.index));
             });
+
+            if (state.status === 'completed' && events.length) {
+                reportTerminal('completed', stepForIndex(data.index)?.id);
+            }
+            if (state.status === 'skipped' && events.includes('tour_skipped')) {
+                reportTerminal('skipped', stepForIndex(data.index)?.id);
+            }
+
+            if (state.run && state.stepIndex !== prev.stepIndex) {
+                // Advance asynchronously once route + target are ready; keep
+                // showing the previous step until prepared.
+                applyRunState({ ...state, stepIndex: prev.stepIndex });
+                prepareStep(state.stepIndex, state.stepIndex < prev.stepIndex ? -1 : 1);
+                return;
+            }
+            applyRunState(state);
         },
-        [emit, prepareStep, reportTerminal, steps],
+        [applyRunState, emit, prepareStep, reportTerminal, steps],
     );
 
     if (!active) {

--- a/src/components/productTour/ProductTourAdapter.tsx
+++ b/src/components/productTour/ProductTourAdapter.tsx
@@ -5,242 +5,218 @@ import type { EventData } from 'react-joyride';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
-	effectivePlacement,
-	initialTourRunState,
-	mapStepsToJoyride,
-	reduceTourCallback,
-	tourTargetSelector,
-	TourRunState
+    effectivePlacement,
+    initialTourRunState,
+    mapStepsToJoyride,
+    reduceTourCallback,
+    tourTargetSelector,
+    TourRunState,
 } from './tourEngine';
 import { waitForTarget } from './targetReadiness';
-import type {
-	TourDefinition,
-	TourEvent,
-	TourPlacement,
-	TourProgress,
-	TourStep
-} from './types';
+import type { TourDefinition, TourEvent, TourPlacement, TourProgress, TourStep } from './types';
 
 export interface ProductTourAdapterProps {
-	tour: TourDefinition;
-	/** All app-level gates passed; the adapter renders nothing when false. */
-	active: boolean;
-	/** A higher-priority blocking surface (e.g. the 2FA dialog) is visible. */
-	paused?: boolean;
-	/** Bounded wait for a step target before it is skipped as missing. */
-	targetTimeoutMs?: number;
-	onEvent?: (event: TourEvent, step?: TourStep) => void;
-	/** Called exactly once when the tour reaches completed or skipped. */
-	onTerminalStatus?: (progress: TourProgress) => void | Promise<void>;
-	tooltipComponent?: React.ComponentType<any>;
+    tour: TourDefinition;
+    /** All app-level gates passed; the adapter renders nothing when false. */
+    active: boolean;
+    /** A higher-priority blocking surface (e.g. the 2FA dialog) is visible. */
+    paused?: boolean;
+    /** Bounded wait for a step target before it is skipped as missing. */
+    targetTimeoutMs?: number;
+    onEvent?: (event: TourEvent, step?: TourStep) => void;
+    /** Called exactly once when the tour reaches completed or skipped. */
+    onTerminalStatus?: (progress: TourProgress) => void | Promise<void>;
+    tooltipComponent?: React.ComponentType<any>;
 }
 
 const DEFAULT_TARGET_TIMEOUT_MS = 4000;
 
 export const ProductTourAdapter = ({
-	tour,
-	active,
-	paused = false,
-	targetTimeoutMs = DEFAULT_TARGET_TIMEOUT_MS,
-	onEvent,
-	onTerminalStatus,
-	tooltipComponent
+    tour,
+    active,
+    paused = false,
+    targetTimeoutMs = DEFAULT_TARGET_TIMEOUT_MS,
+    onEvent,
+    onTerminalStatus,
+    tooltipComponent,
 }: ProductTourAdapterProps) => {
-	const { t: translate } = useTranslation();
-	const navigate = useNavigate();
-	const location = useLocation();
+    const { t: translate } = useTranslation();
+    const navigate = useNavigate();
+    const location = useLocation();
 
-	const [runState, setRunState] = useState<TourRunState>({
-		...initialTourRunState,
-		run: true
-	});
-	// The index Joyride actually shows; advanced only after route + target
-	// for that step are ready.
-	const [readyIndex, setReadyIndex] = useState(0);
-	// Per-step placement corrections measured against the real target size
-	// (a full-viewport target falls back to a centered tooltip).
-	const [placementOverrides, setPlacementOverrides] = useState<
-		Record<number, TourPlacement | undefined>
-	>({});
+    const [runState, setRunState] = useState<TourRunState>({
+        ...initialTourRunState,
+        run: true,
+    });
+    // The index Joyride actually shows; advanced only after route + target
+    // for that step are ready.
+    const [readyIndex, setReadyIndex] = useState(0);
+    // Per-step placement corrections measured against the real target size
+    // (a full-viewport target falls back to a centered tooltip).
+    const [placementOverrides, setPlacementOverrides] = useState<Record<number, TourPlacement | undefined>>({});
 
-	const startedAtRef = useRef<string | undefined>(undefined);
-	const terminalReportedRef = useRef(false);
-	const prepareTokenRef = useRef(0);
-	const locationRef = useRef(location);
-	locationRef.current = location;
+    const startedAtRef = useRef<string | undefined>(undefined);
+    const terminalReportedRef = useRef(false);
+    const prepareTokenRef = useRef(0);
+    const locationRef = useRef(location);
+    locationRef.current = location;
 
-	const steps = tour.steps;
-	const joyrideSteps = useMemo(() => {
-		const mapped = mapStepsToJoyride(steps);
-		return mapped.map((step, index) =>
-			placementOverrides[index]
-				? { ...step, placement: placementOverrides[index] }
-				: step
-		);
-	}, [placementOverrides, steps]);
+    const { steps } = tour;
+    const joyrideSteps = useMemo(() => {
+        const mapped = mapStepsToJoyride(steps);
+        return mapped.map((step, index) =>
+            placementOverrides[index] ? { ...step, placement: placementOverrides[index] } : step,
+        );
+    }, [placementOverrides, steps]);
 
-	const emit = useCallback(
-		(event: TourEvent, step?: TourStep) => {
-			onEvent?.(event, step);
-		},
-		[onEvent]
-	);
+    const emit = useCallback(
+        (event: TourEvent, step?: TourStep) => {
+            onEvent?.(event, step);
+        },
+        [onEvent],
+    );
 
-	const reportTerminal = useCallback(
-		(status: 'completed' | 'skipped', currentStepId?: string) => {
-			if (terminalReportedRef.current) {
-				return;
-			}
-			terminalReportedRef.current = true;
-			const progress: TourProgress = {
-				tourId: tour.id,
-				tourVersion: tour.version,
-				status,
-				currentStepId,
-				startedAt: startedAtRef.current,
-				completedAt: new Date().toISOString()
-			};
-			Promise.resolve(onTerminalStatus?.(progress)).catch(() => {
-				// A failed write must not crash the tour surface; the caller
-				// owns retry/reporting semantics.
-				terminalReportedRef.current = false;
-			});
-		},
-		[onTerminalStatus, tour.id, tour.version]
-	);
+    const reportTerminal = useCallback(
+        (status: 'completed' | 'skipped', currentStepId?: string) => {
+            if (terminalReportedRef.current) {
+                return;
+            }
+            terminalReportedRef.current = true;
+            const progress: TourProgress = {
+                tourId: tour.id,
+                tourVersion: tour.version,
+                status,
+                currentStepId,
+                startedAt: startedAtRef.current,
+                completedAt: new Date().toISOString(),
+            };
+            Promise.resolve(onTerminalStatus?.(progress)).catch(() => {
+                // A failed write must not crash the tour surface; the caller
+                // owns retry/reporting semantics.
+                terminalReportedRef.current = false;
+            });
+        },
+        [onTerminalStatus, tour.id, tour.version],
+    );
 
-	/**
-	 * Makes step `index` presentable: navigates to its route when needed and
-	 * waits (bounded) for its target. A missing target is skipped safely; if
-	 * no presentable step remains the tour closes without completion.
-	 */
-	const prepareStep = useCallback(
-		async (index: number) => {
-			const token = ++prepareTokenRef.current;
-			for (let i = index; i < steps.length; i++) {
-				const step = steps[i];
-				if (step.route) {
-					const current =
-						locationRef.current.pathname +
-						locationRef.current.search;
-					if (current !== step.route) {
-						navigate(step.route);
-					}
-				}
-				if (step.target) {
-					const found = await waitForTarget(
-						tourTargetSelector(step.target),
-						{ timeoutMs: targetTimeoutMs }
-					);
-					if (prepareTokenRef.current !== token) {
-						return;
-					}
-					if (!found) {
-						emit('target_missing', step);
-						continue;
-					}
-					const rect = document
-						.querySelector(tourTargetSelector(step.target))
-						?.getBoundingClientRect();
-					const placement = effectivePlacement(
-						step.placement ?? 'bottom',
-						rect
-							? { width: rect.width, height: rect.height }
-							: null,
-						{
-							width: window.innerWidth,
-							height: window.innerHeight
-						}
-					);
-					setPlacementOverrides((prev) =>
-						prev[i] === placement
-							? prev
-							: { ...prev, [i]: placement }
-					);
-				}
-				setReadyIndex(i);
-				setRunState((prev) => ({ ...prev, stepIndex: i }));
-				return;
-			}
-			// No presentable step left: close without recording completion.
-			setRunState((prev) => ({ ...prev, run: false }));
-		},
-		[emit, navigate, steps, targetTimeoutMs]
-	);
+    /**
+     * Makes step `index` presentable: navigates to its route when needed and
+     * waits (bounded) for its target. A missing target is skipped safely; if
+     * no presentable step remains the tour closes without completion.
+     */
+    const prepareStep = useCallback(
+        async (index: number) => {
+            prepareTokenRef.current += 1;
+            const token = prepareTokenRef.current;
+            /* eslint-disable no-await-in-loop, no-continue -- steps are prepared strictly sequentially; a skipped target falls through to the next step */
+            for (let i = index; i < steps.length; i += 1) {
+                const step = steps[i];
+                if (step.route) {
+                    const current = locationRef.current.pathname + locationRef.current.search;
+                    if (current !== step.route) {
+                        navigate(step.route);
+                    }
+                }
+                if (step.target) {
+                    const found = await waitForTarget(tourTargetSelector(step.target), { timeoutMs: targetTimeoutMs });
+                    if (prepareTokenRef.current !== token) {
+                        return;
+                    }
+                    if (!found) {
+                        emit('target_missing', step);
+                        continue;
+                    }
+                    const rect = document.querySelector(tourTargetSelector(step.target))?.getBoundingClientRect();
+                    const placement = effectivePlacement(
+                        step.placement ?? 'bottom',
+                        rect ? { width: rect.width, height: rect.height } : null,
+                        {
+                            width: window.innerWidth,
+                            height: window.innerHeight,
+                        },
+                    );
+                    setPlacementOverrides((prev) => (prev[i] === placement ? prev : { ...prev, [i]: placement }));
+                }
+                setReadyIndex(i);
+                setRunState((prev) => ({ ...prev, stepIndex: i }));
+                return;
+            }
+            /* eslint-enable no-await-in-loop, no-continue */
+            // No presentable step left: close without recording completion.
+            setRunState((prev) => ({ ...prev, run: false }));
+        },
+        [emit, navigate, steps, targetTimeoutMs],
+    );
 
-	const handleCallback = useCallback(
-		(data: EventData) => {
-			const stepForIndex = (index: number): TourStep | undefined =>
-				steps[index];
+    const handleCallback = useCallback(
+        (data: EventData) => {
+            const stepForIndex = (index: number): TourStep | undefined => steps[index];
 
-			setRunState((prev) => {
-				const { state, events } = reduceTourCallback(
-					prev,
-					{
-						action: data.action,
-						index: data.index,
-						status: data.status,
-						type: data.type
-					},
-					steps.length
-				);
+            setRunState((prev) => {
+                const { state, events } = reduceTourCallback(
+                    prev,
+                    {
+                        action: data.action,
+                        index: data.index,
+                        status: data.status,
+                        type: data.type,
+                    },
+                    steps.length,
+                );
 
-				events.forEach((event) => {
-					if (event === 'tour_started') {
-						startedAtRef.current = new Date().toISOString();
-					}
-					emit(event, stepForIndex(data.index));
-				});
+                events.forEach((event) => {
+                    if (event === 'tour_started') {
+                        startedAtRef.current = new Date().toISOString();
+                    }
+                    emit(event, stepForIndex(data.index));
+                });
 
-				if (state.status === 'completed' && events.length) {
-					reportTerminal('completed', stepForIndex(data.index)?.id);
-				}
-				if (
-					state.status === 'skipped' &&
-					events.includes('tour_skipped')
-				) {
-					reportTerminal('skipped', stepForIndex(data.index)?.id);
-				}
+                if (state.status === 'completed' && events.length) {
+                    reportTerminal('completed', stepForIndex(data.index)?.id);
+                }
+                if (state.status === 'skipped' && events.includes('tour_skipped')) {
+                    reportTerminal('skipped', stepForIndex(data.index)?.id);
+                }
 
-				if (state.run && state.stepIndex !== prev.stepIndex) {
-					// Advance asynchronously once route + target are ready.
-					prepareStep(state.stepIndex);
-					// Keep showing the previous step until prepared.
-					return { ...state, stepIndex: prev.stepIndex };
-				}
-				return state;
-			});
-		},
-		[emit, prepareStep, reportTerminal, steps]
-	);
+                if (state.run && state.stepIndex !== prev.stepIndex) {
+                    // Advance asynchronously once route + target are ready.
+                    prepareStep(state.stepIndex);
+                    // Keep showing the previous step until prepared.
+                    return { ...state, stepIndex: prev.stepIndex };
+                }
+                return state;
+            });
+        },
+        [emit, prepareStep, reportTerminal, steps],
+    );
 
-	if (!active) {
-		return null;
-	}
+    if (!active) {
+        return null;
+    }
 
-	return (
-		<Joyride
-			steps={joyrideSteps}
-			run={runState.run && !paused}
-			stepIndex={readyIndex}
-			continuous
-			onEvent={handleCallback}
-			tooltipComponent={tooltipComponent}
-			locale={{
-				back: translate('productTour.back'),
-				next: translate('productTour.next'),
-				last: translate('productTour.done'),
-				close: translate('productTour.done'),
-				skip: translate('productTour.done')
-			}}
-			options={{
-				skipBeacon: true,
-				closeButtonAction: 'skip',
-				// The app shell is a fixed-viewport layout; scrolling the
-				// window would break it and every tour target is in view.
-				skipScroll: true,
-				zIndex: 53
-			}}
-		/>
-	);
+    return (
+        <Joyride
+            steps={joyrideSteps}
+            run={runState.run && !paused}
+            stepIndex={readyIndex}
+            continuous
+            onEvent={handleCallback}
+            tooltipComponent={tooltipComponent}
+            locale={{
+                back: translate('productTour.back'),
+                next: translate('productTour.next'),
+                last: translate('productTour.done'),
+                close: translate('productTour.done'),
+                skip: translate('productTour.done'),
+            }}
+            options={{
+                skipBeacon: true,
+                closeButtonAction: 'skip',
+                // The app shell is a fixed-viewport layout; scrolling the
+                // window would break it and every tour target is in view.
+                skipScroll: true,
+                zIndex: 53,
+            }}
+        />
+    );
 };

--- a/src/components/productTour/ProductTourAdapter.tsx
+++ b/src/components/productTour/ProductTourAdapter.tsx
@@ -1,0 +1,246 @@
+import * as React from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { Joyride } from 'react-joyride';
+import type { EventData } from 'react-joyride';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+	effectivePlacement,
+	initialTourRunState,
+	mapStepsToJoyride,
+	reduceTourCallback,
+	tourTargetSelector,
+	TourRunState
+} from './tourEngine';
+import { waitForTarget } from './targetReadiness';
+import type {
+	TourDefinition,
+	TourEvent,
+	TourPlacement,
+	TourProgress,
+	TourStep
+} from './types';
+
+export interface ProductTourAdapterProps {
+	tour: TourDefinition;
+	/** All app-level gates passed; the adapter renders nothing when false. */
+	active: boolean;
+	/** A higher-priority blocking surface (e.g. the 2FA dialog) is visible. */
+	paused?: boolean;
+	/** Bounded wait for a step target before it is skipped as missing. */
+	targetTimeoutMs?: number;
+	onEvent?: (event: TourEvent, step?: TourStep) => void;
+	/** Called exactly once when the tour reaches completed or skipped. */
+	onTerminalStatus?: (progress: TourProgress) => void | Promise<void>;
+	tooltipComponent?: React.ComponentType<any>;
+}
+
+const DEFAULT_TARGET_TIMEOUT_MS = 4000;
+
+export const ProductTourAdapter = ({
+	tour,
+	active,
+	paused = false,
+	targetTimeoutMs = DEFAULT_TARGET_TIMEOUT_MS,
+	onEvent,
+	onTerminalStatus,
+	tooltipComponent
+}: ProductTourAdapterProps) => {
+	const { t: translate } = useTranslation();
+	const navigate = useNavigate();
+	const location = useLocation();
+
+	const [runState, setRunState] = useState<TourRunState>({
+		...initialTourRunState,
+		run: true
+	});
+	// The index Joyride actually shows; advanced only after route + target
+	// for that step are ready.
+	const [readyIndex, setReadyIndex] = useState(0);
+	// Per-step placement corrections measured against the real target size
+	// (a full-viewport target falls back to a centered tooltip).
+	const [placementOverrides, setPlacementOverrides] = useState<
+		Record<number, TourPlacement | undefined>
+	>({});
+
+	const startedAtRef = useRef<string | undefined>(undefined);
+	const terminalReportedRef = useRef(false);
+	const prepareTokenRef = useRef(0);
+	const locationRef = useRef(location);
+	locationRef.current = location;
+
+	const steps = tour.steps;
+	const joyrideSteps = useMemo(() => {
+		const mapped = mapStepsToJoyride(steps);
+		return mapped.map((step, index) =>
+			placementOverrides[index]
+				? { ...step, placement: placementOverrides[index] }
+				: step
+		);
+	}, [placementOverrides, steps]);
+
+	const emit = useCallback(
+		(event: TourEvent, step?: TourStep) => {
+			onEvent?.(event, step);
+		},
+		[onEvent]
+	);
+
+	const reportTerminal = useCallback(
+		(status: 'completed' | 'skipped', currentStepId?: string) => {
+			if (terminalReportedRef.current) {
+				return;
+			}
+			terminalReportedRef.current = true;
+			const progress: TourProgress = {
+				tourId: tour.id,
+				tourVersion: tour.version,
+				status,
+				currentStepId,
+				startedAt: startedAtRef.current,
+				completedAt: new Date().toISOString()
+			};
+			Promise.resolve(onTerminalStatus?.(progress)).catch(() => {
+				// A failed write must not crash the tour surface; the caller
+				// owns retry/reporting semantics.
+				terminalReportedRef.current = false;
+			});
+		},
+		[onTerminalStatus, tour.id, tour.version]
+	);
+
+	/**
+	 * Makes step `index` presentable: navigates to its route when needed and
+	 * waits (bounded) for its target. A missing target is skipped safely; if
+	 * no presentable step remains the tour closes without completion.
+	 */
+	const prepareStep = useCallback(
+		async (index: number) => {
+			const token = ++prepareTokenRef.current;
+			for (let i = index; i < steps.length; i++) {
+				const step = steps[i];
+				if (step.route) {
+					const current =
+						locationRef.current.pathname +
+						locationRef.current.search;
+					if (current !== step.route) {
+						navigate(step.route);
+					}
+				}
+				if (step.target) {
+					const found = await waitForTarget(
+						tourTargetSelector(step.target),
+						{ timeoutMs: targetTimeoutMs }
+					);
+					if (prepareTokenRef.current !== token) {
+						return;
+					}
+					if (!found) {
+						emit('target_missing', step);
+						continue;
+					}
+					const rect = document
+						.querySelector(tourTargetSelector(step.target))
+						?.getBoundingClientRect();
+					const placement = effectivePlacement(
+						step.placement ?? 'bottom',
+						rect
+							? { width: rect.width, height: rect.height }
+							: null,
+						{
+							width: window.innerWidth,
+							height: window.innerHeight
+						}
+					);
+					setPlacementOverrides((prev) =>
+						prev[i] === placement
+							? prev
+							: { ...prev, [i]: placement }
+					);
+				}
+				setReadyIndex(i);
+				setRunState((prev) => ({ ...prev, stepIndex: i }));
+				return;
+			}
+			// No presentable step left: close without recording completion.
+			setRunState((prev) => ({ ...prev, run: false }));
+		},
+		[emit, navigate, steps, targetTimeoutMs]
+	);
+
+	const handleCallback = useCallback(
+		(data: EventData) => {
+			const stepForIndex = (index: number): TourStep | undefined =>
+				steps[index];
+
+			setRunState((prev) => {
+				const { state, events } = reduceTourCallback(
+					prev,
+					{
+						action: data.action,
+						index: data.index,
+						status: data.status,
+						type: data.type
+					},
+					steps.length
+				);
+
+				events.forEach((event) => {
+					if (event === 'tour_started') {
+						startedAtRef.current = new Date().toISOString();
+					}
+					emit(event, stepForIndex(data.index));
+				});
+
+				if (state.status === 'completed' && events.length) {
+					reportTerminal('completed', stepForIndex(data.index)?.id);
+				}
+				if (
+					state.status === 'skipped' &&
+					events.includes('tour_skipped')
+				) {
+					reportTerminal('skipped', stepForIndex(data.index)?.id);
+				}
+
+				if (state.run && state.stepIndex !== prev.stepIndex) {
+					// Advance asynchronously once route + target are ready.
+					prepareStep(state.stepIndex);
+					// Keep showing the previous step until prepared.
+					return { ...state, stepIndex: prev.stepIndex };
+				}
+				return state;
+			});
+		},
+		[emit, prepareStep, reportTerminal, steps]
+	);
+
+	if (!active) {
+		return null;
+	}
+
+	return (
+		<Joyride
+			steps={joyrideSteps}
+			run={runState.run && !paused}
+			stepIndex={readyIndex}
+			continuous
+			onEvent={handleCallback}
+			tooltipComponent={tooltipComponent}
+			locale={{
+				back: translate('productTour.back'),
+				next: translate('productTour.next'),
+				last: translate('productTour.done'),
+				close: translate('productTour.done'),
+				skip: translate('productTour.done')
+			}}
+			options={{
+				skipBeacon: true,
+				closeButtonAction: 'skip',
+				// The app shell is a fixed-viewport layout; scrolling the
+				// window would break it and every tour target is in view.
+				skipScroll: true,
+				zIndex: 53
+			}}
+		/>
+	);
+};

--- a/src/components/productTour/ProductTourTooltip.stories.tsx
+++ b/src/components/productTour/ProductTourTooltip.stories.tsx
@@ -1,0 +1,153 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect } from 'react';
+import i18n from 'i18next';
+import { ProductTourTooltip } from './ProductTourTooltip';
+
+/**
+ * Fake Joyride render props so every tooltip state is reviewable in
+ * isolation; positioning is covered by the ProductTour stories.
+ */
+const tooltipProps = (over: Record<string, unknown> = {}) =>
+    ({
+        index: 1,
+        size: 4,
+        isLastStep: false,
+        continuous: true,
+        step: {
+            title: 'productTour.adminTour.navigation.title',
+            content: 'productTour.adminTour.navigation.content',
+        },
+        backProps: { onClick: () => {}, 'aria-label': 'back' },
+        closeProps: { onClick: () => {}, 'aria-label': 'close' },
+        primaryProps: { onClick: () => {}, 'aria-label': 'next' },
+        skipProps: { onClick: () => {}, 'aria-label': 'skip' },
+        tooltipProps: {},
+        controls: {
+            next: () => {},
+            prev: () => {},
+            skip: () => {},
+            close: () => {},
+        },
+        ...over,
+    } as never);
+
+const WithLanguage = ({ language, children }: { language: string; children: React.ReactNode }) => {
+    useEffect(() => {
+        const previous = i18n.language;
+        i18n.changeLanguage(language);
+        return () => {
+            i18n.changeLanguage(previous);
+        };
+    }, [language]);
+    return children as React.ReactElement;
+};
+
+const meta = {
+    title: 'Molecules/ProductTourTooltip',
+    component: ProductTourTooltip,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'centered',
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/design/QfsgojtHQzBjbzU3Im9Cet/Admin.ORISO?node-id=899-26642',
+        },
+        docs: {
+            description: {
+                component:
+                    'Admin/M3-styled tooltip for React Joyride product tours. Renders translated step copy, progress, bullets and the admin button styles; all colors come from the --m3-* token variables (app.css).',
+            },
+        },
+    },
+} satisfies Meta<typeof ProductTourTooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FirstStep: Story = {
+    args: tooltipProps({
+        index: 0,
+        step: {
+            title: 'productTour.adminTour.welcome.title',
+            content: 'productTour.adminTour.welcome.content',
+        },
+    }),
+};
+
+export const MiddleStep: Story = {
+    args: tooltipProps({ index: 2 }),
+};
+
+export const FinalStep: Story = {
+    args: tooltipProps({ index: 3, isLastStep: true }),
+};
+
+export const LongTranslatedCopy: Story = {
+    args: tooltipProps({
+        step: {
+            title: 'productTour.adminTour.welcome.title',
+            content: 'productTour.adminTour.welcome.content',
+        },
+    }),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Long translated copy wraps without hiding the navigation actions.',
+            },
+        },
+    },
+};
+
+export const German: Story = {
+    args: tooltipProps({ index: 0 }),
+    decorators: [
+        (StoryComponent) => (
+            <WithLanguage language="de">
+                <StoryComponent />
+            </WithLanguage>
+        ),
+    ],
+};
+
+export const English: Story = {
+    args: tooltipProps({ index: 0 }),
+    decorators: [
+        (StoryComponent) => (
+            <WithLanguage language="en">
+                <StoryComponent />
+            </WithLanguage>
+        ),
+    ],
+};
+
+export const MobileViewport: Story = {
+    args: tooltipProps(),
+    globals: { viewport: { value: 'mobile1', isRotated: false } },
+};
+
+export const TenantThemeTokenProof: Story = {
+    args: tooltipProps(),
+    decorators: [
+        (StoryComponent) => (
+            <div
+                style={
+                    {
+                        '--m3-primary': '#1d4ed8',
+                        '--m3-surface': '#f8fafc',
+                        '--m3-on-surface': '#0f172a',
+                        '--m3-on-surface-variant': '#475569',
+                    } as React.CSSProperties
+                }
+            >
+                <StoryComponent />
+            </div>
+        ),
+    ],
+    parameters: {
+        docs: {
+            description: {
+                story: 'Overriding the --m3-* custom properties restyles the tooltip completely — proof that the component consumes theme tokens instead of hardcoded colors.',
+            },
+        },
+    },
+};

--- a/src/components/productTour/ProductTourTooltip.test.tsx
+++ b/src/components/productTour/ProductTourTooltip.test.tsx
@@ -61,25 +61,15 @@ describe('ProductTourTooltip (admin)', () => {
         render(<ProductTourTooltip {...(baseProps() as any)} />);
 
         expect(screen.getByText('Schritt 2 von 4')).toBeTruthy();
-        expect(
-            screen
-                .getByRole('alertdialog')
-                .querySelectorAll('.productTourTooltip__bullet')
-        ).toHaveLength(4);
+        expect(screen.getByRole('alertdialog').querySelectorAll('.productTourTooltip__bullet')).toHaveLength(4);
     });
 
     it('hides the back button on the first step and shows done on the last', () => {
-        const { unmount } = render(
-            <ProductTourTooltip {...(baseProps({ index: 0 }) as any)} />
-        );
+        const { unmount } = render(<ProductTourTooltip {...(baseProps({ index: 0 }) as any)} />);
         expect(screen.queryByText('Zurück')).toBeNull();
         unmount();
 
-        render(
-            <ProductTourTooltip
-                {...(baseProps({ index: 3, isLastStep: true }) as any)}
-            />
-        );
+        render(<ProductTourTooltip {...(baseProps({ index: 3, isLastStep: true }) as any)} />);
         expect(screen.getByText('Fertig')).toBeTruthy();
         expect(screen.queryByText('Weiter')).toBeNull();
     });

--- a/src/components/productTour/ProductTourTooltip.test.tsx
+++ b/src/components/productTour/ProductTourTooltip.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProductTourTooltip } from './ProductTourTooltip';
+
+const translations: Record<string, string> = {
+    't.title': 'Mandanten verwalten',
+    't.content': 'Hier verwalten Sie <br /> Ihre Mandanten.',
+    'productTour.next': 'Weiter',
+    'productTour.back': 'Zurück',
+    'productTour.done': 'Fertig',
+    'productTour.step': 'Schritt',
+    'productTour.of': 'von',
+    'productTour.close': 'Tour schließen',
+};
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string) => translations[key] ?? key,
+        i18n: { language: 'de', resolvedLanguage: 'de' },
+    }),
+}));
+
+const baseProps = (over: Record<string, any> = {}) => ({
+    index: 1,
+    size: 4,
+    isLastStep: false,
+    continuous: true,
+    step: {
+        title: 't.title',
+        content: 't.content',
+    },
+    backProps: { onClick: vi.fn(), 'aria-label': 'back' },
+    closeProps: { onClick: vi.fn(), 'aria-label': 'close' },
+    primaryProps: { onClick: vi.fn(), 'aria-label': 'primary' },
+    skipProps: { onClick: vi.fn(), 'aria-label': 'skip' },
+    tooltipProps: { 'aria-modal': true },
+    controls: {
+        next: vi.fn(),
+        prev: vi.fn(),
+        skip: vi.fn(),
+        close: vi.fn(),
+    },
+    ...over,
+});
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+});
+
+describe('ProductTourTooltip (admin)', () => {
+    it('renders translated title and html content as a dialog', () => {
+        render(<ProductTourTooltip {...(baseProps() as any)} />);
+
+        expect(screen.getByRole('alertdialog')).toBeTruthy();
+        expect(screen.getByText('Mandanten verwalten')).toBeTruthy();
+        expect(screen.getByText(/Ihre Mandanten/, { exact: false })).toBeTruthy();
+    });
+
+    it('shows step progress and bullets', () => {
+        render(<ProductTourTooltip {...(baseProps() as any)} />);
+
+        expect(screen.getByText('Schritt 2 von 4')).toBeTruthy();
+        expect(
+            screen
+                .getByRole('alertdialog')
+                .querySelectorAll('.productTourTooltip__bullet')
+        ).toHaveLength(4);
+    });
+
+    it('hides the back button on the first step and shows done on the last', () => {
+        const { unmount } = render(
+            <ProductTourTooltip {...(baseProps({ index: 0 }) as any)} />
+        );
+        expect(screen.queryByText('Zurück')).toBeNull();
+        unmount();
+
+        render(
+            <ProductTourTooltip
+                {...(baseProps({ index: 3, isLastStep: true }) as any)}
+            />
+        );
+        expect(screen.getByText('Fertig')).toBeTruthy();
+        expect(screen.queryByText('Weiter')).toBeNull();
+    });
+
+    it('wires next, back and close to the joyride tour controls', () => {
+        const props = baseProps();
+        render(<ProductTourTooltip {...(props as any)} />);
+
+        fireEvent.click(screen.getByText('Weiter'));
+        fireEvent.click(screen.getByText('Zurück'));
+        fireEvent.click(screen.getByLabelText('Tour schließen'));
+
+        expect(props.controls.next).toHaveBeenCalled();
+        expect(props.controls.prev).toHaveBeenCalled();
+        expect(props.controls.skip).toHaveBeenCalled();
+    });
+});

--- a/src/components/productTour/ProductTourTooltip.test.tsx
+++ b/src/components/productTour/ProductTourTooltip.test.tsx
@@ -74,6 +74,24 @@ describe('ProductTourTooltip (admin)', () => {
         expect(screen.queryByText('Weiter')).toBeNull();
     });
 
+    it('strips scriptable markup from translated content', () => {
+        translations['t.evil'] =
+            'Sicher<br /><script>window.hacked = true;</script><img src=x onerror="window.hacked=true" />';
+        render(
+            <ProductTourTooltip
+                {...(baseProps({
+                    step: { title: 't.title', content: 't.evil' },
+                }) as any)}
+            />,
+        );
+
+        const content = document.querySelector('.productTourTooltip__content')!;
+        expect(content.innerHTML).not.toContain('<script');
+        expect(content.innerHTML).not.toContain('onerror');
+        expect(content.innerHTML).toContain('<br');
+        expect((window as any).hacked).toBeUndefined();
+    });
+
     it('wires next, back and close to the joyride tour controls', () => {
         const props = baseProps();
         render(<ProductTourTooltip {...(props as any)} />);

--- a/src/components/productTour/ProductTourTooltip.tsx
+++ b/src/components/productTour/ProductTourTooltip.tsx
@@ -1,0 +1,88 @@
+import { CloseOutlined } from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
+import type { TooltipRenderProps } from 'react-joyride';
+import { Button, BUTTON_TYPES } from '../button/Button';
+
+/**
+ * Admin/M3-styled Joyride tooltip. Step titles and contents arrive as i18n
+ * keys (set by mapStepsToJoyride) and are translated here; step copy may
+ * contain static markup like <br /> from the translation bundles.
+ */
+export const ProductTourTooltip = ({
+    index,
+    size,
+    isLastStep,
+    step,
+    controls,
+    tooltipProps,
+}: TooltipRenderProps) => {
+    const { t } = useTranslation();
+
+    const nextLabel = isLastStep ? t('productTour.done') : t('productTour.next');
+
+    return (
+        <div
+            className="productTourTooltip"
+            role="alertdialog"
+            aria-label={t(String(step.title))}
+            {...tooltipProps}
+        >
+            <div className="productTourTooltip__header">
+                <h2 className="productTourTooltip__title">
+                    {t(String(step.title))}
+                </h2>
+                <button
+                    type="button"
+                    className="productTourTooltip__close"
+                    onClick={() => controls.skip('button_close')}
+                    aria-label={t('productTour.close')}
+                >
+                    <CloseOutlined aria-hidden="true" />
+                </button>
+            </div>
+            <div
+                className="productTourTooltip__content"
+                dangerouslySetInnerHTML={{
+                    __html: t(String(step.content)),
+                }}
+            />
+            <div className="productTourTooltip__actions">
+                {index > 0 && (
+                    <Button
+                        item={{
+                            label: t('productTour.back'),
+                            type: BUTTON_TYPES.SECONDARY,
+                        }}
+                        buttonHandle={() => controls.prev()}
+                        className="productTourTooltip__back"
+                    />
+                )}
+                <Button
+                    item={{
+                        label: nextLabel,
+                        type: BUTTON_TYPES.PRIMARY,
+                    }}
+                    buttonHandle={() => controls.next()}
+                    className="productTourTooltip__next"
+                />
+            </div>
+            <div className="productTourTooltip__footer">
+                <span className="productTourTooltip__progress" aria-live="polite">
+                    {`${t('productTour.step')} ${index + 1} ${t('productTour.of')} ${size}`}
+                </span>
+                <div className="productTourTooltip__bullets" aria-hidden="true">
+                    {Array.from({ length: size }, (_, bulletIndex) => (
+                        <span
+                            key={bulletIndex}
+                            className={
+                                bulletIndex === index
+                                    ? 'productTourTooltip__bullet productTourTooltip__bullet--active'
+                                    : 'productTourTooltip__bullet'
+                            }
+                        />
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/components/productTour/ProductTourTooltip.tsx
+++ b/src/components/productTour/ProductTourTooltip.tsx
@@ -1,4 +1,5 @@
 import { CloseOutlined } from '@ant-design/icons';
+import DOMPurify from 'dompurify';
 import { useTranslation } from 'react-i18next';
 import type { TooltipRenderProps } from 'react-joyride';
 import { Button, BUTTON_TYPES } from '../button/Button';
@@ -28,9 +29,12 @@ export const ProductTourTooltip = ({ index, size, isLastStep, step, controls, to
             </div>
             <div
                 className="productTourTooltip__content"
-                // eslint-disable-next-line react/no-danger -- step copy is static, trusted i18n bundle text (same rendering the legacy intro.js walkthrough used)
+                // eslint-disable-next-line react/no-danger -- sanitized below; only inline formatting from the i18n bundles survives
                 dangerouslySetInnerHTML={{
-                    __html: t(String(step.content)),
+                    __html: DOMPurify.sanitize(t(String(step.content)), {
+                        ALLOWED_TAGS: ['br', 'b', 'strong', 'i', 'em'],
+                        ALLOWED_ATTR: [],
+                    }),
                 }}
             />
             <div className="productTourTooltip__actions">

--- a/src/components/productTour/ProductTourTooltip.tsx
+++ b/src/components/productTour/ProductTourTooltip.tsx
@@ -8,29 +8,15 @@ import { Button, BUTTON_TYPES } from '../button/Button';
  * keys (set by mapStepsToJoyride) and are translated here; step copy may
  * contain static markup like <br /> from the translation bundles.
  */
-export const ProductTourTooltip = ({
-    index,
-    size,
-    isLastStep,
-    step,
-    controls,
-    tooltipProps,
-}: TooltipRenderProps) => {
+export const ProductTourTooltip = ({ index, size, isLastStep, step, controls, tooltipProps }: TooltipRenderProps) => {
     const { t } = useTranslation();
 
     const nextLabel = isLastStep ? t('productTour.done') : t('productTour.next');
 
     return (
-        <div
-            className="productTourTooltip"
-            role="alertdialog"
-            aria-label={t(String(step.title))}
-            {...tooltipProps}
-        >
+        <div className="productTourTooltip" role="alertdialog" aria-label={t(String(step.title))} {...tooltipProps}>
             <div className="productTourTooltip__header">
-                <h2 className="productTourTooltip__title">
-                    {t(String(step.title))}
-                </h2>
+                <h2 className="productTourTooltip__title">{t(String(step.title))}</h2>
                 <button
                     type="button"
                     className="productTourTooltip__close"
@@ -42,6 +28,7 @@ export const ProductTourTooltip = ({
             </div>
             <div
                 className="productTourTooltip__content"
+                // eslint-disable-next-line react/no-danger -- step copy is static, trusted i18n bundle text (same rendering the legacy intro.js walkthrough used)
                 dangerouslySetInnerHTML={{
                     __html: t(String(step.content)),
                 }}

--- a/src/components/productTour/targetReadiness.test.ts
+++ b/src/components/productTour/targetReadiness.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { waitForTarget } from './targetReadiness';
+
+afterEach(() => {
+	document.body.innerHTML = '';
+});
+
+describe('waitForTarget', () => {
+	it('resolves immediately when the target is already in the DOM', async () => {
+		document.body.innerHTML =
+			'<nav data-tour-target="sessions-archive-tab"></nav>';
+
+		const found = await waitForTarget(
+			'[data-tour-target="sessions-archive-tab"]',
+			{ timeoutMs: 50 }
+		);
+
+		expect(found).toBe(true);
+	});
+
+	it('resolves when the target appears before the timeout', async () => {
+		const pending = waitForTarget('[data-tour-target="late"]', {
+			timeoutMs: 1000,
+			pollMs: 5
+		});
+		setTimeout(() => {
+			const el = document.createElement('div');
+			el.setAttribute('data-tour-target', 'late');
+			document.body.appendChild(el);
+		}, 20);
+
+		await expect(pending).resolves.toBe(true);
+	});
+
+	it('resolves false after the bounded timeout when the target never appears', async () => {
+		const found = await waitForTarget('[data-tour-target="never"]', {
+			timeoutMs: 40,
+			pollMs: 5
+		});
+
+		expect(found).toBe(false);
+	});
+});

--- a/src/components/productTour/targetReadiness.test.ts
+++ b/src/components/productTour/targetReadiness.test.ts
@@ -38,3 +38,9 @@ describe('waitForTarget', () => {
         expect(found).toBe(false);
     });
 });
+
+describe('waitForTarget malformed selectors', () => {
+    it('resolves false instead of rejecting on an invalid selector', async () => {
+        await expect(waitForTarget(':::not-a-selector', { timeoutMs: 40 })).resolves.toBe(false);
+    });
+});

--- a/src/components/productTour/targetReadiness.test.ts
+++ b/src/components/productTour/targetReadiness.test.ts
@@ -3,42 +3,38 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { waitForTarget } from './targetReadiness';
 
 afterEach(() => {
-	document.body.innerHTML = '';
+    document.body.innerHTML = '';
 });
 
 describe('waitForTarget', () => {
-	it('resolves immediately when the target is already in the DOM', async () => {
-		document.body.innerHTML =
-			'<nav data-tour-target="sessions-archive-tab"></nav>';
+    it('resolves immediately when the target is already in the DOM', async () => {
+        document.body.innerHTML = '<nav data-tour-target="sessions-archive-tab"></nav>';
 
-		const found = await waitForTarget(
-			'[data-tour-target="sessions-archive-tab"]',
-			{ timeoutMs: 50 }
-		);
+        const found = await waitForTarget('[data-tour-target="sessions-archive-tab"]', { timeoutMs: 50 });
 
-		expect(found).toBe(true);
-	});
+        expect(found).toBe(true);
+    });
 
-	it('resolves when the target appears before the timeout', async () => {
-		const pending = waitForTarget('[data-tour-target="late"]', {
-			timeoutMs: 1000,
-			pollMs: 5
-		});
-		setTimeout(() => {
-			const el = document.createElement('div');
-			el.setAttribute('data-tour-target', 'late');
-			document.body.appendChild(el);
-		}, 20);
+    it('resolves when the target appears before the timeout', async () => {
+        const pending = waitForTarget('[data-tour-target="late"]', {
+            timeoutMs: 1000,
+            pollMs: 5,
+        });
+        setTimeout(() => {
+            const el = document.createElement('div');
+            el.setAttribute('data-tour-target', 'late');
+            document.body.appendChild(el);
+        }, 20);
 
-		await expect(pending).resolves.toBe(true);
-	});
+        await expect(pending).resolves.toBe(true);
+    });
 
-	it('resolves false after the bounded timeout when the target never appears', async () => {
-		const found = await waitForTarget('[data-tour-target="never"]', {
-			timeoutMs: 40,
-			pollMs: 5
-		});
+    it('resolves false after the bounded timeout when the target never appears', async () => {
+        const found = await waitForTarget('[data-tour-target="never"]', {
+            timeoutMs: 40,
+            pollMs: 5,
+        });
 
-		expect(found).toBe(false);
-	});
+        expect(found).toBe(false);
+    });
 });

--- a/src/components/productTour/targetReadiness.ts
+++ b/src/components/productTour/targetReadiness.ts
@@ -1,0 +1,27 @@
+export interface WaitForTargetOptions {
+	timeoutMs: number;
+	pollMs?: number;
+}
+
+/**
+ * Waits until a selector matches an element or the bounded timeout elapses.
+ * Resolves `true` when found, `false` on timeout — it never rejects, so a
+ * missing tour target can be skipped without trapping the user in an overlay.
+ */
+export const waitForTarget = (
+	selector: string,
+	{ timeoutMs, pollMs = 50 }: WaitForTargetOptions
+): Promise<boolean> =>
+	new Promise((resolve) => {
+		const deadline = Date.now() + timeoutMs;
+		const check = () => {
+			if (document.querySelector(selector)) {
+				resolve(true);
+			} else if (Date.now() >= deadline) {
+				resolve(false);
+			} else {
+				setTimeout(check, pollMs);
+			}
+		};
+		check();
+	});

--- a/src/components/productTour/targetReadiness.ts
+++ b/src/components/productTour/targetReadiness.ts
@@ -1,6 +1,6 @@
 export interface WaitForTargetOptions {
-	timeoutMs: number;
-	pollMs?: number;
+    timeoutMs: number;
+    pollMs?: number;
 }
 
 /**
@@ -8,20 +8,17 @@ export interface WaitForTargetOptions {
  * Resolves `true` when found, `false` on timeout — it never rejects, so a
  * missing tour target can be skipped without trapping the user in an overlay.
  */
-export const waitForTarget = (
-	selector: string,
-	{ timeoutMs, pollMs = 50 }: WaitForTargetOptions
-): Promise<boolean> =>
-	new Promise((resolve) => {
-		const deadline = Date.now() + timeoutMs;
-		const check = () => {
-			if (document.querySelector(selector)) {
-				resolve(true);
-			} else if (Date.now() >= deadline) {
-				resolve(false);
-			} else {
-				setTimeout(check, pollMs);
-			}
-		};
-		check();
-	});
+export const waitForTarget = (selector: string, { timeoutMs, pollMs = 50 }: WaitForTargetOptions): Promise<boolean> =>
+    new Promise((resolve) => {
+        const deadline = Date.now() + timeoutMs;
+        const check = () => {
+            if (document.querySelector(selector)) {
+                resolve(true);
+            } else if (Date.now() >= deadline) {
+                resolve(false);
+            } else {
+                setTimeout(check, pollMs);
+            }
+        };
+        check();
+    });

--- a/src/components/productTour/targetReadiness.ts
+++ b/src/components/productTour/targetReadiness.ts
@@ -12,7 +12,16 @@ export const waitForTarget = (selector: string, { timeoutMs, pollMs = 50 }: Wait
     new Promise((resolve) => {
         const deadline = Date.now() + timeoutMs;
         const check = () => {
-            if (document.querySelector(selector)) {
+            let target: Element | null;
+            try {
+                target = document.querySelector(selector);
+            } catch {
+                // An invalid selector can never match: keep the never-reject
+                // contract and let the caller skip the step safely.
+                resolve(false);
+                return;
+            }
+            if (target) {
                 resolve(true);
             } else if (Date.now() >= deadline) {
                 resolve(false);

--- a/src/components/productTour/tourDefinitions.test.ts
+++ b/src/components/productTour/tourDefinitions.test.ts
@@ -20,10 +20,7 @@ describe('admin tour definitions', () => {
         const keys = [
             adminDemoTour.titleKey,
             adminDemoTour.summaryKey,
-            ...adminDemoTour.steps.flatMap((step) => [
-                step.titleKey,
-                step.contentKey,
-            ]),
+            ...adminDemoTour.steps.flatMap((step) => [step.titleKey, step.contentKey]),
         ];
         keys.forEach((key) => {
             expect(typeof de[key], `missing DE key ${key}`).toBe('string');

--- a/src/components/productTour/tourDefinitions.test.ts
+++ b/src/components/productTour/tourDefinitions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import translationDe from '../../locales/de/translation.json';
+import translationEn from '../../locales/en/translation.json';
+import { adminDemoTour, adminTours } from './tourDefinitions';
+
+describe('admin tour definitions', () => {
+    it('ships no production tour in this delivery package', () => {
+        expect(adminTours).toEqual([]);
+    });
+
+    it('provides a representative demo tour for Storybook review only', () => {
+        expect(adminDemoTour.surface).toBe('admin');
+        expect(adminDemoTour.audiences).toContain('tenant_admin');
+        expect(adminDemoTour.steps.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('uses only i18n keys that exist in both admin bundles (flat keys)', () => {
+        const de = translationDe as Record<string, string>;
+        const en = translationEn as Record<string, string>;
+        const keys = [
+            adminDemoTour.titleKey,
+            adminDemoTour.summaryKey,
+            ...adminDemoTour.steps.flatMap((step) => [
+                step.titleKey,
+                step.contentKey,
+            ]),
+        ];
+        keys.forEach((key) => {
+            expect(typeof de[key], `missing DE key ${key}`).toBe('string');
+            expect(typeof en[key], `missing EN key ${key}`).toBe('string');
+        });
+    });
+});

--- a/src/components/productTour/tourDefinitions.ts
+++ b/src/components/productTour/tourDefinitions.ts
@@ -1,0 +1,34 @@
+import type { TourDefinition } from './types';
+
+/**
+ * Representative Admin tour for Storybook review only. Concrete Admin tours
+ * are enabled in production only after their content and target flow are
+ * separately accepted (epic decision — see the TOUR-02 sub-issue).
+ */
+export const adminDemoTour: TourDefinition = {
+    id: 'admin-demo-tour',
+    version: 1,
+    surface: 'admin',
+    audiences: ['tenant_admin', 'platform_admin'],
+    titleKey: 'productTour.adminTour.title',
+    summaryKey: 'productTour.adminTour.summary',
+    steps: [
+        {
+            id: 'welcome',
+            target: '',
+            placement: 'center',
+            titleKey: 'productTour.adminTour.welcome.title',
+            contentKey: 'productTour.adminTour.welcome.content',
+        },
+        {
+            id: 'navigation',
+            target: 'admin-navigation',
+            placement: 'right',
+            titleKey: 'productTour.adminTour.navigation.title',
+            contentKey: 'productTour.adminTour.navigation.content',
+        },
+    ],
+};
+
+/** Tours enabled in the running admin app: none in this package. */
+export const adminTours: TourDefinition[] = [];

--- a/src/components/productTour/tourEngine.test.ts
+++ b/src/components/productTour/tourEngine.test.ts
@@ -1,0 +1,246 @@
+import { ACTIONS, EVENTS, STATUS } from 'react-joyride';
+import { describe, expect, it } from 'vitest';
+import {
+	effectivePlacement,
+	initialTourRunState,
+	mapStepsToJoyride,
+	reduceTourCallback
+} from './tourEngine';
+import type { TourStep } from './types';
+
+describe('mapStepsToJoyride', () => {
+	it('maps a centered step without target to a body-centered joyride step', () => {
+		const steps: TourStep[] = [
+			{
+				id: 'intro',
+				target: '',
+				titleKey: 'walkthrough.step.0.title',
+				contentKey: 'walkthrough.step.0.intro',
+				placement: 'center'
+			}
+		];
+
+		const joyrideSteps = mapStepsToJoyride(steps);
+
+		expect(joyrideSteps).toHaveLength(1);
+		expect(joyrideSteps[0].target).toBe('body');
+		expect(joyrideSteps[0].placement).toBe('center');
+		expect(joyrideSteps[0].id).toBe('intro');
+	});
+
+	it('maps a semantic target name to a data-tour-target selector', () => {
+		const steps: TourStep[] = [
+			{
+				id: 'archive',
+				target: 'sessions-archive-tab',
+				titleKey: 'walkthrough.step.4.title',
+				contentKey: 'walkthrough.step.4.intro'
+			}
+		];
+
+		const joyrideSteps = mapStepsToJoyride(steps);
+
+		expect(joyrideSteps[0].target).toBe(
+			'[data-tour-target="sessions-archive-tab"]'
+		);
+	});
+
+	it('defaults placement to bottom and passes an explicit placement through', () => {
+		const steps: TourStep[] = [
+			{
+				id: 'a',
+				target: 'a-target',
+				titleKey: 't',
+				contentKey: 'c'
+			},
+			{
+				id: 'b',
+				target: 'b-target',
+				titleKey: 't',
+				contentKey: 'c',
+				placement: 'right'
+			}
+		];
+
+		const joyrideSteps = mapStepsToJoyride(steps);
+
+		expect(joyrideSteps[0].placement).toBe('bottom');
+		expect(joyrideSteps[1].placement).toBe('right');
+	});
+});
+
+describe('reduceTourCallback', () => {
+	const cb = (
+		over: Partial<Record<'action' | 'index' | 'status' | 'type', any>>
+	) => ({
+		action: ACTIONS.UPDATE,
+		index: 0,
+		status: STATUS.RUNNING,
+		type: EVENTS.TOOLTIP,
+		...over
+	});
+
+	it('marks the tour started and in progress on tour:start', () => {
+		const { state, events } = reduceTourCallback(
+			initialTourRunState,
+			cb({ type: EVENTS.TOUR_START }),
+			5
+		);
+
+		expect(state.status).toBe('in_progress');
+		expect(events).toContain('tour_started');
+	});
+
+	it('records step_viewed when a step tooltip is shown', () => {
+		const { events } = reduceTourCallback(
+			{ ...initialTourRunState, status: 'in_progress' },
+			cb({ type: EVENTS.TOOLTIP, index: 1 }),
+			5
+		);
+
+		expect(events).toContain('step_viewed');
+	});
+
+	it('advances the step index and records step_completed on next', () => {
+		const { state, events } = reduceTourCallback(
+			{ status: 'in_progress', stepIndex: 1, run: true },
+			cb({ type: EVENTS.STEP_AFTER, action: ACTIONS.NEXT, index: 1 }),
+			5
+		);
+
+		expect(state.stepIndex).toBe(2);
+		expect(events).toContain('step_completed');
+		expect(state.run).toBe(true);
+	});
+
+	it('steps back without recording completion on prev', () => {
+		const { state, events } = reduceTourCallback(
+			{ ...initialTourRunState, status: 'in_progress', stepIndex: 2 },
+			cb({ type: EVENTS.STEP_AFTER, action: ACTIONS.PREV, index: 2 }),
+			5
+		);
+
+		expect(state.stepIndex).toBe(1);
+		expect(events).not.toContain('step_completed');
+	});
+
+	it('completes the tour when next is clicked on the final step', () => {
+		const { state, events } = reduceTourCallback(
+			{ ...initialTourRunState, status: 'in_progress', stepIndex: 4 },
+			cb({ type: EVENTS.STEP_AFTER, action: ACTIONS.NEXT, index: 4 }),
+			5
+		);
+
+		expect(state.run).toBe(false);
+		expect(state.status).toBe('completed');
+		expect(events).toContain('tour_completed');
+	});
+
+	it('records skipped, not completed, when the tour is closed mid-way', () => {
+		const { state, events } = reduceTourCallback(
+			{ ...initialTourRunState, status: 'in_progress', stepIndex: 2 },
+			cb({ type: EVENTS.STEP_AFTER, action: ACTIONS.CLOSE, index: 2 }),
+			5
+		);
+
+		expect(state.run).toBe(false);
+		expect(state.status).toBe('skipped');
+		expect(events).toContain('tour_skipped');
+		expect(events).not.toContain('tour_completed');
+	});
+
+	it('records skipped when the skip button ends the tour', () => {
+		const { state, events } = reduceTourCallback(
+			{ ...initialTourRunState, status: 'in_progress', stepIndex: 1 },
+			cb({
+				type: EVENTS.TOUR_END,
+				action: ACTIONS.SKIP,
+				status: STATUS.SKIPPED,
+				index: 1
+			}),
+			5
+		);
+
+		expect(state.run).toBe(false);
+		expect(state.status).toBe('skipped');
+		expect(events).toContain('tour_skipped');
+	});
+
+	it('skips a missing target safely and records target_missing', () => {
+		const { state, events } = reduceTourCallback(
+			{ status: 'in_progress', stepIndex: 1, run: true },
+			cb({ type: EVENTS.TARGET_NOT_FOUND, index: 1 }),
+			5
+		);
+
+		expect(events).toContain('target_missing');
+		expect(state.stepIndex).toBe(2);
+		expect(state.run).toBe(true);
+	});
+
+	it('closes without completion when the final step target is missing', () => {
+		const { state, events } = reduceTourCallback(
+			{ ...initialTourRunState, status: 'in_progress', stepIndex: 4 },
+			cb({ type: EVENTS.TARGET_NOT_FOUND, index: 4 }),
+			5
+		);
+
+		expect(state.run).toBe(false);
+		expect(state.status).toBe('in_progress');
+		expect(events).toContain('target_missing');
+		expect(events).not.toContain('tour_completed');
+	});
+
+	it('treats finishing via tour:end with finished status as completed once', () => {
+		const { state, events } = reduceTourCallback(
+			{
+				...initialTourRunState,
+				status: 'completed',
+				stepIndex: 4,
+				run: false
+			},
+			cb({
+				type: EVENTS.TOUR_END,
+				action: ACTIONS.NEXT,
+				status: STATUS.FINISHED,
+				index: 4
+			}),
+			5
+		);
+
+		expect(state.status).toBe('completed');
+		expect(events).not.toContain('tour_completed');
+	});
+});
+
+describe('effectivePlacement', () => {
+	it('keeps the configured placement for a normal-sized target', () => {
+		expect(
+			effectivePlacement(
+				'right',
+				{ width: 300, height: 400 },
+				{ width: 1440, height: 900 }
+			)
+		).toBe('right');
+	});
+
+	it('centers the tooltip when the target dominates the viewport', () => {
+		expect(
+			effectivePlacement(
+				'right',
+				{ width: 390, height: 700 },
+				{ width: 390, height: 844 }
+			)
+		).toBe('center');
+	});
+
+	it('keeps center as center', () => {
+		expect(
+			effectivePlacement(
+				'center',
+				{ width: 100, height: 100 },
+				{ width: 1440, height: 900 }
+			)
+		).toBe('center');
+	});
+});

--- a/src/components/productTour/tourEngine.test.ts
+++ b/src/components/productTour/tourEngine.test.ts
@@ -1,246 +1,215 @@
 import { ACTIONS, EVENTS, STATUS } from 'react-joyride';
 import { describe, expect, it } from 'vitest';
-import {
-	effectivePlacement,
-	initialTourRunState,
-	mapStepsToJoyride,
-	reduceTourCallback
-} from './tourEngine';
+import { effectivePlacement, initialTourRunState, mapStepsToJoyride, reduceTourCallback } from './tourEngine';
 import type { TourStep } from './types';
 
 describe('mapStepsToJoyride', () => {
-	it('maps a centered step without target to a body-centered joyride step', () => {
-		const steps: TourStep[] = [
-			{
-				id: 'intro',
-				target: '',
-				titleKey: 'walkthrough.step.0.title',
-				contentKey: 'walkthrough.step.0.intro',
-				placement: 'center'
-			}
-		];
+    it('maps a centered step without target to a body-centered joyride step', () => {
+        const steps: TourStep[] = [
+            {
+                id: 'intro',
+                target: '',
+                titleKey: 'walkthrough.step.0.title',
+                contentKey: 'walkthrough.step.0.intro',
+                placement: 'center',
+            },
+        ];
 
-		const joyrideSteps = mapStepsToJoyride(steps);
+        const joyrideSteps = mapStepsToJoyride(steps);
 
-		expect(joyrideSteps).toHaveLength(1);
-		expect(joyrideSteps[0].target).toBe('body');
-		expect(joyrideSteps[0].placement).toBe('center');
-		expect(joyrideSteps[0].id).toBe('intro');
-	});
+        expect(joyrideSteps).toHaveLength(1);
+        expect(joyrideSteps[0].target).toBe('body');
+        expect(joyrideSteps[0].placement).toBe('center');
+        expect(joyrideSteps[0].id).toBe('intro');
+    });
 
-	it('maps a semantic target name to a data-tour-target selector', () => {
-		const steps: TourStep[] = [
-			{
-				id: 'archive',
-				target: 'sessions-archive-tab',
-				titleKey: 'walkthrough.step.4.title',
-				contentKey: 'walkthrough.step.4.intro'
-			}
-		];
+    it('maps a semantic target name to a data-tour-target selector', () => {
+        const steps: TourStep[] = [
+            {
+                id: 'archive',
+                target: 'sessions-archive-tab',
+                titleKey: 'walkthrough.step.4.title',
+                contentKey: 'walkthrough.step.4.intro',
+            },
+        ];
 
-		const joyrideSteps = mapStepsToJoyride(steps);
+        const joyrideSteps = mapStepsToJoyride(steps);
 
-		expect(joyrideSteps[0].target).toBe(
-			'[data-tour-target="sessions-archive-tab"]'
-		);
-	});
+        expect(joyrideSteps[0].target).toBe('[data-tour-target="sessions-archive-tab"]');
+    });
 
-	it('defaults placement to bottom and passes an explicit placement through', () => {
-		const steps: TourStep[] = [
-			{
-				id: 'a',
-				target: 'a-target',
-				titleKey: 't',
-				contentKey: 'c'
-			},
-			{
-				id: 'b',
-				target: 'b-target',
-				titleKey: 't',
-				contentKey: 'c',
-				placement: 'right'
-			}
-		];
+    it('defaults placement to bottom and passes an explicit placement through', () => {
+        const steps: TourStep[] = [
+            {
+                id: 'a',
+                target: 'a-target',
+                titleKey: 't',
+                contentKey: 'c',
+            },
+            {
+                id: 'b',
+                target: 'b-target',
+                titleKey: 't',
+                contentKey: 'c',
+                placement: 'right',
+            },
+        ];
 
-		const joyrideSteps = mapStepsToJoyride(steps);
+        const joyrideSteps = mapStepsToJoyride(steps);
 
-		expect(joyrideSteps[0].placement).toBe('bottom');
-		expect(joyrideSteps[1].placement).toBe('right');
-	});
+        expect(joyrideSteps[0].placement).toBe('bottom');
+        expect(joyrideSteps[1].placement).toBe('right');
+    });
 });
 
 describe('reduceTourCallback', () => {
-	const cb = (
-		over: Partial<Record<'action' | 'index' | 'status' | 'type', any>>
-	) => ({
-		action: ACTIONS.UPDATE,
-		index: 0,
-		status: STATUS.RUNNING,
-		type: EVENTS.TOOLTIP,
-		...over
-	});
+    const cb = (over: Partial<Record<'action' | 'index' | 'status' | 'type', any>>) => ({
+        action: ACTIONS.UPDATE,
+        index: 0,
+        status: STATUS.RUNNING,
+        type: EVENTS.TOOLTIP,
+        ...over,
+    });
 
-	it('marks the tour started and in progress on tour:start', () => {
-		const { state, events } = reduceTourCallback(
-			initialTourRunState,
-			cb({ type: EVENTS.TOUR_START }),
-			5
-		);
+    it('marks the tour started and in progress on tour:start', () => {
+        const { state, events } = reduceTourCallback(initialTourRunState, cb({ type: EVENTS.TOUR_START }), 5);
 
-		expect(state.status).toBe('in_progress');
-		expect(events).toContain('tour_started');
-	});
+        expect(state.status).toBe('in_progress');
+        expect(events).toContain('tour_started');
+    });
 
-	it('records step_viewed when a step tooltip is shown', () => {
-		const { events } = reduceTourCallback(
-			{ ...initialTourRunState, status: 'in_progress' },
-			cb({ type: EVENTS.TOOLTIP, index: 1 }),
-			5
-		);
+    it('records step_viewed when a step tooltip is shown', () => {
+        const { events } = reduceTourCallback(
+            { ...initialTourRunState, status: 'in_progress' },
+            cb({ type: EVENTS.TOOLTIP, index: 1 }),
+            5,
+        );
 
-		expect(events).toContain('step_viewed');
-	});
+        expect(events).toContain('step_viewed');
+    });
 
-	it('advances the step index and records step_completed on next', () => {
-		const { state, events } = reduceTourCallback(
-			{ status: 'in_progress', stepIndex: 1, run: true },
-			cb({ type: EVENTS.STEP_AFTER, action: ACTIONS.NEXT, index: 1 }),
-			5
-		);
+    it('advances the step index and records step_completed on next', () => {
+        const { state, events } = reduceTourCallback(
+            { status: 'in_progress', stepIndex: 1, run: true },
+            cb({ type: EVENTS.STEP_AFTER, action: ACTIONS.NEXT, index: 1 }),
+            5,
+        );
 
-		expect(state.stepIndex).toBe(2);
-		expect(events).toContain('step_completed');
-		expect(state.run).toBe(true);
-	});
+        expect(state.stepIndex).toBe(2);
+        expect(events).toContain('step_completed');
+        expect(state.run).toBe(true);
+    });
 
-	it('steps back without recording completion on prev', () => {
-		const { state, events } = reduceTourCallback(
-			{ ...initialTourRunState, status: 'in_progress', stepIndex: 2 },
-			cb({ type: EVENTS.STEP_AFTER, action: ACTIONS.PREV, index: 2 }),
-			5
-		);
+    it('steps back without recording completion on prev', () => {
+        const { state, events } = reduceTourCallback(
+            { ...initialTourRunState, status: 'in_progress', stepIndex: 2 },
+            cb({ type: EVENTS.STEP_AFTER, action: ACTIONS.PREV, index: 2 }),
+            5,
+        );
 
-		expect(state.stepIndex).toBe(1);
-		expect(events).not.toContain('step_completed');
-	});
+        expect(state.stepIndex).toBe(1);
+        expect(events).not.toContain('step_completed');
+    });
 
-	it('completes the tour when next is clicked on the final step', () => {
-		const { state, events } = reduceTourCallback(
-			{ ...initialTourRunState, status: 'in_progress', stepIndex: 4 },
-			cb({ type: EVENTS.STEP_AFTER, action: ACTIONS.NEXT, index: 4 }),
-			5
-		);
+    it('completes the tour when next is clicked on the final step', () => {
+        const { state, events } = reduceTourCallback(
+            { ...initialTourRunState, status: 'in_progress', stepIndex: 4 },
+            cb({ type: EVENTS.STEP_AFTER, action: ACTIONS.NEXT, index: 4 }),
+            5,
+        );
 
-		expect(state.run).toBe(false);
-		expect(state.status).toBe('completed');
-		expect(events).toContain('tour_completed');
-	});
+        expect(state.run).toBe(false);
+        expect(state.status).toBe('completed');
+        expect(events).toContain('tour_completed');
+    });
 
-	it('records skipped, not completed, when the tour is closed mid-way', () => {
-		const { state, events } = reduceTourCallback(
-			{ ...initialTourRunState, status: 'in_progress', stepIndex: 2 },
-			cb({ type: EVENTS.STEP_AFTER, action: ACTIONS.CLOSE, index: 2 }),
-			5
-		);
+    it('records skipped, not completed, when the tour is closed mid-way', () => {
+        const { state, events } = reduceTourCallback(
+            { ...initialTourRunState, status: 'in_progress', stepIndex: 2 },
+            cb({ type: EVENTS.STEP_AFTER, action: ACTIONS.CLOSE, index: 2 }),
+            5,
+        );
 
-		expect(state.run).toBe(false);
-		expect(state.status).toBe('skipped');
-		expect(events).toContain('tour_skipped');
-		expect(events).not.toContain('tour_completed');
-	});
+        expect(state.run).toBe(false);
+        expect(state.status).toBe('skipped');
+        expect(events).toContain('tour_skipped');
+        expect(events).not.toContain('tour_completed');
+    });
 
-	it('records skipped when the skip button ends the tour', () => {
-		const { state, events } = reduceTourCallback(
-			{ ...initialTourRunState, status: 'in_progress', stepIndex: 1 },
-			cb({
-				type: EVENTS.TOUR_END,
-				action: ACTIONS.SKIP,
-				status: STATUS.SKIPPED,
-				index: 1
-			}),
-			5
-		);
+    it('records skipped when the skip button ends the tour', () => {
+        const { state, events } = reduceTourCallback(
+            { ...initialTourRunState, status: 'in_progress', stepIndex: 1 },
+            cb({
+                type: EVENTS.TOUR_END,
+                action: ACTIONS.SKIP,
+                status: STATUS.SKIPPED,
+                index: 1,
+            }),
+            5,
+        );
 
-		expect(state.run).toBe(false);
-		expect(state.status).toBe('skipped');
-		expect(events).toContain('tour_skipped');
-	});
+        expect(state.run).toBe(false);
+        expect(state.status).toBe('skipped');
+        expect(events).toContain('tour_skipped');
+    });
 
-	it('skips a missing target safely and records target_missing', () => {
-		const { state, events } = reduceTourCallback(
-			{ status: 'in_progress', stepIndex: 1, run: true },
-			cb({ type: EVENTS.TARGET_NOT_FOUND, index: 1 }),
-			5
-		);
+    it('skips a missing target safely and records target_missing', () => {
+        const { state, events } = reduceTourCallback(
+            { status: 'in_progress', stepIndex: 1, run: true },
+            cb({ type: EVENTS.TARGET_NOT_FOUND, index: 1 }),
+            5,
+        );
 
-		expect(events).toContain('target_missing');
-		expect(state.stepIndex).toBe(2);
-		expect(state.run).toBe(true);
-	});
+        expect(events).toContain('target_missing');
+        expect(state.stepIndex).toBe(2);
+        expect(state.run).toBe(true);
+    });
 
-	it('closes without completion when the final step target is missing', () => {
-		const { state, events } = reduceTourCallback(
-			{ ...initialTourRunState, status: 'in_progress', stepIndex: 4 },
-			cb({ type: EVENTS.TARGET_NOT_FOUND, index: 4 }),
-			5
-		);
+    it('closes without completion when the final step target is missing', () => {
+        const { state, events } = reduceTourCallback(
+            { ...initialTourRunState, status: 'in_progress', stepIndex: 4 },
+            cb({ type: EVENTS.TARGET_NOT_FOUND, index: 4 }),
+            5,
+        );
 
-		expect(state.run).toBe(false);
-		expect(state.status).toBe('in_progress');
-		expect(events).toContain('target_missing');
-		expect(events).not.toContain('tour_completed');
-	});
+        expect(state.run).toBe(false);
+        expect(state.status).toBe('in_progress');
+        expect(events).toContain('target_missing');
+        expect(events).not.toContain('tour_completed');
+    });
 
-	it('treats finishing via tour:end with finished status as completed once', () => {
-		const { state, events } = reduceTourCallback(
-			{
-				...initialTourRunState,
-				status: 'completed',
-				stepIndex: 4,
-				run: false
-			},
-			cb({
-				type: EVENTS.TOUR_END,
-				action: ACTIONS.NEXT,
-				status: STATUS.FINISHED,
-				index: 4
-			}),
-			5
-		);
+    it('treats finishing via tour:end with finished status as completed once', () => {
+        const { state, events } = reduceTourCallback(
+            {
+                ...initialTourRunState,
+                status: 'completed',
+                stepIndex: 4,
+                run: false,
+            },
+            cb({
+                type: EVENTS.TOUR_END,
+                action: ACTIONS.NEXT,
+                status: STATUS.FINISHED,
+                index: 4,
+            }),
+            5,
+        );
 
-		expect(state.status).toBe('completed');
-		expect(events).not.toContain('tour_completed');
-	});
+        expect(state.status).toBe('completed');
+        expect(events).not.toContain('tour_completed');
+    });
 });
 
 describe('effectivePlacement', () => {
-	it('keeps the configured placement for a normal-sized target', () => {
-		expect(
-			effectivePlacement(
-				'right',
-				{ width: 300, height: 400 },
-				{ width: 1440, height: 900 }
-			)
-		).toBe('right');
-	});
+    it('keeps the configured placement for a normal-sized target', () => {
+        expect(effectivePlacement('right', { width: 300, height: 400 }, { width: 1440, height: 900 })).toBe('right');
+    });
 
-	it('centers the tooltip when the target dominates the viewport', () => {
-		expect(
-			effectivePlacement(
-				'right',
-				{ width: 390, height: 700 },
-				{ width: 390, height: 844 }
-			)
-		).toBe('center');
-	});
+    it('centers the tooltip when the target dominates the viewport', () => {
+        expect(effectivePlacement('right', { width: 390, height: 700 }, { width: 390, height: 844 })).toBe('center');
+    });
 
-	it('keeps center as center', () => {
-		expect(
-			effectivePlacement(
-				'center',
-				{ width: 100, height: 100 },
-				{ width: 1440, height: 900 }
-			)
-		).toBe('center');
-	});
+    it('keeps center as center', () => {
+        expect(effectivePlacement('center', { width: 100, height: 100 }, { width: 1440, height: 900 })).toBe('center');
+    });
 });

--- a/src/components/productTour/tourEngine.test.ts
+++ b/src/components/productTour/tourEngine.test.ts
@@ -213,3 +213,60 @@ describe('effectivePlacement', () => {
         expect(effectivePlacement('center', { width: 100, height: 100 }, { width: 1440, height: 900 })).toBe('center');
     });
 });
+
+describe('reduceTourCallback target_missing direction', () => {
+    const cb = (over: Record<string, any>) => ({
+        action: ACTIONS.UPDATE,
+        index: 0,
+        status: STATUS.RUNNING,
+        type: EVENTS.TOOLTIP,
+        ...over,
+    });
+
+    it('moves backward when the missing target was reached via prev', () => {
+        const { state, events } = reduceTourCallback(
+            { status: 'in_progress', stepIndex: 2, run: true },
+            cb({
+                type: EVENTS.TARGET_NOT_FOUND,
+                action: ACTIONS.PREV,
+                index: 2,
+            }),
+            5,
+        );
+
+        expect(events).toContain('target_missing');
+        expect(state.stepIndex).toBe(1);
+        expect(state.run).toBe(true);
+    });
+
+    it('closes without terminal status when prev hits a missing first step', () => {
+        const { state } = reduceTourCallback(
+            { status: 'in_progress', stepIndex: 0, run: true },
+            cb({
+                type: EVENTS.TARGET_NOT_FOUND,
+                action: ACTIONS.PREV,
+                index: 0,
+            }),
+            5,
+        );
+
+        expect(state.run).toBe(false);
+        expect(state.status).toBe('in_progress');
+    });
+});
+
+describe('effectivePlacement axis-specific coverage', () => {
+    it('centers a side placement when the target spans the viewport width', () => {
+        // Full-width, half-height list on mobile: no horizontal space for a
+        // right-anchored tooltip even though total area coverage is < 0.6.
+        expect(effectivePlacement('right', { width: 390, height: 400 }, { width: 390, height: 844 })).toBe('center');
+    });
+
+    it('keeps a bottom placement for a wide but flat target', () => {
+        expect(effectivePlacement('bottom', { width: 390, height: 120 }, { width: 390, height: 844 })).toBe('bottom');
+    });
+
+    it('centers a bottom placement when the target spans the viewport height', () => {
+        expect(effectivePlacement('bottom', { width: 200, height: 820 }, { width: 390, height: 844 })).toBe('center');
+    });
+});

--- a/src/components/productTour/tourEngine.ts
+++ b/src/components/productTour/tourEngine.ts
@@ -26,10 +26,19 @@ export const effectivePlacement = (
     if (!targetRect || placement === 'center') {
         return placement;
     }
-    const coverage =
-        (Math.min(targetRect.width, viewport.width) * Math.min(targetRect.height, viewport.height)) /
-        (viewport.width * viewport.height);
-    return coverage >= 0.6 ? 'center' : placement;
+    const widthCoverage = Math.min(targetRect.width, viewport.width) / viewport.width;
+    const heightCoverage = Math.min(targetRect.height, viewport.height) / viewport.height;
+    // A side placement needs horizontal room, top/bottom need vertical room;
+    // 'auto' can use whichever axis still has space.
+    let coverage;
+    if (placement === 'left' || placement === 'right') {
+        coverage = widthCoverage;
+    } else if (placement === 'top' || placement === 'bottom') {
+        coverage = heightCoverage;
+    } else {
+        coverage = Math.min(widthCoverage, heightCoverage);
+    }
+    return coverage >= 0.85 ? 'center' : placement;
 };
 
 export interface TourRunState {
@@ -82,10 +91,14 @@ export const reduceTourCallback = (state: TourRunState, cb: TourCallbackInput, s
 
     if (cb.type === EVENTS.TARGET_NOT_FOUND) {
         events.push('target_missing');
-        if (isLastStep) {
+        const direction = cb.action === ACTIONS.PREV ? -1 : 1;
+        const nextIndex = cb.index + direction;
+        if (nextIndex < 0 || nextIndex >= stepCount) {
+            // No presentable step in that direction: close without a terminal
+            // status so the tour stays resumable.
             next.run = false;
         } else {
-            next.stepIndex = cb.index + 1;
+            next.stepIndex = nextIndex;
         }
         return { state: next, events };
     }

--- a/src/components/productTour/tourEngine.ts
+++ b/src/components/productTour/tourEngine.ts
@@ -2,17 +2,16 @@ import { ACTIONS, EVENTS, STATUS } from 'react-joyride';
 import type { Step } from 'react-joyride';
 import type { TourEvent, TourStatus, TourStep } from './types';
 
-export const tourTargetSelector = (target: string) =>
-	`[data-tour-target="${target}"]`;
+export const tourTargetSelector = (target: string) => `[data-tour-target="${target}"]`;
 
 export const mapStepsToJoyride = (steps: TourStep[]): Step[] =>
-	steps.map((step) => ({
-		id: step.id,
-		target: step.target ? tourTargetSelector(step.target) : 'body',
-		placement: step.placement ?? (step.target ? 'bottom' : 'center'),
-		title: step.titleKey,
-		content: step.contentKey
-	}));
+    steps.map((step) => ({
+        id: step.id,
+        target: step.target ? tourTargetSelector(step.target) : 'body',
+        placement: step.placement ?? (step.target ? 'bottom' : 'center'),
+        title: step.titleKey,
+        content: step.contentKey,
+    }));
 
 /**
  * A side placement is meaningless when the target effectively fills the
@@ -20,43 +19,42 @@ export const mapStepsToJoyride = (steps: TourStep[]): Step[] =>
  * positioned off-screen. Fall back to a centered overlay in that case.
  */
 export const effectivePlacement = (
-	placement: TourStep['placement'],
-	targetRect: { width: number; height: number } | null,
-	viewport: { width: number; height: number }
+    placement: TourStep['placement'],
+    targetRect: { width: number; height: number } | null,
+    viewport: { width: number; height: number },
 ): TourStep['placement'] => {
-	if (!targetRect || placement === 'center') {
-		return placement;
-	}
-	const coverage =
-		(Math.min(targetRect.width, viewport.width) *
-			Math.min(targetRect.height, viewport.height)) /
-		(viewport.width * viewport.height);
-	return coverage >= 0.6 ? 'center' : placement;
+    if (!targetRect || placement === 'center') {
+        return placement;
+    }
+    const coverage =
+        (Math.min(targetRect.width, viewport.width) * Math.min(targetRect.height, viewport.height)) /
+        (viewport.width * viewport.height);
+    return coverage >= 0.6 ? 'center' : placement;
 };
 
 export interface TourRunState {
-	status: TourStatus;
-	stepIndex: number;
-	run: boolean;
+    status: TourStatus;
+    stepIndex: number;
+    run: boolean;
 }
 
 export const initialTourRunState: TourRunState = {
-	status: 'not_started',
-	stepIndex: 0,
-	run: false
+    status: 'not_started',
+    stepIndex: 0,
+    run: false,
 };
 
 /** The subset of Joyride's CallBackProps the reducer consumes. */
 export interface TourCallbackInput {
-	action: string;
-	index: number;
-	status: string;
-	type: string;
+    action: string;
+    index: number;
+    status: string;
+    type: string;
 }
 
 export interface TourReduction {
-	state: TourRunState;
-	events: TourEvent[];
+    state: TourRunState;
+    events: TourEvent[];
 }
 
 /**
@@ -65,76 +63,69 @@ export interface TourReduction {
  * reported as completion; a missing final target closes the tour without a
  * terminal status so it stays resumable.
  */
-export const reduceTourCallback = (
-	state: TourRunState,
-	cb: TourCallbackInput,
-	stepCount: number
-): TourReduction => {
-	const events: TourEvent[] = [];
-	let next = { ...state };
-	const isLastStep = cb.index >= stepCount - 1;
+export const reduceTourCallback = (state: TourRunState, cb: TourCallbackInput, stepCount: number): TourReduction => {
+    const events: TourEvent[] = [];
+    const next = { ...state };
+    const isLastStep = cb.index >= stepCount - 1;
 
-	if (cb.type === EVENTS.TOUR_START) {
-		next.status = 'in_progress';
-		next.run = true;
-		events.push('tour_started');
-		return { state: next, events };
-	}
+    if (cb.type === EVENTS.TOUR_START) {
+        next.status = 'in_progress';
+        next.run = true;
+        events.push('tour_started');
+        return { state: next, events };
+    }
 
-	if (cb.type === EVENTS.TOOLTIP) {
-		events.push('step_viewed');
-		return { state: next, events };
-	}
+    if (cb.type === EVENTS.TOOLTIP) {
+        events.push('step_viewed');
+        return { state: next, events };
+    }
 
-	if (cb.type === EVENTS.TARGET_NOT_FOUND) {
-		events.push('target_missing');
-		if (isLastStep) {
-			next.run = false;
-		} else {
-			next.stepIndex = cb.index + 1;
-		}
-		return { state: next, events };
-	}
+    if (cb.type === EVENTS.TARGET_NOT_FOUND) {
+        events.push('target_missing');
+        if (isLastStep) {
+            next.run = false;
+        } else {
+            next.stepIndex = cb.index + 1;
+        }
+        return { state: next, events };
+    }
 
-	if (cb.type === EVENTS.STEP_AFTER) {
-		if (cb.action === ACTIONS.CLOSE) {
-			next.run = false;
-			next.status = 'skipped';
-			events.push('tour_skipped');
-			return { state: next, events };
-		}
-		if (cb.action === ACTIONS.PREV) {
-			next.stepIndex = Math.max(0, cb.index - 1);
-			return { state: next, events };
-		}
-		if (cb.action === ACTIONS.NEXT) {
-			events.push('step_completed');
-			if (isLastStep) {
-				next.run = false;
-				next.status = 'completed';
-				events.push('tour_completed');
-			} else {
-				next.stepIndex = cb.index + 1;
-			}
-			return { state: next, events };
-		}
-	}
+    if (cb.type === EVENTS.STEP_AFTER) {
+        if (cb.action === ACTIONS.CLOSE) {
+            next.run = false;
+            next.status = 'skipped';
+            events.push('tour_skipped');
+            return { state: next, events };
+        }
+        if (cb.action === ACTIONS.PREV) {
+            next.stepIndex = Math.max(0, cb.index - 1);
+            return { state: next, events };
+        }
+        if (cb.action === ACTIONS.NEXT) {
+            events.push('step_completed');
+            if (isLastStep) {
+                next.run = false;
+                next.status = 'completed';
+                events.push('tour_completed');
+            } else {
+                next.stepIndex = cb.index + 1;
+            }
+            return { state: next, events };
+        }
+    }
 
-	if (cb.type === EVENTS.TOUR_END) {
-		if (cb.status === STATUS.SKIPPED && state.status !== 'completed') {
-			next.run = false;
-			next.status = 'skipped';
-			events.push('tour_skipped');
-		} else if (
-			cb.status === STATUS.FINISHED &&
-			state.status !== 'completed'
-		) {
-			next.run = false;
-			next.status = 'completed';
-			events.push('tour_completed');
-		}
-		return { state: next, events };
-	}
+    if (cb.type === EVENTS.TOUR_END) {
+        if (cb.status === STATUS.SKIPPED && state.status !== 'completed') {
+            next.run = false;
+            next.status = 'skipped';
+            events.push('tour_skipped');
+        } else if (cb.status === STATUS.FINISHED && state.status !== 'completed') {
+            next.run = false;
+            next.status = 'completed';
+            events.push('tour_completed');
+        }
+        return { state: next, events };
+    }
 
-	return { state: next, events };
+    return { state: next, events };
 };

--- a/src/components/productTour/tourEngine.ts
+++ b/src/components/productTour/tourEngine.ts
@@ -1,0 +1,140 @@
+import { ACTIONS, EVENTS, STATUS } from 'react-joyride';
+import type { Step } from 'react-joyride';
+import type { TourEvent, TourStatus, TourStep } from './types';
+
+export const tourTargetSelector = (target: string) =>
+	`[data-tour-target="${target}"]`;
+
+export const mapStepsToJoyride = (steps: TourStep[]): Step[] =>
+	steps.map((step) => ({
+		id: step.id,
+		target: step.target ? tourTargetSelector(step.target) : 'body',
+		placement: step.placement ?? (step.target ? 'bottom' : 'center'),
+		title: step.titleKey,
+		content: step.contentKey
+	}));
+
+/**
+ * A side placement is meaningless when the target effectively fills the
+ * viewport (e.g. the session list column on mobile) — the tooltip would be
+ * positioned off-screen. Fall back to a centered overlay in that case.
+ */
+export const effectivePlacement = (
+	placement: TourStep['placement'],
+	targetRect: { width: number; height: number } | null,
+	viewport: { width: number; height: number }
+): TourStep['placement'] => {
+	if (!targetRect || placement === 'center') {
+		return placement;
+	}
+	const coverage =
+		(Math.min(targetRect.width, viewport.width) *
+			Math.min(targetRect.height, viewport.height)) /
+		(viewport.width * viewport.height);
+	return coverage >= 0.6 ? 'center' : placement;
+};
+
+export interface TourRunState {
+	status: TourStatus;
+	stepIndex: number;
+	run: boolean;
+}
+
+export const initialTourRunState: TourRunState = {
+	status: 'not_started',
+	stepIndex: 0,
+	run: false
+};
+
+/** The subset of Joyride's CallBackProps the reducer consumes. */
+export interface TourCallbackInput {
+	action: string;
+	index: number;
+	status: string;
+	type: string;
+}
+
+export interface TourReduction {
+	state: TourRunState;
+	events: TourEvent[];
+}
+
+/**
+ * Pure transition function from a Joyride callback to the next controlled
+ * run-state plus the domain events it implies. Closing or skipping is never
+ * reported as completion; a missing final target closes the tour without a
+ * terminal status so it stays resumable.
+ */
+export const reduceTourCallback = (
+	state: TourRunState,
+	cb: TourCallbackInput,
+	stepCount: number
+): TourReduction => {
+	const events: TourEvent[] = [];
+	let next = { ...state };
+	const isLastStep = cb.index >= stepCount - 1;
+
+	if (cb.type === EVENTS.TOUR_START) {
+		next.status = 'in_progress';
+		next.run = true;
+		events.push('tour_started');
+		return { state: next, events };
+	}
+
+	if (cb.type === EVENTS.TOOLTIP) {
+		events.push('step_viewed');
+		return { state: next, events };
+	}
+
+	if (cb.type === EVENTS.TARGET_NOT_FOUND) {
+		events.push('target_missing');
+		if (isLastStep) {
+			next.run = false;
+		} else {
+			next.stepIndex = cb.index + 1;
+		}
+		return { state: next, events };
+	}
+
+	if (cb.type === EVENTS.STEP_AFTER) {
+		if (cb.action === ACTIONS.CLOSE) {
+			next.run = false;
+			next.status = 'skipped';
+			events.push('tour_skipped');
+			return { state: next, events };
+		}
+		if (cb.action === ACTIONS.PREV) {
+			next.stepIndex = Math.max(0, cb.index - 1);
+			return { state: next, events };
+		}
+		if (cb.action === ACTIONS.NEXT) {
+			events.push('step_completed');
+			if (isLastStep) {
+				next.run = false;
+				next.status = 'completed';
+				events.push('tour_completed');
+			} else {
+				next.stepIndex = cb.index + 1;
+			}
+			return { state: next, events };
+		}
+	}
+
+	if (cb.type === EVENTS.TOUR_END) {
+		if (cb.status === STATUS.SKIPPED && state.status !== 'completed') {
+			next.run = false;
+			next.status = 'skipped';
+			events.push('tour_skipped');
+		} else if (
+			cb.status === STATUS.FINISHED &&
+			state.status !== 'completed'
+		) {
+			next.run = false;
+			next.status = 'completed';
+			events.push('tour_completed');
+		}
+		return { state: next, events };
+	}
+
+	return { state: next, events };
+};

--- a/src/components/productTour/tourProgressRepository.test.ts
+++ b/src/components/productTour/tourProgressRepository.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { inMemoryTourProgressRepository } from './tourProgressRepository';
+import type { TourProgress } from './types';
+
+const progress = (over: Partial<TourProgress> = {}): TourProgress => ({
+    tourId: 'admin-tour',
+    tourVersion: 1,
+    status: 'in_progress',
+    ...over,
+});
+
+describe('inMemoryTourProgressRepository', () => {
+    it('stores and returns progress per tour id and version', async () => {
+        const repo = inMemoryTourProgressRepository();
+
+        await repo.saveProgress(progress({ status: 'completed' }));
+
+        expect(await repo.getProgress('admin-tour', 1)).toMatchObject({
+            status: 'completed',
+        });
+    });
+
+    it('scopes progress by tour version', async () => {
+        const repo = inMemoryTourProgressRepository();
+
+        await repo.saveProgress(progress({ status: 'completed' }));
+
+        expect(await repo.getProgress('admin-tour', 2)).toBeNull();
+    });
+
+    it('overwrites earlier progress for the same scope', async () => {
+        const repo = inMemoryTourProgressRepository();
+
+        await repo.saveProgress(progress({ status: 'in_progress' }));
+        await repo.saveProgress(progress({ status: 'skipped' }));
+
+        expect(await repo.getProgress('admin-tour', 1)).toMatchObject({
+            status: 'skipped',
+        });
+    });
+});

--- a/src/components/productTour/tourProgressRepository.ts
+++ b/src/components/productTour/tourProgressRepository.ts
@@ -22,10 +22,7 @@ export const inMemoryTourProgressRepository = (): TourProgressRepository => {
         async saveProgress(progress: TourProgress): Promise<void> {
             store.set(key(progress.tourId, progress.tourVersion), progress);
         },
-        async getProgress(
-            tourId: string,
-            tourVersion: number
-        ): Promise<TourProgress | null> {
+        async getProgress(tourId: string, tourVersion: number): Promise<TourProgress | null> {
             return store.get(key(tourId, tourVersion)) ?? null;
         },
     };

--- a/src/components/productTour/tourProgressRepository.ts
+++ b/src/components/productTour/tourProgressRepository.ts
@@ -1,0 +1,32 @@
+import type { TourProgress } from './types';
+
+export interface TourProgressRepository {
+    /**
+     * Persists tour progress. Rejects on write failure so callers never
+     * report a completion the server has not accepted.
+     */
+    saveProgress(progress: TourProgress): Promise<void>;
+    getProgress(tourId: string, tourVersion: number): Promise<TourProgress | null>;
+}
+
+/**
+ * Session-local repository used by Storybook and tests until the versioned
+ * UserService progress API lands (epic packages TOUR-03/TOUR-05). Progress is
+ * keyed by tour id + version — a newer tour version is a fresh scope.
+ */
+export const inMemoryTourProgressRepository = (): TourProgressRepository => {
+    const store = new Map<string, TourProgress>();
+    const key = (tourId: string, tourVersion: number) => `${tourId}@${tourVersion}`;
+
+    return {
+        async saveProgress(progress: TourProgress): Promise<void> {
+            store.set(key(progress.tourId, progress.tourVersion), progress);
+        },
+        async getProgress(
+            tourId: string,
+            tourVersion: number
+        ): Promise<TourProgress | null> {
+            return store.get(key(tourId, tourVersion)) ?? null;
+        },
+    };
+};

--- a/src/components/productTour/types.ts
+++ b/src/components/productTour/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared ORISO product-tour domain contract.
+ *
+ * The same names and semantics are implemented app-locally in ORISO-Frontend
+ * and ORISO-Admin (design: 0 - Docs/plans/2026-07-18-react-joyride-product-tours-design.md).
+ * Definitions carry i18n keys and behavior metadata only — never rendered text.
+ */
+
+export type TourAudience =
+	| 'asker'
+	| 'consultant'
+	| 'agency_admin'
+	| 'tenant_admin'
+	| 'platform_admin';
+
+export type TourStatus =
+	| 'not_started'
+	| 'in_progress'
+	| 'completed'
+	| 'skipped';
+
+export type TourPlacement =
+	| 'auto'
+	| 'center'
+	| 'top'
+	| 'bottom'
+	| 'left'
+	| 'right';
+
+export interface TourStep {
+	id: string;
+	/** Route to navigate to before showing this step; relative app path. */
+	route?: string;
+	/**
+	 * Semantic target name resolved as `[data-tour-target="<name>"]`.
+	 * Empty string means a centered step without a page target.
+	 */
+	target: string;
+	titleKey: string;
+	contentKey: string;
+	placement?: TourPlacement;
+}
+
+export interface TourDefinition {
+	id: string;
+	version: number;
+	surface: 'frontend' | 'admin';
+	audiences: TourAudience[];
+	titleKey: string;
+	summaryKey: string;
+	steps: TourStep[];
+}
+
+export interface TourProgress {
+	tourId: string;
+	tourVersion: number;
+	status: TourStatus;
+	currentStepId?: string;
+	startedAt?: string;
+	completedAt?: string;
+}
+
+export type TourEvent =
+	| 'tour_started'
+	| 'step_viewed'
+	| 'step_completed'
+	| 'tour_skipped'
+	| 'tour_completed'
+	| 'tour_restarted'
+	| 'target_missing';

--- a/src/components/productTour/types.ts
+++ b/src/components/productTour/types.ts
@@ -6,65 +6,50 @@
  * Definitions carry i18n keys and behavior metadata only — never rendered text.
  */
 
-export type TourAudience =
-	| 'asker'
-	| 'consultant'
-	| 'agency_admin'
-	| 'tenant_admin'
-	| 'platform_admin';
+export type TourAudience = 'asker' | 'consultant' | 'agency_admin' | 'tenant_admin' | 'platform_admin';
 
-export type TourStatus =
-	| 'not_started'
-	| 'in_progress'
-	| 'completed'
-	| 'skipped';
+export type TourStatus = 'not_started' | 'in_progress' | 'completed' | 'skipped';
 
-export type TourPlacement =
-	| 'auto'
-	| 'center'
-	| 'top'
-	| 'bottom'
-	| 'left'
-	| 'right';
+export type TourPlacement = 'auto' | 'center' | 'top' | 'bottom' | 'left' | 'right';
 
 export interface TourStep {
-	id: string;
-	/** Route to navigate to before showing this step; relative app path. */
-	route?: string;
-	/**
-	 * Semantic target name resolved as `[data-tour-target="<name>"]`.
-	 * Empty string means a centered step without a page target.
-	 */
-	target: string;
-	titleKey: string;
-	contentKey: string;
-	placement?: TourPlacement;
+    id: string;
+    /** Route to navigate to before showing this step; relative app path. */
+    route?: string;
+    /**
+     * Semantic target name resolved as `[data-tour-target="<name>"]`.
+     * Empty string means a centered step without a page target.
+     */
+    target: string;
+    titleKey: string;
+    contentKey: string;
+    placement?: TourPlacement;
 }
 
 export interface TourDefinition {
-	id: string;
-	version: number;
-	surface: 'frontend' | 'admin';
-	audiences: TourAudience[];
-	titleKey: string;
-	summaryKey: string;
-	steps: TourStep[];
+    id: string;
+    version: number;
+    surface: 'frontend' | 'admin';
+    audiences: TourAudience[];
+    titleKey: string;
+    summaryKey: string;
+    steps: TourStep[];
 }
 
 export interface TourProgress {
-	tourId: string;
-	tourVersion: number;
-	status: TourStatus;
-	currentStepId?: string;
-	startedAt?: string;
-	completedAt?: string;
+    tourId: string;
+    tourVersion: number;
+    status: TourStatus;
+    currentStepId?: string;
+    startedAt?: string;
+    completedAt?: string;
 }
 
 export type TourEvent =
-	| 'tour_started'
-	| 'step_viewed'
-	| 'step_completed'
-	| 'tour_skipped'
-	| 'tour_completed'
-	| 'tour_restarted'
-	| 'target_missing';
+    | 'tour_started'
+    | 'step_viewed'
+    | 'step_completed'
+    | 'tour_skipped'
+    | 'tour_completed'
+    | 'tour_restarted'
+    | 'target_missing';

--- a/src/components/productTour/types.ts
+++ b/src/components/productTour/types.ts
@@ -42,6 +42,11 @@ export interface TourProgress {
     status: TourStatus;
     currentStepId?: string;
     startedAt?: string;
+    /**
+     * Timestamp of reaching a terminal status — set for BOTH 'completed' and
+     * 'skipped'. `status` is the single source of truth for the outcome;
+     * consumers must never infer completion from this field alone.
+     */
     completedAt?: string;
 }
 

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1346,5 +1346,17 @@
     "pillSelect.toggleOptions": "Optionen für {{label}} anzeigen",
     "tenants.permissions.feature.mediaUpload": "Medien-Upload",
     "tenants.permissions.feature.mediaInlineDisplay": "Medien-Vorschau (Inline-Anzeige)",
-    "tenants.permissions.feature.mediaAiScan": "KI-Bildprüfung"
+    "tenants.permissions.feature.mediaAiScan": "KI-Bildprüfung",
+    "productTour.next": "Weiter",
+    "productTour.back": "Zurück",
+    "productTour.done": "Fertig",
+    "productTour.step": "Schritt",
+    "productTour.of": "von",
+    "productTour.close": "Tour schließen",
+    "productTour.adminTour.title": "Admin-Rundgang",
+    "productTour.adminTour.summary": "Lernen Sie die wichtigsten Bereiche der Verwaltung kennen.",
+    "productTour.adminTour.welcome.title": "Willkommen",
+    "productTour.adminTour.welcome.content": "Diese kurze Tour zeigt Ihnen die wichtigsten Bereiche der Verwaltungsoberfläche. <br /><br /> Sie können sie jederzeit schließen.",
+    "productTour.adminTour.navigation.title": "Navigation",
+    "productTour.adminTour.navigation.content": "Über die Seitenleiste erreichen Sie alle Verwaltungsbereiche."
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1346,5 +1346,17 @@
     "pillSelect.toggleOptions": "Show options for {{label}}",
     "tenants.permissions.feature.mediaUpload": "Media upload",
     "tenants.permissions.feature.mediaInlineDisplay": "Media preview (inline display)",
-    "tenants.permissions.feature.mediaAiScan": "AI media check"
+    "tenants.permissions.feature.mediaAiScan": "AI media check",
+    "productTour.next": "Next",
+    "productTour.back": "Back",
+    "productTour.done": "Done",
+    "productTour.step": "Step",
+    "productTour.of": "of",
+    "productTour.close": "Close tour",
+    "productTour.adminTour.title": "Admin tour",
+    "productTour.adminTour.summary": "Get to know the most important areas of the admin console.",
+    "productTour.adminTour.welcome.title": "Welcome",
+    "productTour.adminTour.welcome.content": "This short tour shows you the most important areas of the admin console. <br /><br /> You can close it at any time.",
+    "productTour.adminTour.navigation.title": "Navigation",
+    "productTour.adminTour.navigation.content": "The sidebar takes you to every admin area."
 }

--- a/src/styles/components/index.less
+++ b/src/styles/components/index.less
@@ -31,3 +31,4 @@
 @import 'statistic.less';
 @import 'emptyState.less';
 @import 'notification.less';
+@import 'productTour.less';

--- a/src/styles/components/productTour.less
+++ b/src/styles/components/productTour.less
@@ -9,10 +9,7 @@
     background-color: var(--m3-surface, #fcf9f9);
     color: var(--m3-on-surface, #1b1b1c);
     font-family: var(--m3-body-font-family, Inter, Arial, sans-serif);
-    box-shadow:
-        0 6px 16px 0 rgba(0, 0, 0, 0.08),
-        0 3px 6px -4px rgba(0, 0, 0, 0.12),
-        0 9px 28px 8px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 6px 16px 0 rgba(0, 0, 0, 0.08), 0 3px 6px -4px rgba(0, 0, 0, 0.12), 0 9px 28px 8px rgba(0, 0, 0, 0.05);
 
     &__header {
         display: flex;

--- a/src/styles/components/productTour.less
+++ b/src/styles/components/productTour.less
@@ -1,0 +1,119 @@
+.productTourTooltip {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    box-sizing: border-box;
+    width: min(400px, calc(100vw - 32px));
+    padding: 24px;
+    border-radius: 16px;
+    background-color: var(--m3-surface, #fcf9f9);
+    color: var(--m3-on-surface, #1b1b1c);
+    font-family: var(--m3-body-font-family, Inter, Arial, sans-serif);
+    box-shadow:
+        0 6px 16px 0 rgba(0, 0, 0, 0.08),
+        0 3px 6px -4px rgba(0, 0, 0, 0.12),
+        0 9px 28px 8px rgba(0, 0, 0, 0.05);
+
+    &__header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        column-gap: 16px;
+    }
+
+    &__title {
+        margin: 0;
+        font-size: 16px;
+        font-weight: 600;
+        color: var(--m3-on-surface, #1b1b1c);
+    }
+
+    &__close {
+        padding: 4px;
+        border: none;
+        border-radius: 50%;
+        appearance: none;
+        background: transparent;
+        cursor: pointer;
+        line-height: 0;
+        color: var(--m3-on-surface-variant, #444748);
+        font-size: 16px;
+
+        &:hover {
+            color: var(--m3-primary, #a5000a);
+        }
+
+        &:focus-visible {
+            outline: 2px solid var(--m3-primary, #a5000a);
+            outline-offset: 2px;
+        }
+    }
+
+    &__content {
+        font-size: 14px;
+        line-height: 22px;
+        overflow-wrap: anywhere;
+    }
+
+    &__actions {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 8px;
+
+        .button__wrapper {
+            flex: 1 1 auto;
+        }
+
+        .button__item {
+            width: 100%;
+            min-width: 0;
+        }
+    }
+
+    &__footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        column-gap: 16px;
+    }
+
+    &__progress {
+        font-size: 12px;
+        color: var(--m3-on-surface-variant, #444748);
+    }
+
+    &__bullets {
+        display: flex;
+        gap: 4px;
+    }
+
+    &__bullet {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background-color: var(--m3-surface-variant, #e1e3e3);
+
+        &--active {
+            background-color: var(--m3-primary, #a5000a);
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        transition: none;
+    }
+}
+
+@media (max-width: 520px) {
+    .productTourTooltip {
+        padding: 16px;
+
+        &__actions {
+            flex-direction: column-reverse;
+
+            .button__wrapper {
+                width: 100%;
+            }
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1213,6 +1213,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fastify/deepmerge@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz"
+  integrity sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==
+
 "@figspec/components@^2.0.1":
   version "2.1.0"
   resolved "https://registry.npmjs.org/@figspec/components/-/components-2.1.0.tgz"
@@ -1225,6 +1230,52 @@
   dependencies:
     "@figspec/components" "^2.0.1"
     "@lit-labs/react" "^2.0.0"
+
+"@floating-ui/core@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz"
+  integrity sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==
+  dependencies:
+    "@floating-ui/utils" "^0.2.12"
+
+"@floating-ui/dom@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz"
+  integrity sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==
+  dependencies:
+    "@floating-ui/core" "^1.8.0"
+    "@floating-ui/utils" "^0.2.12"
+
+"@floating-ui/react-dom@^2.1.8":
+  version "2.1.9"
+  resolved "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz"
+  integrity sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==
+  dependencies:
+    "@floating-ui/dom" "^1.8.0"
+
+"@floating-ui/utils@^0.2.12":
+  version "0.2.12"
+  resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz"
+  integrity sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==
+
+"@gilbarbara/deep-equal@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz"
+  integrity sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==
+
+"@gilbarbara/hooks@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz"
+  integrity sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==
+  dependencies:
+    "@gilbarbara/deep-equal" "^0.4.1"
+
+"@gilbarbara/types@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz"
+  integrity sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==
+  dependencies:
+    type-fest "^4.1.0"
 
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
@@ -2260,13 +2311,6 @@
   dependencies:
     "@tmcp/session-manager" "^0.2.2"
     esm-env "^1.2.2"
-
-"@tybys/wasm-util@^0.10.3":
-  version "0.10.3"
-  resolved "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz"
-  integrity sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==
-  dependencies:
-    tslib "^2.4.0"
 
 "@types/aria-query@^5.0.1":
   version "5.0.4"
@@ -5278,6 +5322,11 @@ is-installed-globally@~0.4.0:
     global-dirs "^3.0.0"
     is-path-inside "^3.0.2"
 
+is-lite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz"
+  integrity sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==
+
 is-map@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz"
@@ -7280,6 +7329,11 @@ react-i18next@^11.15.4:
     "@babel/runtime" "^7.14.5"
     html-parse-stringify "^3.0.1"
 
+react-innertext@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz"
+  integrity sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
@@ -7304,6 +7358,22 @@ react-is@^19.2.6:
   version "19.2.7"
   resolved "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz"
   integrity sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==
+
+react-joyride@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/react-joyride/-/react-joyride-3.2.0.tgz"
+  integrity sha512-UrA/XWdWElMLNnjZt2eWmPFmpHl1IZ2CeI9XhS+PuEVvfqHMD9U4tavCq1csDAGVoj0YEGfaCDmhZwgNc9yE2g==
+  dependencies:
+    "@fastify/deepmerge" "^3.2.1"
+    "@floating-ui/react-dom" "^2.1.8"
+    "@gilbarbara/deep-equal" "^0.4.1"
+    "@gilbarbara/hooks" "^0.11.0"
+    "@gilbarbara/types" "^0.2.2"
+    is-lite "^2.0.0"
+    react-innertext "^1.1.5"
+    scroll "^3.0.1"
+    scrollparent "^2.1.0"
+    use-sync-external-store "^1.6.0"
 
 react-resizable@^3.0.4:
   version "3.2.0"
@@ -7747,6 +7817,16 @@ scroll-into-view-if-needed@^3.1.0:
   integrity sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==
   dependencies:
     compute-scroll-into-view "^3.0.2"
+
+scroll@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz"
+  integrity sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==
+
+scrollparent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz"
+  integrity sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==
 
 semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
@@ -8640,11 +8720,6 @@ tslib@^2.0.3:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
-tslib@^2.4.0:
-  version "2.8.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz"
@@ -8690,6 +8765,11 @@ type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^4.1.0:
+  version "4.41.0"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
 type-fest@^5.5.0:
   version "5.8.0"
@@ -8866,7 +8946,7 @@ use-debounce@^8.0.4:
   resolved "https://registry.npmjs.org/use-debounce/-/use-debounce-8.0.4.tgz"
   integrity sha512-fGqsYQzl8kLHF2QpQSgIwgOgJmnh6j5L6SIzQiHdLfwp3q1egUL3btq5Bg2SJysH6A0ILLgT2IqXZKoNJr0nFw==
 
-use-sync-external-store@^1, use-sync-external-store@^1.5.0:
+use-sync-external-store@^1, use-sync-external-store@^1.5.0, use-sync-external-store@^1.6.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==


### PR DESCRIPTION
Closes #385

Part of epic OpenResilienceInitiative/ORISO-Frontend#521. Counterpart of the Frontend package OpenResilienceInitiative/ORISO-Frontend#524.

**Problem:** the admin console has a walkthrough config flag but no guided-tour runtime; the epic requires an Admin/M3 adapter sharing the Frontend's domain contract without a shared UI package.

**What changed**

- App-local product-tour domain contract (`types.ts`) + pure engine (`tourEngine.ts`: Joyride mapping, callback reducer, `effectivePlacement` viewport fallback) + bounded `waitForTarget`.
- `ProductTourAdapter`: controlled react-joyride@3.2.0 (`onEvent`/`controls` v3 API, `skipScroll`, `skipBeacon`, close = skip semantics).
- `ProductTourTooltip`: Admin/M3 tokens (`--m3-*`), admin Button styles, `productTour.less`.
- Flat `productTour.*` i18n keys (DE/EN); in-memory progress repository (server persistence follows in TOUR-03/05).
- 17 Storybook stories (same matrix names as Frontend) incl. representative protected-layout tour; `adminTours` stays empty — **no production tour is enabled**.

**Verification:** `npm run test` 806 passed (36 new, red-first TDD) · `npx eslint . --max-warnings=0` · `npx prettier . --check` · `npm run build` · Storybook a11y panel 0 violations (tooltip + adapter stories) · tour behavior clicked through in the running Storybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
