### PR TITLE
feat(admin): migrate form dialogs onto shared Modal + DialogButton

### DIFF
--- a/src/components/CreateAgencyModal/index.tsx
+++ b/src/components/CreateAgencyModal/index.tsx
@@ -1,12 +1,15 @@
-import { Alert, Button, Form, message, Modal, Tooltip } from 'antd';
+import { Alert, Button, Form, message, Tooltip } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
+import DomainAddOutlinedIcon from '@mui/icons-material/DomainAddOutlined';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { UnsavedChangesModal } from '../CardEditable/components/UnsavedChanges';
 import { FormInputField } from '../FormInputField';
+import { Modal, DialogButton } from '../Modal';
 import { useAgencyUpdate } from '../../hooks/useAgencyUpdate';
 import { AgencyData } from '../../types/agency';
 import { extractApiErrorMessage } from '../../utils/extractApiErrorMessage';
+import styles from './styles.module.scss';
 
 interface CreateAgencyModalProps {
     /**
@@ -88,45 +91,51 @@ export const CreateAgencyModal = ({ tenantId, disabled, onSuccess }: CreateAgenc
             ) : (
                 button
             )}
-            <Modal
-                title={t('counselor.form.createAgency.title')}
-                open={open}
-                centered
-                destroyOnClose
-                confirmLoading={isPending}
-                okText={t('counselor.form.createAgency.confirm')}
-                cancelText={t('btn.cancel')}
-                onOk={() => form.submit()}
-                onCancel={requestClose}
-            >
-                {/* disabled={false} keeps the outer (read-only) form context from disabling these fields */}
-                {/* onFinish also fires on Enter inside a field, not only via the OK button */}
-                <Form form={form} layout="vertical" size="large" disabled={false} onFinish={onFinish}>
-                    <Alert type="info" description={t('counselor.form.createAgency.offlineHint')} />
-                    <br />
-                    <FormInputField
-                        name="name"
-                        labelKey="agency.edit.general.general_information.name"
-                        placeholderKey="agency.edit.general.general_information.name"
-                        required
-                        autoFocus
-                    />
-                    <FormInputField
-                        name="postcode"
-                        labelKey="agency.edit.general.address.postcode"
-                        placeholderKey="agency.edit.general.address.postcode"
-                        required
-                        maxLength={5}
-                        rules={[{ min: 5, required: true, message: t('agency.postcode.minimum') }]}
-                    />
-                    <FormInputField
-                        name="city"
-                        labelKey="agency.edit.general.address.city"
-                        placeholderKey="agency.edit.general.address.city"
-                        required
-                    />
-                </Form>
-            </Modal>
+            {open && (
+                <Modal
+                    titleKey="counselor.form.createAgency.title"
+                    icon={<DomainAddOutlinedIcon />}
+                    footer={
+                        <div className={styles.footerActions}>
+                            <DialogButton onClick={requestClose} disabled={isPending}>
+                                {t('btn.cancel')}
+                            </DialogButton>
+                            <DialogButton primary loading={isPending} onClick={() => form.submit()}>
+                                {t('counselor.form.createAgency.confirm')}
+                            </DialogButton>
+                        </div>
+                    }
+                    onClose={requestClose}
+                >
+                    {/* disabled={false} keeps the outer (read-only) form context from disabling these fields */}
+                    {/* onFinish also fires on Enter inside a field, not only via the OK button */}
+                    <Form form={form} layout="vertical" size="large" disabled={false} onFinish={onFinish}>
+                        <Alert type="info" description={t('counselor.form.createAgency.offlineHint')} />
+                        <br />
+                        <FormInputField
+                            name="name"
+                            labelKey="agency.edit.general.general_information.name"
+                            placeholderKey="agency.edit.general.general_information.name"
+                            required
+                            autoFocus
+                        />
+                        <FormInputField
+                            name="postcode"
+                            labelKey="agency.edit.general.address.postcode"
+                            placeholderKey="agency.edit.general.address.postcode"
+                            required
+                            maxLength={5}
+                            rules={[{ min: 5, required: true, message: t('agency.postcode.minimum') }]}
+                        />
+                        <FormInputField
+                            name="city"
+                            labelKey="agency.edit.general.address.city"
+                            placeholderKey="agency.edit.general.address.city"
+                            required
+                        />
+                    </Form>
+                </Modal>
+            )}
             {showUnsavedWarning && (
                 <UnsavedChangesModal onConfirm={closeModal} onClose={() => setShowUnsavedWarning(false)} />
             )}

--- a/src/components/CreateAgencyModal/styles.module.scss
+++ b/src/components/CreateAgencyModal/styles.module.scss
@@ -1,0 +1,7 @@
+/* Right-aligned action row; the shared Modal supplies the surrounding padding. */
+.footerActions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+}

--- a/src/components/CreateConsultantModal/index.tsx
+++ b/src/components/CreateConsultantModal/index.tsx
@@ -1,15 +1,18 @@
-import { Button, Form, message, Modal, Tooltip } from 'antd';
+import { Button, Form, message, Tooltip } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
+import PersonAddOutlinedIcon from '@mui/icons-material/PersonAddOutlined';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FETCH_ERRORS, X_REASON } from '../../api/fetchData';
 import { UnsavedChangesModal } from '../CardEditable/components/UnsavedChanges';
 import { FormInputField } from '../FormInputField';
 import { FormInputPasswordField } from '../FormInputPasswordField';
+import { Modal, DialogButton } from '../Modal';
 import { TypeOfUser } from '../../enums/TypeOfUser';
 import { useAddOrUpdateConsultantOrAdmin } from '../../hooks/useAddOrUpdateConsultantOrAgencyAdmin';
 import { CounselorData } from '../../types/counselor';
 import { extractApiErrorMessage } from '../../utils/extractApiErrorMessage';
+import styles from './styles.module.scss';
 
 interface CreateConsultantModalProps {
     /**
@@ -104,97 +107,103 @@ export const CreateConsultantModal = ({ tenantId, disabled, onSuccess }: CreateC
             ) : (
                 button
             )}
-            <Modal
-                title={t('agency.form.registrationSettings.createConsultant.title')}
-                open={open}
-                centered
-                destroyOnClose
-                confirmLoading={isPending}
-                okText={t('agency.form.registrationSettings.createConsultant.confirm')}
-                cancelText={t('btn.cancel')}
-                onOk={() => form.submit()}
-                onCancel={requestClose}
-            >
-                {/* disabled={false} keeps the outer (read-only) form context from disabling these fields */}
-                {/* onFinish also fires on Enter inside a field, not only via the OK button */}
-                <Form form={form} layout="vertical" size="large" disabled={false} onFinish={onFinish}>
-                    <FormInputField
-                        name="firstname"
-                        labelKey="firstname"
-                        placeholderKey="placeholder.firstname"
-                        required
-                        autoFocus
-                    />
-                    <FormInputField
-                        name="lastname"
-                        labelKey="lastname"
-                        placeholderKey="placeholder.lastname"
-                        required
-                    />
-                    <FormInputField
-                        name="email"
-                        labelKey="email"
-                        placeholderKey="placeholder.email"
-                        rules={[
-                            {
-                                required: true,
-                                type: 'email',
-                                message: t('message.error.email.incorrect'),
-                            },
-                        ]}
-                    />
-                    <FormInputField
-                        name="username"
-                        labelKey="counselor.username"
-                        placeholderKey="placeholder.username"
-                        rules={[
-                            {
-                                required: true,
-                                message: t('message.error.username.required'),
-                            },
-                            {
-                                pattern: /^[a-z0-9_-]+$/,
-                                message: t('message.error.username.format'),
-                            },
-                        ]}
-                    />
-                    <FormInputPasswordField
-                        name="password"
-                        labelKey="counselor.password"
-                        placeholderKey="placeholder.password"
-                        required
-                        rules={[
-                            {
-                                min: 8,
-                                message: t('message.error.password.minLength'),
-                            },
-                            {
-                                pattern: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/,
-                                message: t('message.error.password.policy'),
-                            },
-                        ]}
-                    />
-                    <FormInputPasswordField
-                        name="passwordConfirmation"
-                        labelKey="counselor.passwordConfirmation"
-                        placeholderKey="placeholder.password"
-                        required
-                        dependencies={['password']}
-                        rules={[
-                            ({ getFieldValue }) => ({
-                                validator(_, value) {
-                                    if (!value || getFieldValue('password') === value) {
-                                        return Promise.resolve();
-                                    }
-                                    return Promise.reject(
-                                        new Error(t('profile.passwordChange.error.passwordsNotMatch')),
-                                    );
+            {open && (
+                <Modal
+                    titleKey="agency.form.registrationSettings.createConsultant.title"
+                    icon={<PersonAddOutlinedIcon />}
+                    footer={
+                        <div className={styles.footerActions}>
+                            <DialogButton onClick={requestClose} disabled={isPending}>
+                                {t('btn.cancel')}
+                            </DialogButton>
+                            <DialogButton primary loading={isPending} onClick={() => form.submit()}>
+                                {t('agency.form.registrationSettings.createConsultant.confirm')}
+                            </DialogButton>
+                        </div>
+                    }
+                    onClose={requestClose}
+                >
+                    {/* disabled={false} keeps the outer (read-only) form context from disabling these fields */}
+                    {/* onFinish also fires on Enter inside a field, not only via the OK button */}
+                    <Form form={form} layout="vertical" size="large" disabled={false} onFinish={onFinish}>
+                        <FormInputField
+                            name="firstname"
+                            labelKey="firstname"
+                            placeholderKey="placeholder.firstname"
+                            required
+                            autoFocus
+                        />
+                        <FormInputField
+                            name="lastname"
+                            labelKey="lastname"
+                            placeholderKey="placeholder.lastname"
+                            required
+                        />
+                        <FormInputField
+                            name="email"
+                            labelKey="email"
+                            placeholderKey="placeholder.email"
+                            rules={[
+                                {
+                                    required: true,
+                                    type: 'email',
+                                    message: t('message.error.email.incorrect'),
                                 },
-                            }),
-                        ]}
-                    />
-                </Form>
-            </Modal>
+                            ]}
+                        />
+                        <FormInputField
+                            name="username"
+                            labelKey="counselor.username"
+                            placeholderKey="placeholder.username"
+                            rules={[
+                                {
+                                    required: true,
+                                    message: t('message.error.username.required'),
+                                },
+                                {
+                                    pattern: /^[a-z0-9_-]+$/,
+                                    message: t('message.error.username.format'),
+                                },
+                            ]}
+                        />
+                        <FormInputPasswordField
+                            name="password"
+                            labelKey="counselor.password"
+                            placeholderKey="placeholder.password"
+                            required
+                            rules={[
+                                {
+                                    min: 8,
+                                    message: t('message.error.password.minLength'),
+                                },
+                                {
+                                    pattern: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/,
+                                    message: t('message.error.password.policy'),
+                                },
+                            ]}
+                        />
+                        <FormInputPasswordField
+                            name="passwordConfirmation"
+                            labelKey="counselor.passwordConfirmation"
+                            placeholderKey="placeholder.password"
+                            required
+                            dependencies={['password']}
+                            rules={[
+                                ({ getFieldValue }) => ({
+                                    validator(_, value) {
+                                        if (!value || getFieldValue('password') === value) {
+                                            return Promise.resolve();
+                                        }
+                                        return Promise.reject(
+                                            new Error(t('profile.passwordChange.error.passwordsNotMatch')),
+                                        );
+                                    },
+                                }),
+                            ]}
+                        />
+                    </Form>
+                </Modal>
+            )}
             {showUnsavedWarning && (
                 <UnsavedChangesModal onConfirm={closeModal} onClose={() => setShowUnsavedWarning(false)} />
             )}

--- a/src/components/CreateConsultantModal/styles.module.scss
+++ b/src/components/CreateConsultantModal/styles.module.scss
@@ -1,0 +1,7 @@
+/* Right-aligned action row; the shared Modal supplies the surrounding padding. */
+.footerActions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+}

--- a/src/components/GrantConsultantIdentityModal/index.tsx
+++ b/src/components/GrantConsultantIdentityModal/index.tsx
@@ -1,12 +1,15 @@
-import { Button, Form, message, Modal } from 'antd';
+import { Button, Form, message } from 'antd';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LabeledValue } from 'antd/lib/select';
+import AssignmentIndOutlinedIcon from '@mui/icons-material/AssignmentIndOutlined';
 import { SelectFormField } from '../SelectFormField';
+import { Modal, DialogButton } from '../Modal';
 import { useAgenciesData } from '../../hooks/useAgencysData';
 import { convertToOptions } from '../../utils/convertToOptions';
 import { grantConsultantIdentityData } from '../../api/admins/grantConsultantIdentityData';
 import { isActiveDeleteDate } from '../../utils/deleteDate';
+import styles from './styles.module.scss';
 
 interface GrantConsultantIdentityModalProps {
     adminId: string;
@@ -75,30 +78,36 @@ export const GrantConsultantIdentityModal = ({
             <Button type="default" disabled={disabled} onClick={() => setOpen(true)}>
                 {t('grantConsultantIdentity.button')}
             </Button>
-            <Modal
-                title={t('grantConsultantIdentity.modal.title')}
-                open={open}
-                centered
-                destroyOnClose
-                confirmLoading={isSubmitting}
-                okText={t('grantConsultantIdentity.modal.confirm')}
-                cancelText={t('btn.cancel')}
-                onOk={onConfirm}
-                onCancel={closeModal}
-            >
-                <Form form={form} layout="vertical">
-                    <SelectFormField
-                        name="agencies"
-                        label="grantConsultantIdentity.modal.agencyLabel"
-                        labelInValue
-                        isMulti
-                        required
-                        loading={isLoading}
-                        placeholder="plsSelect"
-                        options={convertToOptions(availableAgencies, ['postcode', 'name', 'city'], 'id')}
-                    />
-                </Form>
-            </Modal>
+            {open && (
+                <Modal
+                    titleKey="grantConsultantIdentity.modal.title"
+                    icon={<AssignmentIndOutlinedIcon />}
+                    footer={
+                        <div className={styles.footerActions}>
+                            <DialogButton onClick={closeModal} disabled={isSubmitting}>
+                                {t('btn.cancel')}
+                            </DialogButton>
+                            <DialogButton primary loading={isSubmitting} onClick={onConfirm}>
+                                {t('grantConsultantIdentity.modal.confirm')}
+                            </DialogButton>
+                        </div>
+                    }
+                    onClose={closeModal}
+                >
+                    <Form form={form} layout="vertical">
+                        <SelectFormField
+                            name="agencies"
+                            label="grantConsultantIdentity.modal.agencyLabel"
+                            labelInValue
+                            isMulti
+                            required
+                            loading={isLoading}
+                            placeholder="plsSelect"
+                            options={convertToOptions(availableAgencies, ['postcode', 'name', 'city'], 'id')}
+                        />
+                    </Form>
+                </Modal>
+            )}
         </>
     );
 };

--- a/src/components/GrantConsultantIdentityModal/styles.module.scss
+++ b/src/components/GrantConsultantIdentityModal/styles.module.scss
@@ -1,0 +1,7 @@
+/* Right-aligned action row; the shared Modal supplies the surrounding padding. */
+.footerActions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+}

--- a/src/pages/Links/AccountInvitesTab.tsx
+++ b/src/pages/Links/AccountInvitesTab.tsx
@@ -2,6 +2,7 @@ import { Button, message, Tag } from 'antd';
 import type { TablePaginationConfig } from 'antd/es/table';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
 import {
     accountInviteAcceptBaseUrl,
     AccountInviteDTO,
@@ -633,6 +634,7 @@ export const AccountInvitesTab = ({ targetRole, templateKind, includeAgencyField
             {bulkDeleteConfirmOpen && (
                 <Modal
                     titleKey="links.bulk.deleteConfirmTitle"
+                    icon={<DeleteOutlineOutlinedIcon />}
                     contentKey="links.bulk.deleteConfirmBody"
                     contentKeyOptions={{ count: selectedInvites.length }}
                     okLabelKey="links.bulk.deleteConfirmOk"

--- a/src/pages/Links/EmailTemplatesDialog.module.scss
+++ b/src/pages/Links/EmailTemplatesDialog.module.scss
@@ -1,0 +1,9 @@
+/* Right-aligned action row; the shared Modal supplies the surrounding padding.
+   `listingTableStyles.actionGroup` isn't used here — it's inline-flex without
+   right-alignment (fine for a table-row action cell, wrong for a dialog footer). */
+.footerActions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+}

--- a/src/pages/Links/EmailTemplatesDialog.tsx
+++ b/src/pages/Links/EmailTemplatesDialog.tsx
@@ -1,6 +1,7 @@
 import { Button, Form, Input, message, Select, Switch, Tag, Tooltip } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined';
 import {
     createInviteEmailTemplate,
     InviteEmailTemplateDTO,
@@ -10,7 +11,8 @@ import {
     updateInviteEmailTemplate,
 } from '../../api/accountInvites/accountInvites';
 import { ListingTable, listingTableStyles } from '../../components/ListingTable';
-import { Modal } from '../../components/Modal';
+import { Modal, DialogButton } from '../../components/Modal';
+import styles from './EmailTemplatesDialog.module.scss';
 
 const TEMPLATE_KINDS: InviteEmailTemplateKind[] = ['TENANT_INVITE', 'COUNSELLOR_INVITE', 'DPA_FORWARD'];
 
@@ -220,25 +222,22 @@ export const EmailTemplatesDialog = ({
     );
 
     const listFooter = (
-        <div className={listingTableStyles.actionGroup}>
-            <Button onClick={onClose}>{t('links.templates.close', 'Close')}</Button>
-            <Button type="primary" className={listingTableStyles.createButton} onClick={openCreateForm}>
+        <div className={styles.footerActions}>
+            <DialogButton onClick={onClose}>{t('links.templates.close', 'Close')}</DialogButton>
+            <DialogButton primary onClick={openCreateForm}>
                 {t('links.templates.new', 'New template')}
-            </Button>
+            </DialogButton>
         </div>
     );
 
     const formFooter = (
-        <div className={listingTableStyles.actionGroup}>
-            <Button onClick={backToList}>{t('links.templates.back', 'Back')}</Button>
-            <Button
-                type="primary"
-                className={listingTableStyles.createButton}
-                loading={submitting}
-                onClick={() => form.submit()}
-            >
+        <div className={styles.footerActions}>
+            <DialogButton onClick={backToList} disabled={submitting}>
+                {t('links.templates.back', 'Back')}
+            </DialogButton>
+            <DialogButton primary loading={submitting} onClick={() => form.submit()}>
                 {t('links.templates.save', 'Save')}
-            </Button>
+            </DialogButton>
         </div>
     );
 
@@ -248,7 +247,13 @@ export const EmailTemplatesDialog = ({
     }
 
     return (
-        <Modal titleKey={titleKey} onClose={onClose} footer={view === 'list' ? listFooter : formFooter} width={860}>
+        <Modal
+            titleKey={titleKey}
+            icon={<EmailOutlinedIcon />}
+            onClose={onClose}
+            footer={view === 'list' ? listFooter : formFooter}
+            width={860}
+        >
             {view === 'list' ? (
                 <ListingTable
                     rowKey="id"

--- a/src/pages/Links/InviteCsvImportModal.tsx
+++ b/src/pages/Links/InviteCsvImportModal.tsx
@@ -2,8 +2,9 @@ import { useMemo, useState } from 'react';
 import { DeleteOutlined } from '@ant-design/icons';
 import { Button, Input, message, Tag, Tooltip } from 'antd';
 import { useTranslation } from 'react-i18next';
+import UploadFileOutlinedIcon from '@mui/icons-material/UploadFileOutlined';
 import { ListingTable } from '../../components/ListingTable';
-import { Modal } from '../../components/Modal';
+import { Modal, DialogButton } from '../../components/Modal';
 import { assignBatchTenantIds, type InviteCsvRejectionReason, type ParseInviteCsvResult } from './csv/parseInviteCsv';
 import styles from './inviteCsvImport.module.scss';
 
@@ -270,20 +271,21 @@ export const InviteCsvImportModal = ({
     return (
         <Modal
             titleKey="links.csvImport.title"
+            icon={<UploadFileOutlinedIcon />}
             width={880}
             footer={
                 <div className={styles.footer}>
-                    <Button disabled={running} onClick={onClose}>
+                    <DialogButton disabled={running} onClick={onClose}>
                         {t('links.csvImport.cancel', 'Abbrechen')}
-                    </Button>
-                    <Button
+                    </DialogButton>
+                    <DialogButton
+                        primary
                         disabled={running || pendingRows.length === 0}
                         loading={running}
-                        type="primary"
                         onClick={runImport}
                     >
                         {t('links.csvImport.confirm', '{{count}} Empfänger anlegen', { count: pendingRows.length })}
-                    </Button>
+                    </DialogButton>
                 </div>
             }
             onClose={onClose}


### PR DESCRIPTION
## Problem
Form dialogs (already built on `FormInputField`/`SelectFormField`) still wrapped their content in a raw antd `Modal` with `okText`/`cancelText` — the last inconsistency between dialogs using the shared M3 anatomy and ones that don't. `EmailTemplatesDialog`'s primary action even carried a separate dark uppercase CTA button style, distinct from every other dialog's button.

## What changed
- **CreateAgencyModal, CreateConsultantModal, GrantConsultantIdentityModal**: raw antd `Modal` → shared `Modal` + `DialogButton` footer (grey cancel / red confirm, loading+disabled while pending), each with a hero icon. Field content (`FormInputField`/`SelectFormField`) untouched — they already used the right components.
- **EmailTemplatesDialog / InviteCsvImportModal**: hand-rolled antd `<Button>` footers → `DialogButton`, so every dialog footer renders identically. Added a hero icon to both (same lines were already being touched). `EmailTemplatesDialog`'s footer no longer reuses `listingTableStyles.actionGroup` (inline-flex, not right-aligned — fine for a table-row action cell, wrong for a dialog footer) but a local right-aligned `.footerActions`, matching `TranslateOnPublishModal`/`CreateAgencyModal`.
- **AccountInvitesTab**: added the missing hero icon to the bulk-delete confirm dialog (already used the standard `okLabelKey`/`cancelLabelKey` footer).

## Verification
- `npm run test` → 153 files pass · `tsc --noEmit` clean · `eslint` clean · `prettier` clean · `npm run build` ✓
- Verified visually in Storybook: all 6 touched dialogs (hero icon, grey/red button pairing, right-aligned footers, list AND form views for EmailTemplatesDialog).

Independent of #407/#408 — branched directly off `pre-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)