### PR TITLE
fix(admin): repair card deck creation layouts

### DIFF
--- a/src/components/CardDeck/index.test.tsx
+++ b/src/components/CardDeck/index.test.tsx
@@ -23,8 +23,10 @@ const setElementMetric = (element: Element, property: 'clientWidth' | 'offsetWid
 
 describe('CardDeck', () => {
     const originalGetComputedStyle = window.getComputedStyle;
+    let mockedGap = '48px';
 
     beforeEach(() => {
+        mockedGap = '48px';
         Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
             configurable: true,
             value: vi.fn(),
@@ -32,10 +34,10 @@ describe('CardDeck', () => {
         window.getComputedStyle = ((element: Element) => {
             const style = originalGetComputedStyle(element);
 
-            if (element.hasAttribute('data-admin-card-deck-scroll')) {
+            if (element.hasAttribute('data-admin-card-deck-list')) {
                 return Object.create(style, {
-                    columnGap: { value: '48px' },
-                    gap: { value: '48px' },
+                    columnGap: { value: mockedGap },
+                    gap: { value: mockedGap },
                 });
             }
 
@@ -82,7 +84,11 @@ describe('CardDeck', () => {
         expect(nextButton).toHaveAttribute('aria-controls', scrollGroup.id);
     });
 
-    it('scrolls by one card step from the footer controls', async () => {
+    it.each([
+        { gap: '48px', expectedStep: 473 },
+        { gap: '0px', expectedStep: 425 },
+    ])('scrolls by one card step with a $gap gap', async ({ gap, expectedStep }) => {
+        mockedGap = gap;
         const user = userEvent.setup();
         const { container } = renderDeck();
         const deck = container.querySelector('[data-admin-card-deck-scroll]');
@@ -109,7 +115,7 @@ describe('CardDeck', () => {
         await user.click(nextButton);
 
         expect(scrollBy).toHaveBeenCalledWith({
-            left: 473,
+            left: expectedStep,
             behavior: 'smooth',
         });
     });

--- a/src/components/CardDeck/index.tsx
+++ b/src/components/CardDeck/index.tsx
@@ -72,8 +72,10 @@ const CardDeckRoot = ({
                 return;
             }
 
-            const computedStyle = window.getComputedStyle(deck);
-            const gap = Number.parseFloat(computedStyle.columnGap || computedStyle.gap) || 24;
+            const list = deck.querySelector('[data-admin-card-deck-list]');
+            const computedStyle = window.getComputedStyle(list ?? deck);
+            const parsedGap = Number.parseFloat(computedStyle.columnGap || computedStyle.gap);
+            const gap = Number.isFinite(parsedGap) ? parsedGap : 24;
             const firstCard = deck.querySelector('[data-admin-card-deck-item]') as HTMLElement | null;
             const cardStep = firstCard ? firstCard.offsetWidth + gap : deck.clientWidth * 0.86;
 
@@ -139,7 +141,7 @@ const CardDeckRoot = ({
                 data-admin-card-deck-scroll
                 role="group"
             >
-                <ul className={styles.list} aria-label={ariaLabel}>
+                <ul className={styles.list} aria-label={ariaLabel} data-admin-card-deck-list>
                     {cards}
                 </ul>
             </div>

--- a/src/components/CardDeck/styles.module.scss
+++ b/src/components/CardDeck/styles.module.scss
@@ -31,7 +31,7 @@
     align-items: flex-start;
     padding: 0;
     margin: 0;
-    gap: 24px;
+    gap: var(--card-deck-gap, 24px);
     list-style: none;
 }
 

--- a/src/components/CardDeck/styles.test.ts
+++ b/src/components/CardDeck/styles.test.ts
@@ -21,4 +21,9 @@ describe('CardDeck responsive contract', () => {
         // The desktop item rule must not force the min-width to 0.
         expect(itemRule).not.toMatch(/min-width:\s*0/);
     });
+
+    it('exposes the distance between cards as a deck token', () => {
+        const listRule = cardDeckStyles.match(/\.list\s*{([^}]*)}/s)?.[1] ?? '';
+        expect(listRule).toMatch(/gap:\s*var\(--card-deck-gap,\s*24px\)/);
+    });
 });

--- a/src/pages/Agency/Edit/index.test.tsx
+++ b/src/pages/Agency/Edit/index.test.tsx
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AgencyPageEdit } from './index';
+import agencyStyles from './styles.module.scss';
 
 // Render AgencyPageEdit inside a QueryClientProvider so child components that use
 // react-query (e.g. RegistrationSettings → useConsultantsOrAdminsData) don't throw
@@ -233,12 +234,14 @@ describe('AgencyPageEdit create flow', () => {
     });
 
     it('renders the tenant assignment field for super-admin agency creation', async () => {
-        renderWithClient(<AgencyPageEdit />);
+        const { container } = renderWithClient(<AgencyPageEdit />);
 
         // Required field: SelectFormField now mirrors FormInputField's M3 label
         // convention (a visible " *" appended to the text) instead of antd's
         // CSS-only pseudo-asterisk.
         expect(await screen.findByText('Trägerzuordnung *')).toBeInTheDocument();
+        expect(container.querySelector('[data-admin-card-deck]')).toHaveClass(agencyStyles.createCardDeck);
+        expect(container.querySelectorAll('[data-admin-card-deck-item]')).toHaveLength(3);
         expect(mocks.searchTenantData).toHaveBeenCalledWith({ perPage: 1000 });
     });
 

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -319,12 +319,15 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
             >
                 <h3 className={styles.backHeadline}>{t(`agency.edit.settings.general.title`)}</h3>
                 <CardDeck
+                    className={agencyStyles.createCardDeck}
                     ariaLabel={t(`agency.edit.settings.general.title`)}
                     previousLabel={t('agency.cardDeck.previous')}
                     nextLabel={t('agency.cardDeck.next')}
                 >
-                    <CardDeck.Item className={agencyStyles.createCardGroup}>
+                    <CardDeck.Item>
                         <AgencyGeneralInformation />
+                    </CardDeck.Item>
+                    <CardDeck.Item>
                         <RegistrationSettings />
                     </CardDeck.Item>
                     <CardDeck.Item>

--- a/src/pages/Agency/Edit/styles.module.scss
+++ b/src/pages/Agency/Edit/styles.module.scss
@@ -1,22 +1,5 @@
-.createCardGroup {
-    --card-deck-item-min-width: 624px;
-    --card-deck-item-width: 624px;
-
-    gap: 24px;
-
-    > * {
-        min-width: 300px;
-        flex: 1 1 300px;
-    }
-}
-
-@media (max-width: 767px) {
-    .createCardGroup {
-        flex-direction: column;
-
-        > * {
-            min-width: 0;
-            flex-basis: auto;
-        }
-    }
+.createCardDeck {
+    --card-deck-item-min-width: 420px;
+    --card-deck-item-width: 420px;
+    --card-deck-gap: 32px;
 }

--- a/src/pages/Agency/Edit/styles.test.ts
+++ b/src/pages/Agency/Edit/styles.test.ts
@@ -4,17 +4,11 @@ import { describe, expect, it } from 'vitest';
 
 const styles = readFileSync(resolve(__dirname, './styles.module.scss'), 'utf8');
 
-describe('agency creation card widths', () => {
-    it('keeps both left-hand creation cards readable on desktop', () => {
-        const group = styles.match(/\.createCardGroup\s*{([\s\S]*?)\n}/)?.[1] ?? '';
-        expect(group).toMatch(/--card-deck-item-min-width:\s*624px/);
-        expect(group).toMatch(/>\s*\*\s*{[\s\S]*?min-width:\s*300px/);
-    });
-
-    it('stacks the grouped cards without a desktop minimum on mobile', () => {
-        expect(styles).toMatch(
-            /@media\s*\(max-width:\s*767px\)[\s\S]*?\.createCardGroup[\s\S]*?flex-direction:\s*column/,
-        );
-        expect(styles).toMatch(/@media\s*\(max-width:\s*767px\)[\s\S]*?>\s*\*\s*{[\s\S]*?min-width:\s*0/);
+describe('agency creation card deck', () => {
+    it('uses 420px cards with 32px between them', () => {
+        const deck = styles.match(/\.createCardDeck\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+        expect(deck).toMatch(/--card-deck-item-min-width:\s*420px/);
+        expect(deck).toMatch(/--card-deck-item-width:\s*420px/);
+        expect(deck).toMatch(/--card-deck-gap:\s*32px/);
     });
 });

--- a/src/pages/Tenants/Edit/General/index.tsx
+++ b/src/pages/Tenants/Edit/General/index.tsx
@@ -214,6 +214,7 @@ export const GeneralTenantSettings = () => {
                     ariaLabel={t('tenants.add.mainTenantTitle')}
                     className={styles.tenantCardDeck}
                     deckClassName={styles.tenantCardDeckScroll}
+                    footerClassName={styles.tenantCardDeckFooter}
                     previousLabel={t('tenant.settings.cardDeck.previous')}
                     nextLabel={t('tenant.settings.cardDeck.next')}
                 >

--- a/src/pages/Tenants/Edit/General/styles.module.scss
+++ b/src/pages/Tenants/Edit/General/styles.module.scss
@@ -7,8 +7,13 @@
 }
 
 .tenantCardDeck {
+    --card-deck-min-height: 0;
     --card-deck-item-width: 425px;
     --card-deck-item-max-width: calc(100vw - 176px);
+}
+
+.tenantCardDeckFooter {
+    margin-top: 32px;
 }
 
 .tenantCardDeckScroll {

--- a/src/pages/Tenants/Edit/General/styles.test.ts
+++ b/src/pages/Tenants/Edit/General/styles.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const styles = readFileSync(resolve(__dirname, './styles.module.scss'), 'utf8');
+const source = readFileSync(resolve(__dirname, './index.tsx'), 'utf8');
+
+describe('tenant creation card navigation', () => {
+    it('keeps the arrow buttons close to the cards', () => {
+        const deck = styles.match(/\.tenantCardDeck\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+        const footer = styles.match(/\.tenantCardDeckFooter\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+
+        expect(deck).toMatch(/--card-deck-min-height:\s*0/);
+        expect(footer).toMatch(/margin-top:\s*32px/);
+        expect(source).toContain('footerClassName={styles.tenantCardDeckFooter}');
+    });
+});


### PR DESCRIPTION
## Problem

Admin card surfaces had drifted, while the agency and tenant creation layouts developed overlapping cards and navigation controls detached from their content.

## Changes

- Rebuild shared M3 card primitives and representative card organisms.
- Restore consistent card elevation, typography, fields, and reusable footer slots.
- Render agency creation as separate 420px cards with a 32px gap.
- Keep tenant creation arrows 32px below the cards.
- Make CardDeck scrolling use its configured visual gap.

## Verification

- `npm test -- src/pages/Tenants/Edit/General/styles.test.ts src/pages/Agency/Edit/styles.test.ts src/components/CardDeck/styles.test.ts src/components/CardDeck/index.test.tsx src/pages/Agency/Edit/index.test.tsx`
- `npm run build`
- `git diff --check`

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)
