### PR TITLE
Image upload in the admin TipTap editors (WP-3b)

### DIFF
--- a/src/api/fetchData.test.ts
+++ b/src/api/fetchData.test.ts
@@ -32,7 +32,7 @@ vi.mock('antd', () => ({ message: { error: vi.fn() } }));
 vi.mock('i18next', () => ({ default: { resolvedLanguage: 'de', language: 'de', t: (key: unknown) => key } }));
 
 // eslint-disable-next-line import/first
-import { fetchData, FETCH_METHODS, FETCH_ERRORS } from './fetchData';
+import { fetchData, FETCH_METHODS, FETCH_ERRORS, FETCH_SUCCESS } from './fetchData';
 
 const response = (status: number, body: Record<string, unknown> = {}) => ({
     status,
@@ -139,6 +139,27 @@ describe('fetchData – self-healing 401 retry (logout-on-create fix)', () => {
             skipAuth: true,
         });
 
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves FormData bodies without forcing a JSON content type', async () => {
+        const body = new FormData();
+        body.append('file', new Blob(['image'], { type: 'image/png' }), 'image.png');
+        const fetchMock = vi.fn().mockImplementation((request: Request) => {
+            expect(request.body).not.toBeNull();
+            expect(request.headers.get('content-type')).toMatch(/^multipart\/form-data; boundary=/);
+            return Promise.resolve(response(201, { id: 'media-id' }));
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await fetchData({
+            url: 'https://api.test/service/tenantadmin/media',
+            method: FETCH_METHODS.POST,
+            bodyData: body,
+            responseHandling: [FETCH_ERRORS.CATCH_ALL_SILENT, FETCH_SUCCESS.CONTENT],
+        });
+
+        expect(result).toEqual({ id: 'media-id' });
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 

--- a/src/api/fetchData.ts
+++ b/src/api/fetchData.ts
@@ -65,7 +65,7 @@ interface FetchDataProps {
     url: string;
     method: string;
     headersData?: object;
-    bodyData?: string;
+    bodyData?: BodyInit;
     skipAuth?: boolean;
     responseHandling?: string[];
     timeout?: number;
@@ -107,10 +107,11 @@ const executeFetchData = (props: FetchDataProps): Promise<any> =>
 
         const normalizedLanguage = normalizeLanguage(i18next.resolvedLanguage || i18next.language) || DEFAULT_LANGUAGE;
 
+        const isMultipartBody = typeof FormData !== 'undefined' && props.bodyData instanceof FormData;
         const req = new Request(props.url, {
             method: props.method,
             headers: {
-                'Content-Type': 'application/json',
+                ...(isMultipartBody ? {} : { 'Content-Type': 'application/json' }),
                 'cache-control': 'no-cache',
                 'Accept-Language': normalizedLanguage,
                 ...authorization,

--- a/src/api/tenant/uploadTenantMedia.test.ts
+++ b/src/api/tenant/uploadTenantMedia.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../auth/auth', () => ({
+    getAccessTokenForRequests: () => 'test-token',
+    tryRefreshAccessToken: vi.fn(),
+}));
+
+import { uploadTenantMedia } from './uploadTenantMedia';
+
+const pngFile = () => new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], 'logo.png', { type: 'image/png' });
+
+describe('uploadTenantMedia', () => {
+    const fetchSpy = vi.fn();
+
+    beforeEach(() => {
+        vi.stubGlobal('fetch', fetchSpy);
+        fetchSpy.mockReset();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('posts the file as multipart form data with auth and without a JSON content type', async () => {
+        fetchSpy.mockResolvedValue(
+            new Response(JSON.stringify({ id: 'abc', url: '/media/abc', contentType: 'image/png' }), {
+                status: 201,
+            }),
+        );
+
+        const result = await uploadTenantMedia(pngFile());
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        expect(url).toContain('/service/tenantadmin/media');
+        expect(init.method).toBe('POST');
+        expect((init.headers as Record<string, string>).Authorization).toBe('Bearer test-token');
+        // the browser must set the multipart boundary itself — no explicit content type
+        expect(Object.keys(init.headers as Record<string, string>)).not.toContain('Content-Type');
+        expect(init.body).toBeInstanceOf(FormData);
+        expect((init.body as FormData).get('file')).toBeInstanceOf(File);
+        expect(result).toEqual({ id: 'abc', url: '/media/abc', contentType: 'image/png' });
+    });
+
+    it('rejects when the server responds with an error status', async () => {
+        fetchSpy.mockResolvedValue(new Response('nope', { status: 400 }));
+
+        await expect(uploadTenantMedia(pngFile())).rejects.toThrow();
+    });
+});

--- a/src/api/tenant/uploadTenantMedia.test.ts
+++ b/src/api/tenant/uploadTenantMedia.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const authMocks = vi.hoisted(() => ({ tryRefreshAccessToken: vi.fn() }));
+
 vi.mock('../auth/auth', () => ({
     getAccessTokenForRequests: () => 'test-token',
-    tryRefreshAccessToken: vi.fn(),
+    tryRefreshAccessToken: authMocks.tryRefreshAccessToken,
 }));
 
 import { uploadTenantMedia } from './uploadTenantMedia';
@@ -15,6 +17,7 @@ describe('uploadTenantMedia', () => {
     beforeEach(() => {
         vi.stubGlobal('fetch', fetchSpy);
         fetchSpy.mockReset();
+        authMocks.tryRefreshAccessToken.mockReset();
     });
 
     afterEach(() => {
@@ -31,14 +34,11 @@ describe('uploadTenantMedia', () => {
         const result = await uploadTenantMedia(pngFile());
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
-        const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-        expect(url).toContain('/service/tenantadmin/media');
-        expect(init.method).toBe('POST');
-        expect((init.headers as Record<string, string>).Authorization).toBe('Bearer test-token');
-        // the browser must set the multipart boundary itself — no explicit content type
-        expect(Object.keys(init.headers as Record<string, string>)).not.toContain('Content-Type');
-        expect(init.body).toBeInstanceOf(FormData);
-        expect((init.body as FormData).get('file')).toBeInstanceOf(File);
+        const request = fetchSpy.mock.calls[0][0] as Request;
+        expect(request.url).toContain('/service/tenantadmin/media');
+        expect(request.method).toBe('POST');
+        expect(request.headers.get('Authorization')).toBe('Bearer test-token');
+        expect(request.headers.get('Content-Type')).toMatch(/^multipart\/form-data; boundary=/);
         expect(result).toEqual({ id: 'abc', url: '/media/abc', contentType: 'image/png' });
     });
 
@@ -46,5 +46,21 @@ describe('uploadTenantMedia', () => {
         fetchSpy.mockResolvedValue(new Response('nope', { status: 400 }));
 
         await expect(uploadTenantMedia(pngFile())).rejects.toThrow();
+    });
+
+    it('refreshes an expired access token and retries the multipart upload once', async () => {
+        fetchSpy
+            .mockResolvedValueOnce(new Response(null, { status: 401 }))
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ id: 'abc', url: '/media/abc', contentType: 'image/png' }), {
+                    status: 201,
+                }),
+            );
+        authMocks.tryRefreshAccessToken.mockResolvedValue(true);
+
+        await expect(uploadTenantMedia(pngFile())).resolves.toMatchObject({ id: 'abc' });
+
+        expect(authMocks.tryRefreshAccessToken).toHaveBeenCalledTimes(1);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/api/tenant/uploadTenantMedia.test.ts
+++ b/src/api/tenant/uploadTenantMedia.test.ts
@@ -49,13 +49,11 @@ describe('uploadTenantMedia', () => {
     });
 
     it('refreshes an expired access token and retries the multipart upload once', async () => {
-        fetchSpy
-            .mockResolvedValueOnce(new Response(null, { status: 401 }))
-            .mockResolvedValueOnce(
-                new Response(JSON.stringify({ id: 'abc', url: '/media/abc', contentType: 'image/png' }), {
-                    status: 201,
-                }),
-            );
+        fetchSpy.mockResolvedValueOnce(new Response(null, { status: 401 })).mockResolvedValueOnce(
+            new Response(JSON.stringify({ id: 'abc', url: '/media/abc', contentType: 'image/png' }), {
+                status: 201,
+            }),
+        );
         authMocks.tryRefreshAccessToken.mockResolvedValue(true);
 
         await expect(uploadTenantMedia(pngFile())).resolves.toMatchObject({ id: 'abc' });

--- a/src/api/tenant/uploadTenantMedia.ts
+++ b/src/api/tenant/uploadTenantMedia.ts
@@ -1,0 +1,33 @@
+import { tenantAdminEndpoint } from '../../appConfig';
+import { getAccessTokenForRequests } from '../auth/auth';
+import generateCsrfToken from '../../utils/generateCsrfToken';
+
+export interface TenantMediaResponse {
+    id: string;
+    url: string;
+    contentType: string;
+}
+
+/**
+ * Uploads an editor image to the tenant media endpoint (WP-3a, TenantService#92).
+ * Deliberately not routed through `fetchData`: multipart bodies must let the browser
+ * set the boundary content type, which fetchData hardwires to application/json.
+ */
+export const uploadTenantMedia = async (file: File): Promise<TenantMediaResponse> => {
+    const body = new FormData();
+    body.append('file', file, file.name);
+
+    const response = await fetch(`${tenantAdminEndpoint}/media`, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${getAccessTokenForRequests()}`,
+            'X-CSRF-TOKEN': generateCsrfToken(),
+        },
+        credentials: 'include',
+        body,
+    });
+    if (!response.ok) {
+        throw new Error(`media upload failed with status ${response.status}`);
+    }
+    return response.json();
+};

--- a/src/api/tenant/uploadTenantMedia.ts
+++ b/src/api/tenant/uploadTenantMedia.ts
@@ -1,6 +1,5 @@
 import { tenantAdminEndpoint } from '../../appConfig';
-import { getAccessTokenForRequests } from '../auth/auth';
-import generateCsrfToken from '../../utils/generateCsrfToken';
+import { FETCH_ERRORS, FETCH_METHODS, FETCH_SUCCESS, fetchData } from '../fetchData';
 
 export interface TenantMediaResponse {
     id: string;
@@ -10,24 +9,17 @@ export interface TenantMediaResponse {
 
 /**
  * Uploads an editor image to the tenant media endpoint (WP-3a, TenantService#92).
- * Deliberately not routed through `fetchData`: multipart bodies must let the browser
- * set the boundary content type, which fetchData hardwires to application/json.
+ * `fetchData` keeps auth refresh/logout behavior consistent with the other Admin APIs
+ * while omitting its JSON content type for FormData so the browser owns the boundary.
  */
 export const uploadTenantMedia = async (file: File): Promise<TenantMediaResponse> => {
     const body = new FormData();
     body.append('file', file, file.name);
 
-    const response = await fetch(`${tenantAdminEndpoint}/media`, {
-        method: 'POST',
-        headers: {
-            Authorization: `Bearer ${getAccessTokenForRequests()}`,
-            'X-CSRF-TOKEN': generateCsrfToken(),
-        },
-        credentials: 'include',
-        body,
+    return fetchData({
+        url: `${tenantAdminEndpoint}/media`,
+        method: FETCH_METHODS.POST,
+        bodyData: body,
+        responseHandling: [FETCH_ERRORS.CATCH_ALL_SILENT, FETCH_SUCCESS.CONTENT],
     });
-    if (!response.ok) {
-        throw new Error(`media upload failed with status ${response.status}`);
-    }
-    return response.json();
 };

--- a/src/components/FormPluginEditor/EditorImageUpload.stories.tsx
+++ b/src/components/FormPluginEditor/EditorImageUpload.stories.tsx
@@ -20,7 +20,7 @@ const pngFile = () => {
 };
 
 const pasteImageIntoEditor = async (canvasElement: HTMLElement) => {
-    const editorEl = canvasElement.querySelector('[contenteditable="true"]');
+    const editorEl = within(canvasElement).getByRole('textbox', { name: 'Impressum' });
     // A real DataTransfer: the browser's ClipboardEvent constructor rejects plain objects.
     const clipboardData = new DataTransfer();
     clipboardData.items.add(pngFile());
@@ -98,9 +98,7 @@ export const UploadError: Story = {
     },
     play: async ({ canvasElement }) => {
         await pasteImageIntoEditor(canvasElement);
-        await waitFor(() => {
-            expect(document.body.textContent).toMatch(/upload failed|Upload fehlgeschlagen/i);
-        });
+        expect(await within(document.body).findByText(/upload failed|Upload fehlgeschlagen/i)).toBeTruthy();
         expect(canvasElement.querySelector('img')).toBeFalsy();
     },
 };

--- a/src/components/FormPluginEditor/EditorImageUpload.stories.tsx
+++ b/src/components/FormPluginEditor/EditorImageUpload.stories.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+// eslint-disable-next-line import/no-unresolved -- SB10 subpath export, invisible to the eslint import resolver
+import { expect, waitFor, within } from 'storybook/test';
+import { delay, http, HttpResponse } from 'msw';
+import { M3RichTextEditor } from './M3RichTextEditor';
+
+// WP-3b (epic ORISO-Admin#366): image upload in the admin TipTap editor. The
+// image button opens a file picker; dropping or pasting an image uploads it to
+// the tenant media endpoint and inserts the served /media/{id} url.
+const MEDIA_UPLOAD = '*/service/tenantadmin/media';
+
+// 120x72 solid-red PNG so the inserted image is clearly visible without a backend.
+const PNG_DATA_URL =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAABICAYAAAA9HjF/AAAAwElEQVR4nO3RsQkAIBDAwK/dfwXn1DGEeMX1gcyedeia1wEYjMEY/CmD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjO4DiD4wyOMzjuAl4Hs8nHnWSXAAAAAElFTkSuQmCC';
+
+const pngFile = () => {
+    const bytes = Uint8Array.from(atob(PNG_DATA_URL.split(',')[1]), (c) => c.charCodeAt(0));
+    return new File([bytes], 'pasted.png', { type: 'image/png' });
+};
+
+const pasteImageIntoEditor = async (canvasElement: HTMLElement) => {
+    const editorEl = canvasElement.querySelector('[contenteditable="true"]');
+    // A real DataTransfer: the browser's ClipboardEvent constructor rejects plain objects.
+    const clipboardData = new DataTransfer();
+    clipboardData.items.add(pngFile());
+    editorEl.dispatchEvent(new ClipboardEvent('paste', { clipboardData, bubbles: true, cancelable: true }));
+};
+
+const ControlledEditor = (args: Parameters<typeof M3RichTextEditor>[0]) => {
+    const [value, setValue] = useState(args.value ?? '');
+    return <M3RichTextEditor {...args} value={value} onChange={setValue} />;
+};
+
+const meta = {
+    title: 'Organisms/M3 Rich Text Editor/ImageUpload',
+    component: M3RichTextEditor,
+    parameters: { layout: 'centered' },
+    args: {
+        title: 'Impressum',
+        value: '<p>Text vor dem Bild.</p>',
+        onPublish: () => undefined,
+        onSaveDraft: () => undefined,
+    },
+    render: (args) => <ControlledEditor {...args} />,
+} satisfies Meta<typeof M3RichTextEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Pasting an image uploads it and inserts the served /media/{id} url. */
+export const UploadInserted: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.post(MEDIA_UPLOAD, () =>
+                    HttpResponse.json(
+                        { id: 'story-media', url: PNG_DATA_URL, contentType: 'image/png' },
+                        { status: 201 },
+                    ),
+                ),
+            ],
+        },
+    },
+    play: async ({ canvasElement }) => {
+        await pasteImageIntoEditor(canvasElement);
+        await waitFor(() => expect(canvasElement.querySelector('img')).toBeTruthy());
+    },
+};
+
+/** Upload in flight: the toolbar image button shows its busy state. */
+export const Uploading: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.post(MEDIA_UPLOAD, async () => {
+                    await delay('infinite');
+                    return HttpResponse.json({}, { status: 201 });
+                }),
+            ],
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await pasteImageIntoEditor(canvasElement);
+        await waitFor(async () => {
+            expect(await canvas.findByText(/Uploading|Lädt hoch/)).toBeTruthy();
+        });
+    },
+};
+
+/** Backend rejects the upload (e.g. failed magic-byte check): error toast, no image. */
+export const UploadError: Story = {
+    parameters: {
+        msw: {
+            handlers: [http.post(MEDIA_UPLOAD, () => new HttpResponse(null, { status: 400 }))],
+        },
+    },
+    play: async ({ canvasElement }) => {
+        await pasteImageIntoEditor(canvasElement);
+        await waitFor(() => {
+            expect(document.body.textContent).toMatch(/upload failed|Upload fehlgeschlagen/i);
+        });
+        expect(canvasElement.querySelector('img')).toBeFalsy();
+    },
+};

--- a/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
@@ -103,7 +103,11 @@ describe('M3RichTextEditor accessibility', () => {
 describe('M3RichTextEditor image upload integrity', () => {
     it('blocks save and publish until a pending image has been inserted', async () => {
         let resolveUpload: (value: { id: string; url: string; contentType: string }) => void = () => undefined;
-        imageUploadMocks.uploadTenantMedia.mockReturnValueOnce(new Promise((resolve) => (resolveUpload = resolve)));
+        imageUploadMocks.uploadTenantMedia.mockReturnValueOnce(
+            new Promise((resolve) => {
+                resolveUpload = resolve;
+            }),
+        );
         const onPublish = vi.fn();
         const onSaveDraft = vi.fn();
         render(<M3RichTextEditor title="Impressum" onPublish={onPublish} onSaveDraft={onSaveDraft} />);

--- a/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+const imageUploadMocks = vi.hoisted(() => ({ uploadTenantMedia: vi.fn() }));
+vi.mock('../../api/tenant/uploadTenantMedia', () => ({ uploadTenantMedia: imageUploadMocks.uploadTenantMedia }));
+
 import { M3RichTextEditor } from './M3RichTextEditor';
 
 describe('M3RichTextEditor fullscreen dialog', () => {
@@ -93,5 +97,33 @@ describe('M3RichTextEditor accessibility', () => {
 
         const expectedTokenHtml = ['<p>$', '{responsible}</p>'].join('');
         await waitFor(() => expect(onChange).toHaveBeenLastCalledWith(expectedTokenHtml));
+    });
+});
+
+describe('M3RichTextEditor image upload integrity', () => {
+    it('blocks save and publish until a pending image has been inserted', async () => {
+        let resolveUpload: (value: { id: string; url: string; contentType: string }) => void = () => undefined;
+        imageUploadMocks.uploadTenantMedia.mockReturnValueOnce(new Promise((resolve) => (resolveUpload = resolve)));
+        const onPublish = vi.fn();
+        const onSaveDraft = vi.fn();
+        render(<M3RichTextEditor title="Impressum" onPublish={onPublish} onSaveDraft={onSaveDraft} />);
+        const editor = await screen.findByRole('textbox', { name: 'Impressum' });
+
+        fireEvent.paste(editor, {
+            clipboardData: {
+                files: [new File(['image'], 'image.png', { type: 'image/png' })],
+                getData: vi.fn(() => ''),
+            },
+        });
+
+        const publish = screen.getByRole('button', { name: /legal\.m3Editor\.publish|publish/i });
+        const saveDraft = screen.getByRole('button', { name: /legal\.m3Editor\.saveDraft|save draft/i });
+        await waitFor(() => expect(publish).toBeDisabled());
+        expect(saveDraft).toBeDisabled();
+
+        await act(async () => resolveUpload({ id: 'image', url: '/media/image', contentType: 'image/png' }));
+
+        await waitFor(() => expect(publish).toBeEnabled());
+        expect(saveDraft).toBeEnabled();
     });
 });

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -945,7 +945,8 @@ export const M3RichTextEditor = ({
                             <button
                                 type="button"
                                 className={`${styles.textBtn} ${styles.publish}`}
-                                disabled={publishing}
+                                disabled={publishing || imageUpload.uploading}
+                                aria-busy={publishing || imageUpload.uploading}
                                 onClick={() => onPublish(html())}
                             >
                                 <PublishedIcon />
@@ -956,6 +957,8 @@ export const M3RichTextEditor = ({
                             <button
                                 type="button"
                                 className={`${styles.textBtn} ${styles.draft}`}
+                                disabled={imageUpload.uploading}
+                                aria-busy={imageUpload.uploading}
                                 onClick={() => onSaveDraft(html())}
                             >
                                 <EditIcon />

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useEditor, EditorContent, Editor, BubbleMenu } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
@@ -52,6 +52,7 @@ import {
     PublishedIcon,
     EditIcon,
 } from '../CustomIcons/EditorIcons';
+import { createImageDropPasteHandlers, useEditorImageUpload } from './useEditorImageUpload';
 import { HeadingAnchors } from './headingAnchors';
 import { HeadingMenu } from './HeadingMenu';
 import { SplitDropdown } from './SplitDropdown';
@@ -209,6 +210,10 @@ type ToolbarProps = {
     onToggleAutoChapters?: (level: number) => void;
     /** Template placeholders (key -> i18n label key) inserted as literal `${key}` text. */
     placeholders?: { [key: string]: string };
+    /** Opens the image file picker (upload to the tenant media endpoint). */
+    onInsertImage?: () => void;
+    /** Upload in flight: the image button shows busy state. */
+    imageUploading?: boolean;
 };
 
 const Toolbar = ({
@@ -219,6 +224,8 @@ const Toolbar = ({
     autoChapters,
     onToggleAutoChapters,
     placeholders,
+    onInsertImage,
+    imageUploading,
 }: ToolbarProps) => {
     const { t } = useTranslation();
     const promptLink = () => {
@@ -229,11 +236,6 @@ const Toolbar = ({
         // eslint-disable-next-line no-alert
         const url = window.prompt('URL');
         if (url) editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
-    };
-    const promptImage = () => {
-        // eslint-disable-next-line no-alert
-        const url = window.prompt('Image URL');
-        if (url) editor.chain().focus().setImage({ src: url }).run();
     };
 
     return (
@@ -493,11 +495,17 @@ const Toolbar = ({
                             type="button"
                             className={`${styles.toolBtn} ${styles.withLabel}`}
                             onMouseDown={(e) => e.preventDefault()}
-                            onClick={promptImage}
+                            onClick={onInsertImage}
+                            disabled={imageUploading}
+                            aria-busy={imageUploading}
                             title={t('editor.toolbar.addImage', 'Add image')}
                         >
                             <ImageIcon />
-                            <span>{t('editor.toolbar.add', 'Add')}</span>
+                            <span>
+                                {imageUploading
+                                    ? t('editor.image.upload.uploading', 'Uploading…')
+                                    : t('editor.toolbar.add', 'Add')}
+                            </span>
                         </button>
                     </div>
                     {placeholders && Object.keys(placeholders).length > 0 && (
@@ -596,6 +604,13 @@ export const M3RichTextEditor = ({
     // its own TiptapEditor with its own anchor row.
     const anchorsEnabled = enableAnchors && !editorSlot;
 
+    // Image upload (WP-3b): editor + handler live behind refs so the drop/paste
+    // handlers captured at editor creation always see the current instances.
+    const editorRef = useRef<Editor | null>(null);
+    const imageUpload = useEditorImageUpload(() => editorRef.current);
+    const uploadAndInsertRef = useRef(imageUpload.uploadAndInsert);
+    uploadAndInsertRef.current = imageUpload.uploadAndInsert;
+
     const editor = useEditor({
         extensions: [
             StarterKit,
@@ -616,9 +631,20 @@ export const M3RichTextEditor = ({
         // The ProseMirror contenteditable exposes role="textbox" (browser-only) but
         // no accessible name (axe: aria-input-field-name, WCAG 4.1.2) — pin the role
         // and label it with the card title.
-        editorProps: { attributes: { 'aria-label': title, role: 'textbox' } },
+        editorProps: {
+            attributes: { 'aria-label': title, role: 'textbox' },
+            ...createImageDropPasteHandlers((files) => {
+                if (editorRef.current?.isEditable) {
+                    uploadAndInsertRef.current(files);
+                }
+            }),
+        },
         onUpdate: ({ editor: e }) => onChange?.(e.isEmpty ? '' : e.getHTML()),
     });
+
+    useEffect(() => {
+        editorRef.current = editor;
+    }, [editor]);
 
     useEffect(() => {
         editor?.setEditable(editorEditable);
@@ -633,7 +659,18 @@ export const M3RichTextEditor = ({
     }, [versions, viewingVersionId]);
 
     useEffect(() => {
-        editor?.setOptions({ editorProps: { attributes: { 'aria-label': title, role: 'textbox' } } });
+        // Keep the drop/paste image handlers when re-pinning the label — setOptions
+        // replaces editorProps wholesale.
+        editor?.setOptions({
+            editorProps: {
+                attributes: { 'aria-label': title, role: 'textbox' },
+                ...createImageDropPasteHandlers((files) => {
+                    if (editorRef.current?.isEditable) {
+                        uploadAndInsertRef.current(files);
+                    }
+                }),
+            },
+        });
     }, [editor, title]);
 
     useEffect(() => {
@@ -701,6 +738,8 @@ export const M3RichTextEditor = ({
                     autoChapters={autoChapters}
                     onToggleAutoChapters={toggleAutoChapters}
                     placeholders={placeholders}
+                    onInsertImage={imageUpload.openImagePicker}
+                    imageUploading={imageUpload.uploading}
                 />
             ) : (
                 <div className={styles.toolbar}>{maximizeButton}</div>

--- a/src/components/FormPluginEditor/TiptapEditor.tsx
+++ b/src/components/FormPluginEditor/TiptapEditor.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/icons-material';
 import { Button, ConfigProvider, Select } from 'antd';
 import { useTranslation } from 'react-i18next';
+import { createImageDropPasteHandlers, useEditorImageUpload } from './useEditorImageUpload';
 import { HeadingAnchors } from './headingAnchors';
 import AnchorChips from './AnchorChips';
 import { useHeadingAnchorNav } from './useHeadingAnchorNav';
@@ -74,10 +75,14 @@ const Toolbar = ({
     editor,
     placeholders,
     showHeadingSelect,
+    onInsertImage,
+    imageUploading,
 }: {
     editor: Editor;
     placeholders?: { [key: string]: string };
     showHeadingSelect?: boolean;
+    onInsertImage: () => void;
+    imageUploading?: boolean;
 }) => {
     const { t } = useTranslation();
 
@@ -90,14 +95,6 @@ const Toolbar = ({
         const url = window.prompt(t('editor.plugin.link.url', 'URL'));
         if (url) {
             editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
-        }
-    };
-
-    const insertImage = () => {
-        // eslint-disable-next-line no-alert
-        const url = window.prompt(t('editor.plugin.image.url', 'Image URL'));
-        if (url) {
-            editor.chain().focus().setImage({ src: url }).run();
         }
     };
 
@@ -176,7 +173,7 @@ const Toolbar = ({
                     <ToolbarButton active={editor.isActive('link')} onClick={insertLink} title="Link">
                         <LinkIcon fontSize="small" />
                     </ToolbarButton>
-                    <ToolbarButton onClick={insertImage} title="Image">
+                    <ToolbarButton onClick={onInsertImage} title="Image" active={imageUploading}>
                         <ImageIcon fontSize="small" />
                     </ToolbarButton>
                 </div>
@@ -214,6 +211,13 @@ const TiptapEditor = ({
     const placeholderRef = useRef(placeholder);
     placeholderRef.current = placeholder;
 
+    // Image upload (WP-3b): refs so the handlers captured at editor creation
+    // always see the current editor/handler instances.
+    const editorRef = useRef<Editor | null>(null);
+    const imageUpload = useEditorImageUpload(() => editorRef.current);
+    const uploadAndInsertRef = useRef(imageUpload.uploadAndInsert);
+    uploadAndInsertRef.current = imageUpload.uploadAndInsert;
+
     const editor = useEditor({
         extensions: [
             StarterKit,
@@ -225,7 +229,14 @@ const TiptapEditor = ({
         ],
         content: value,
         editable: !disabled,
-        editorProps: { attributes: { class: 'RichEditor-editor' } },
+        editorProps: {
+            attributes: { class: 'RichEditor-editor' },
+            ...createImageDropPasteHandlers((files) => {
+                if (editorRef.current?.isEditable) {
+                    uploadAndInsertRef.current(files);
+                }
+            }),
+        },
         onUpdate: ({ editor: e }) => {
             onChange?.(e.isEmpty ? '' : e.getHTML());
         },
@@ -243,6 +254,10 @@ const TiptapEditor = ({
             editor.commands.setContent(incoming, false);
         }
     }, [value, editor]);
+
+    useEffect(() => {
+        editorRef.current = editor;
+    }, [editor]);
 
     useEffect(() => {
         editor?.setEditable(!disabled);
@@ -263,7 +278,15 @@ const TiptapEditor = ({
 
     return (
         <>
-            {!disabled && <Toolbar editor={editor} placeholders={placeholders} showHeadingSelect={enableAnchors} />}
+            {!disabled && (
+                <Toolbar
+                    editor={editor}
+                    placeholders={placeholders}
+                    showHeadingSelect={enableAnchors}
+                    onInsertImage={imageUpload.openImagePicker}
+                    imageUploading={imageUpload.uploading}
+                />
+            )}
             {enableAnchors && (
                 <AnchorChips
                     anchors={anchors}

--- a/src/components/FormPluginEditor/TiptapEditor.tsx
+++ b/src/components/FormPluginEditor/TiptapEditor.tsx
@@ -51,11 +51,15 @@ const ToolbarButton = ({
     onClick,
     children,
     title,
+    disabled,
+    busy,
 }: {
     active?: boolean;
     onClick: () => void;
     children: React.ReactNode;
     title: string;
+    disabled?: boolean;
+    busy?: boolean;
 }) => (
     <Button
         type={active ? 'primary' : 'text'}
@@ -64,6 +68,8 @@ const ToolbarButton = ({
         onClick={onClick}
         title={title}
         aria-pressed={active}
+        disabled={disabled}
+        aria-busy={busy}
     >
         {children}
     </Button>
@@ -173,7 +179,13 @@ const Toolbar = ({
                     <ToolbarButton active={editor.isActive('link')} onClick={insertLink} title="Link">
                         <LinkIcon fontSize="small" />
                     </ToolbarButton>
-                    <ToolbarButton onClick={onInsertImage} title="Image" active={imageUploading}>
+                    <ToolbarButton
+                        onClick={onInsertImage}
+                        title="Image"
+                        active={imageUploading}
+                        disabled={imageUploading}
+                        busy={imageUploading}
+                    >
                         <ImageIcon fontSize="small" />
                     </ToolbarButton>
                 </div>

--- a/src/components/FormPluginEditor/useEditorImageUpload.test.tsx
+++ b/src/components/FormPluginEditor/useEditorImageUpload.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '../../i18n';
 
@@ -80,6 +80,79 @@ describe('useEditorImageUpload', () => {
 
         expect(setImage).not.toHaveBeenCalled();
         expect(mocks.notificationError).toHaveBeenCalledTimes(1);
+    });
+
+    it('serializes separate upload invocations and stays busy until the shared queue drains', async () => {
+        let resolveFirst: (value: { id: string; url: string; contentType: string }) => void = () => undefined;
+        let resolveSecond: (value: { id: string; url: string; contentType: string }) => void = () => undefined;
+        mocks.uploadTenantMedia
+            .mockReturnValueOnce(new Promise((resolve) => (resolveFirst = resolve)))
+            .mockReturnValueOnce(new Promise((resolve) => (resolveSecond = resolve)));
+        const { editor, setImage } = makeEditor();
+        const { result } = renderHook(() => useEditorImageUpload(() => editor));
+
+        let first: Promise<void>;
+        let second: Promise<void>;
+        act(() => {
+            first = result.current.uploadAndInsert([file('first.png', 'image/png')]);
+            second = result.current.uploadAndInsert([file('second.png', 'image/png')]);
+        });
+
+        expect(result.current.uploading).toBe(true);
+        await waitFor(() => expect(mocks.uploadTenantMedia).toHaveBeenCalledTimes(1));
+
+        await act(async () => resolveFirst({ id: 'first', url: '/media/first', contentType: 'image/png' }));
+        await waitFor(() => expect(mocks.uploadTenantMedia).toHaveBeenCalledTimes(2));
+        expect(result.current.uploading).toBe(true);
+
+        await act(async () => resolveSecond({ id: 'second', url: '/media/second', contentType: 'image/png' }));
+        await act(async () => Promise.all([first!, second!]));
+
+        expect(result.current.uploading).toBe(false);
+        expect(setImage).toHaveBeenNthCalledWith(1, { src: '/media/first' });
+        expect(setImage).toHaveBeenNthCalledWith(2, { src: '/media/second' });
+    });
+
+    it('maps and restores the original editor selection before inserting an async upload', async () => {
+        let resolveUpload: (value: { id: string; url: string; contentType: string }) => void = () => undefined;
+        mocks.uploadTenantMedia.mockReturnValueOnce(new Promise((resolve) => (resolveUpload = resolve)));
+        const mappedSelection = { from: 7 };
+        const mappedBookmark = { map: vi.fn(), resolve: vi.fn(() => mappedSelection) };
+        mappedBookmark.map.mockReturnValue(mappedBookmark);
+        const initialBookmark = { map: vi.fn(() => mappedBookmark) };
+        const transaction = { setSelection: vi.fn() };
+        transaction.setSelection.mockReturnValue(transaction);
+        const dispatch = vi.fn();
+        let transactionListener: ((event: { transaction: { mapping: object } }) => void) | undefined;
+        const { editor, setImage } = makeEditor();
+        const trackedEditor = {
+            ...editor,
+            state: { selection: { getBookmark: () => initialBookmark }, doc: {}, tr: transaction },
+            view: { dispatch },
+            isDestroyed: false,
+            on: vi.fn((_event: string, listener: typeof transactionListener) => {
+                transactionListener = listener;
+            }),
+            off: vi.fn(),
+        } as any;
+        const { result } = renderHook(() => useEditorImageUpload(() => trackedEditor));
+
+        let pending: Promise<void>;
+        act(() => {
+            pending = result.current.uploadAndInsert([file('positioned.png', 'image/png')]);
+        });
+        await waitFor(() => expect(mocks.uploadTenantMedia).toHaveBeenCalledTimes(1));
+        const mapping = {};
+        act(() => transactionListener?.({ transaction: { mapping } }));
+
+        await act(async () => resolveUpload({ id: 'positioned', url: '/media/positioned', contentType: 'image/png' }));
+        await act(async () => pending!);
+
+        expect(initialBookmark.map).toHaveBeenCalledWith(mapping);
+        expect(mappedBookmark.resolve).toHaveBeenCalledWith(trackedEditor.state.doc);
+        expect(transaction.setSelection).toHaveBeenCalledWith(mappedSelection);
+        expect(dispatch).toHaveBeenCalledWith(transaction);
+        expect(setImage).toHaveBeenCalledWith({ src: '/media/positioned' });
     });
 });
 

--- a/src/components/FormPluginEditor/useEditorImageUpload.test.tsx
+++ b/src/components/FormPluginEditor/useEditorImageUpload.test.tsx
@@ -1,0 +1,97 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '../../i18n';
+
+const mocks = vi.hoisted(() => ({
+    uploadTenantMedia: vi.fn(),
+    notificationError: vi.fn(),
+}));
+
+vi.mock('../../api/tenant/uploadTenantMedia', () => ({
+    uploadTenantMedia: mocks.uploadTenantMedia,
+}));
+vi.mock('antd', async () => {
+    const actual = await vi.importActual<typeof import('antd')>('antd');
+    return {
+        ...actual,
+        notification: { ...actual.notification, error: mocks.notificationError },
+    };
+});
+
+import { imageFilesFrom, useEditorImageUpload } from './useEditorImageUpload';
+
+const makeEditor = () => {
+    const run = vi.fn();
+    const setImage = vi.fn(() => ({ run }));
+    const focus = vi.fn(() => ({ setImage }));
+    const chain = vi.fn(() => ({ focus }));
+    return { editor: { chain } as any, setImage, run };
+};
+
+const file = (name: string, type: string, bytes = 8) => new File([new Uint8Array(bytes)], name, { type });
+
+describe('useEditorImageUpload', () => {
+    beforeEach(() => {
+        mocks.uploadTenantMedia.mockReset();
+        mocks.notificationError.mockReset();
+    });
+
+    it('uploads a supported image and inserts the served url into the editor', async () => {
+        mocks.uploadTenantMedia.mockResolvedValue({ id: 'abc', url: '/media/abc', contentType: 'image/png' });
+        const { editor, setImage, run } = makeEditor();
+        const { result } = renderHook(() => useEditorImageUpload(() => editor));
+
+        await act(() => result.current.uploadAndInsert([file('logo.png', 'image/png')]));
+
+        expect(mocks.uploadTenantMedia).toHaveBeenCalledTimes(1);
+        expect(setImage).toHaveBeenCalledWith({ src: '/media/abc' });
+        expect(run).toHaveBeenCalled();
+        expect(mocks.notificationError).not.toHaveBeenCalled();
+    });
+
+    it('rejects unsupported types client-side without calling the backend', async () => {
+        const { editor, setImage } = makeEditor();
+        const { result } = renderHook(() => useEditorImageUpload(() => editor));
+
+        await act(() => result.current.uploadAndInsert([file('vector.svg', 'image/svg+xml')]));
+
+        expect(mocks.uploadTenantMedia).not.toHaveBeenCalled();
+        expect(setImage).not.toHaveBeenCalled();
+        expect(mocks.notificationError).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects files over the 2 MB limit client-side', async () => {
+        const { editor } = makeEditor();
+        const { result } = renderHook(() => useEditorImageUpload(() => editor));
+        const big = file('big.png', 'image/png', 2 * 1024 * 1024 + 1);
+
+        await act(() => result.current.uploadAndInsert([big]));
+
+        expect(mocks.uploadTenantMedia).not.toHaveBeenCalled();
+        expect(mocks.notificationError).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows an error notification when the upload fails', async () => {
+        mocks.uploadTenantMedia.mockRejectedValue(new Error('boom'));
+        const { editor, setImage } = makeEditor();
+        const { result } = renderHook(() => useEditorImageUpload(() => editor));
+
+        await act(() => result.current.uploadAndInsert([file('logo.png', 'image/png')]));
+
+        expect(setImage).not.toHaveBeenCalled();
+        expect(mocks.notificationError).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('imageFilesFrom', () => {
+    it('extracts only image files from a file list', () => {
+        const files = [file('a.png', 'image/png'), file('b.txt', 'text/plain'), file('c.webp', 'image/webp')];
+        const list = { length: files.length, 0: files[0], 1: files[1], 2: files[2] } as unknown as FileList;
+
+        expect(imageFilesFrom(list).map((f) => f.name)).toEqual(['a.png', 'c.webp']);
+    });
+
+    it('returns an empty array for undefined input', () => {
+        expect(imageFilesFrom(undefined)).toEqual([]);
+    });
+});

--- a/src/components/FormPluginEditor/useEditorImageUpload.test.tsx
+++ b/src/components/FormPluginEditor/useEditorImageUpload.test.tsx
@@ -86,8 +86,16 @@ describe('useEditorImageUpload', () => {
         let resolveFirst: (value: { id: string; url: string; contentType: string }) => void = () => undefined;
         let resolveSecond: (value: { id: string; url: string; contentType: string }) => void = () => undefined;
         mocks.uploadTenantMedia
-            .mockReturnValueOnce(new Promise((resolve) => (resolveFirst = resolve)))
-            .mockReturnValueOnce(new Promise((resolve) => (resolveSecond = resolve)));
+            .mockReturnValueOnce(
+                new Promise((resolve) => {
+                    resolveFirst = resolve;
+                }),
+            )
+            .mockReturnValueOnce(
+                new Promise((resolve) => {
+                    resolveSecond = resolve;
+                }),
+            );
         const { editor, setImage } = makeEditor();
         const { result } = renderHook(() => useEditorImageUpload(() => editor));
 
@@ -115,7 +123,11 @@ describe('useEditorImageUpload', () => {
 
     it('maps and restores the original editor selection before inserting an async upload', async () => {
         let resolveUpload: (value: { id: string; url: string; contentType: string }) => void = () => undefined;
-        mocks.uploadTenantMedia.mockReturnValueOnce(new Promise((resolve) => (resolveUpload = resolve)));
+        mocks.uploadTenantMedia.mockReturnValueOnce(
+            new Promise((resolve) => {
+                resolveUpload = resolve;
+            }),
+        );
         const mappedSelection = { from: 7 };
         const mappedBookmark = { map: vi.fn(), resolve: vi.fn(() => mappedSelection) };
         mappedBookmark.map.mockReturnValue(mappedBookmark);

--- a/src/components/FormPluginEditor/useEditorImageUpload.ts
+++ b/src/components/FormPluginEditor/useEditorImageUpload.ts
@@ -1,0 +1,96 @@
+import { notification } from 'antd';
+import type { Editor } from '@tiptap/react';
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { uploadTenantMedia } from '../../api/tenant/uploadTenantMedia';
+
+/** Mirrors the server-side rules (TenantMediaService): PNG/JPEG/WebP, max 2 MB. */
+export const SUPPORTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
+export const IMAGE_UPLOAD_ACCEPT = SUPPORTED_IMAGE_TYPES.join(',');
+export const MAX_IMAGE_UPLOAD_BYTES = 2 * 1024 * 1024;
+
+/** Image files from a drop/paste/file-picker list; everything else is ignored. */
+export const imageFilesFrom = (files: FileList | File[] | undefined): File[] =>
+    Array.from(files ?? []).filter((file) => file.type.startsWith('image/'));
+
+/**
+ * Upload-and-insert for the TipTap editors: sends images to the tenant media endpoint
+ * and inserts the served `/media/{id}` url as an image node. Client-side checks mirror
+ * the server rules for fast feedback — the server stays authoritative (magic bytes).
+ */
+export const useEditorImageUpload = (getEditor: () => Editor | null) => {
+    const { t } = useTranslation();
+    const [uploading, setUploading] = useState(false);
+
+    const uploadAndInsert = useCallback(
+        async (files: FileList | File[]) => {
+            const uploadOne = async (file: File) => {
+                if (!SUPPORTED_IMAGE_TYPES.includes(file.type)) {
+                    notification.error({
+                        message: t('editor.image.upload.unsupportedType'),
+                        duration: 5,
+                    });
+                    return;
+                }
+                if (file.size > MAX_IMAGE_UPLOAD_BYTES) {
+                    notification.error({ message: t('editor.image.upload.tooLarge'), duration: 5 });
+                    return;
+                }
+                setUploading(true);
+                try {
+                    const media = await uploadTenantMedia(file);
+                    getEditor()?.chain().focus().setImage({ src: media.url }).run();
+                } catch {
+                    notification.error({ message: t('editor.image.upload.failed'), duration: 5 });
+                } finally {
+                    setUploading(false);
+                }
+            };
+            // sequential on purpose: multi-file drops keep their document order
+            await Array.from(files).reduce((chain, file) => chain.then(() => uploadOne(file)), Promise.resolve());
+        },
+        [getEditor, t],
+    );
+
+    const openImagePicker = useCallback(() => {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = IMAGE_UPLOAD_ACCEPT;
+        input.onchange = () => {
+            if (input.files?.length) {
+                uploadAndInsert(input.files);
+            }
+        };
+        input.click();
+    }, [uploadAndInsert]);
+
+    return { uploading, uploadAndInsert, openImagePicker };
+};
+
+/**
+ * ProseMirror editorProps handlers for dropping/pasting images into the editor.
+ * `moved` drops (dragging content within the document) stay with the default handling.
+ */
+export const createImageDropPasteHandlers = (onImageFiles: (files: File[]) => void) => ({
+    handleDrop: (_view: unknown, event: DragEvent, _slice: unknown, moved: boolean): boolean => {
+        if (moved) {
+            return false;
+        }
+        const files = imageFilesFrom(event.dataTransfer?.files);
+        if (!files.length) {
+            return false;
+        }
+        event.preventDefault();
+        onImageFiles(files);
+        return true;
+    },
+    handlePaste: (_view: unknown, event: ClipboardEvent): boolean => {
+        const files = imageFilesFrom(event.clipboardData?.files);
+        if (!files.length) {
+            return false;
+        }
+        event.preventDefault();
+        onImageFiles(files);
+        return true;
+    },
+});

--- a/src/components/FormPluginEditor/useEditorImageUpload.ts
+++ b/src/components/FormPluginEditor/useEditorImageUpload.ts
@@ -1,6 +1,7 @@
 import { notification } from 'antd';
 import type { Editor } from '@tiptap/react';
-import { useCallback, useState } from 'react';
+import type { Transaction } from '@tiptap/pm/state';
+import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { uploadTenantMedia } from '../../api/tenant/uploadTenantMedia';
 
@@ -21,9 +22,26 @@ export const imageFilesFrom = (files: FileList | File[] | undefined): File[] =>
 export const useEditorImageUpload = (getEditor: () => Editor | null) => {
     const { t } = useTranslation();
     const [uploading, setUploading] = useState(false);
+    const queueRef = useRef<Promise<void>>(Promise.resolve());
+    const queuedBatchCountRef = useRef(0);
 
     const uploadAndInsert = useCallback(
-        async (files: FileList | File[]) => {
+        (files: FileList | File[]): Promise<void> => {
+            const editor = getEditor();
+            let selectionBookmark = editor?.state?.selection?.getBookmark();
+            const mapSelection = ({ transaction }: { transaction: Transaction }) => {
+                selectionBookmark = selectionBookmark?.map(transaction.mapping);
+            };
+            editor?.on?.('transaction', mapSelection);
+
+            const restoreInsertionPoint = () => {
+                if (!editor || editor.isDestroyed || !selectionBookmark) {
+                    return;
+                }
+                const selection = selectionBookmark.resolve(editor.state.doc);
+                editor.view.dispatch(editor.state.tr.setSelection(selection));
+            };
+
             const uploadOne = async (file: File) => {
                 if (!SUPPORTED_IMAGE_TYPES.includes(file.type)) {
                     notification.error({
@@ -36,18 +54,35 @@ export const useEditorImageUpload = (getEditor: () => Editor | null) => {
                     notification.error({ message: t('editor.image.upload.tooLarge'), duration: 5 });
                     return;
                 }
-                setUploading(true);
                 try {
                     const media = await uploadTenantMedia(file);
+                    restoreInsertionPoint();
                     getEditor()?.chain().focus().setImage({ src: media.url }).run();
                 } catch {
                     notification.error({ message: t('editor.image.upload.failed'), duration: 5 });
-                } finally {
-                    setUploading(false);
                 }
             };
-            // sequential on purpose: multi-file drops keep their document order
-            await Array.from(files).reduce((chain, file) => chain.then(() => uploadOne(file)), Promise.resolve());
+
+            queuedBatchCountRef.current += 1;
+            setUploading(true);
+
+            // One queue covers picker, paste, and drop invocations so completion
+            // order always matches the document interaction order.
+            const batch = queueRef.current.then(() =>
+                Array.from(files).reduce(
+                    (previous, file) => previous.then(() => uploadOne(file)),
+                    Promise.resolve(),
+                ),
+            );
+            queueRef.current = batch.catch(() => undefined);
+
+            return batch.finally(() => {
+                editor?.off?.('transaction', mapSelection);
+                queuedBatchCountRef.current -= 1;
+                if (queuedBatchCountRef.current === 0) {
+                    setUploading(false);
+                }
+            });
         },
         [getEditor, t],
     );

--- a/src/components/FormPluginEditor/useEditorImageUpload.ts
+++ b/src/components/FormPluginEditor/useEditorImageUpload.ts
@@ -69,10 +69,7 @@ export const useEditorImageUpload = (getEditor: () => Editor | null) => {
             // One queue covers picker, paste, and drop invocations so completion
             // order always matches the document interaction order.
             const batch = queueRef.current.then(() =>
-                Array.from(files).reduce(
-                    (previous, file) => previous.then(() => uploadOne(file)),
-                    Promise.resolve(),
-                ),
+                Array.from(files).reduce((previous, file) => previous.then(() => uploadOne(file)), Promise.resolve()),
             );
             queueRef.current = batch.catch(() => undefined);
 

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1429,5 +1429,9 @@
     "productTour.overview.status.skipped": "Übersprungen",
     "productTour.overview.action.start": "Starten",
     "productTour.overview.action.continue": "Fortsetzen",
-    "productTour.overview.action.restart": "Neu starten"
+    "productTour.overview.action.restart": "Neu starten",
+    "editor.image.upload.unsupportedType": "Nur PNG-, JPEG- oder WebP-Bilder sind erlaubt.",
+    "editor.image.upload.tooLarge": "Das Bild ist zu groß (max. 2 MB).",
+    "editor.image.upload.failed": "Bild-Upload fehlgeschlagen. Bitte erneut versuchen.",
+    "editor.image.upload.uploading": "Lädt hoch…"
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1429,5 +1429,9 @@
     "productTour.overview.status.skipped": "Skipped",
     "productTour.overview.action.start": "Start",
     "productTour.overview.action.continue": "Continue",
-    "productTour.overview.action.restart": "Restart"
+    "productTour.overview.action.restart": "Restart",
+    "editor.image.upload.unsupportedType": "Only PNG, JPEG or WebP images are allowed.",
+    "editor.image.upload.tooLarge": "The image is too large (max. 2 MB).",
+    "editor.image.upload.failed": "Image upload failed. Please try again.",
+    "editor.image.upload.uploading": "Uploading…"
 }


### PR DESCRIPTION
## Problem
Both admin editors could only "insert" images via a window.prompt URL — no real upload existed. WP-3b of the media-upload epic (#366), part of #369; backend endpoint: TenantService#92 (merged).

## What changed
- `useEditorImageUpload` hook (shared): uploads to `POST /tenantadmin/media`, inserts the served `/media/{id}` url via `extension-image`; client-side type/size checks mirror the server (PNG/JPEG/WebP, 2 MB), server stays authoritative (magic bytes); error notifications, never a broken insert
- `uploadTenantMedia` API client (multipart; deliberately not `fetchData`, which hardwires JSON content type)
- Both toolbars (M3 + legacy): image button now opens a file picker; busy state while uploading
- Drop & paste via ProseMirror `editorProps` handlers in both editors; the M3 title effect re-applies them (it previously replaced `editorProps` wholesale); read-only editors ignore files
- 3 Storybook stories (UploadInserted / Uploading / UploadError), MSW-mocked, play functions paste a real PNG via `DataTransfer`

## Verification
- `npm run test` — 764/764 (12 new: multipart client, hook matrix: insert/unsupported/too-large/failure, file filtering)
- ESLint zero-warnings, Prettier, production build clean
- Stories visually verified: pasted image uploads and renders; error case inserts nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image uploads to the rich-text editor via image picker, drag-and-drop, and paste.
  * Added upload progress/busy state and UI feedback while uploading (including disabled publish/save draft controls).
  * Supports PNG, JPEG, and WebP images up to 2 MB.
* **Bug Fixes**
  * Prevents invalid or oversized image files from being inserted.
  * Ensures image insertions are serialized and selection is preserved across async uploads.
* **Tests**
  * Added coverage for multipart uploads, token refresh/retry behavior, and editor upload flow.
* **Documentation**
  * Updated Storybook stories and added localized strings for upload states and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->