### PR TITLE
Resolve /media editor image URLs against the tenant origin (display)

### DIFF
--- a/src/appConfig.ts
+++ b/src/appConfig.ts
@@ -10,7 +10,7 @@ export const appURL = runtimeConfig.appBaseUrl;
 export const matrixURL = runtimeConfig.matrixBaseUrl;
 const userServiceURL = runtimeConfig.userServiceOrigin;
 const agencyServiceURL = runtimeConfig.agencyServiceOrigin;
-const tenantServiceURL = runtimeConfig.tenantServiceOrigin;
+export const tenantServiceURL = runtimeConfig.tenantServiceOrigin;
 const consultingTypeServiceURL = runtimeConfig.consultingTypeServiceOrigin;
 
 export const clusterFeatureFlags = {

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -3,7 +3,7 @@ import { useEditor, EditorContent, Editor, BubbleMenu } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Link from '@tiptap/extension-link';
-import Image from '@tiptap/extension-image';
+import { ResolvingImage } from './createResolvingImage';
 import Highlight from '@tiptap/extension-highlight';
 import TaskItem from '@tiptap/extension-task-item';
 import TaskList from '@tiptap/extension-task-list';
@@ -616,7 +616,7 @@ export const M3RichTextEditor = ({
             StarterKit,
             Underline,
             Link.configure({ openOnClick: false, autolink: false }),
-            Image,
+            ResolvingImage,
             Highlight.configure({ multicolor: true }),
             TaskList,
             TaskItem.configure({ nested: true }),

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -3,7 +3,6 @@ import { useEditor, EditorContent, Editor, BubbleMenu } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Link from '@tiptap/extension-link';
-import { ResolvingImage } from './createResolvingImage';
 import Highlight from '@tiptap/extension-highlight';
 import TaskItem from '@tiptap/extension-task-item';
 import TaskList from '@tiptap/extension-task-list';
@@ -44,6 +43,7 @@ import {
     TextFields,
 } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
+import { ResolvingImage } from './createResolvingImage';
 import {
     CrossReferenceIcon,
     KeyboardArrowDownIcon,

--- a/src/components/FormPluginEditor/TiptapEditor.tsx
+++ b/src/components/FormPluginEditor/TiptapEditor.tsx
@@ -3,7 +3,7 @@ import { useEditor, EditorContent, Editor, BubbleMenu } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Link from '@tiptap/extension-link';
-import Image from '@tiptap/extension-image';
+import { ResolvingImage } from './createResolvingImage';
 import Placeholder from '@tiptap/extension-placeholder';
 import {
     FormatBold,
@@ -235,7 +235,7 @@ const TiptapEditor = ({
             StarterKit,
             Underline,
             Link.configure({ openOnClick: false, autolink: false }),
-            Image,
+            ResolvingImage,
             Placeholder.configure({ placeholder: () => placeholderRef.current || '' }),
             ...(enableAnchors ? [HeadingAnchors] : []),
         ],

--- a/src/components/FormPluginEditor/TiptapEditor.tsx
+++ b/src/components/FormPluginEditor/TiptapEditor.tsx
@@ -3,7 +3,6 @@ import { useEditor, EditorContent, Editor, BubbleMenu } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Link from '@tiptap/extension-link';
-import { ResolvingImage } from './createResolvingImage';
 import Placeholder from '@tiptap/extension-placeholder';
 import {
     FormatBold,
@@ -16,6 +15,7 @@ import {
 } from '@mui/icons-material';
 import { Button, ConfigProvider, Select } from 'antd';
 import { useTranslation } from 'react-i18next';
+import { ResolvingImage } from './createResolvingImage';
 import { createImageDropPasteHandlers, useEditorImageUpload } from './useEditorImageUpload';
 import { HeadingAnchors } from './headingAnchors';
 import AnchorChips from './AnchorChips';

--- a/src/components/FormPluginEditor/createResolvingImage.test.ts
+++ b/src/components/FormPluginEditor/createResolvingImage.test.ts
@@ -1,10 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Editor } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
+import { ResolvingImage } from './createResolvingImage';
 
 vi.mock('../../appConfig', () => ({ tenantServiceURL: 'https://api.oriso-dev.site' }));
-
-import { ResolvingImage } from './createResolvingImage';
 
 let editors: Editor[] = [];
 const createEditor = (content: string) => {

--- a/src/components/FormPluginEditor/createResolvingImage.test.ts
+++ b/src/components/FormPluginEditor/createResolvingImage.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+
+vi.mock('../../appConfig', () => ({ tenantServiceURL: 'https://api.oriso-dev.site' }));
+
+import { ResolvingImage } from './createResolvingImage';
+
+let editors: Editor[] = [];
+const createEditor = (content: string) => {
+    const editor = new Editor({
+        element: document.createElement('div'),
+        extensions: [StarterKit, ResolvingImage],
+        content,
+    });
+    editors.push(editor);
+    return editor;
+};
+
+afterEach(() => {
+    editors.forEach((e) => e.destroy());
+    editors = [];
+});
+
+describe('ResolvingImage', () => {
+    it('displays a resolved /media src in the editing DOM but serializes it relative', () => {
+        const editor = createEditor('<p>Impressum</p><img src="/media/abc-1">');
+
+        const renderedImg = editor.view.dom.querySelector('img');
+        expect(renderedImg?.getAttribute('src')).toBe('https://api.oriso-dev.site/media/abc-1');
+
+        // getHTML (what gets saved) keeps the origin-independent relative path.
+        expect(editor.getHTML()).toContain('src="/media/abc-1"');
+        expect(editor.getHTML()).not.toContain('api.oriso-dev.site');
+    });
+
+    it('leaves absolute image sources unchanged in both DOM and output', () => {
+        const editor = createEditor('<img src="https://cdn/x.png">');
+        expect(editor.view.dom.querySelector('img')?.getAttribute('src')).toBe('https://cdn/x.png');
+        expect(editor.getHTML()).toContain('src="https://cdn/x.png"');
+    });
+});

--- a/src/components/FormPluginEditor/createResolvingImage.ts
+++ b/src/components/FormPluginEditor/createResolvingImage.ts
@@ -1,0 +1,29 @@
+import Image from '@tiptap/extension-image';
+import { tenantServiceURL } from '../../appConfig';
+import { resolveTenantMediaUrl } from './resolveTenantMediaUrl';
+
+/**
+ * TipTap Image extension whose editing NodeView displays `/media/{id}` sources
+ * resolved against the TenantService origin, while serialization (getHTML /
+ * save) keeps the stored `src` relative. The document model is untouched, so
+ * there is no value/onChange round-trip to keep in sync.
+ */
+export const ResolvingImage = Image.extend({
+    addNodeView() {
+        return ({ node }) => {
+            const dom = document.createElement('img');
+            const src = node.attrs.src as string | undefined;
+            const resolved = resolveTenantMediaUrl(src, tenantServiceURL);
+            if (resolved) {
+                dom.setAttribute('src', resolved);
+            }
+            if (node.attrs.alt) {
+                dom.setAttribute('alt', node.attrs.alt as string);
+            }
+            if (node.attrs.title) {
+                dom.setAttribute('title', node.attrs.title as string);
+            }
+            return { dom };
+        };
+    },
+});

--- a/src/components/FormPluginEditor/resolveTenantMediaUrl.test.ts
+++ b/src/components/FormPluginEditor/resolveTenantMediaUrl.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../appConfig', () => ({ tenantServiceURL: 'https://api.oriso-dev.site' }));
+
+import { resolveTenantMediaUrl } from './resolveTenantMediaUrl';
+
+const ORIGIN = 'https://api.oriso-dev.site';
+
+describe('resolveTenantMediaUrl (admin)', () => {
+    it('prefixes a root-relative /media path with the tenant origin', () => {
+        expect(resolveTenantMediaUrl('/media/abc-1', ORIGIN)).toBe('https://api.oriso-dev.site/media/abc-1');
+    });
+    it('collapses a trailing slash on the origin', () => {
+        expect(resolveTenantMediaUrl('/media/x', 'https://api.test/')).toBe('https://api.test/media/x');
+    });
+    it('leaves the path relative when origin is empty (dev proxy)', () => {
+        expect(resolveTenantMediaUrl('/media/x', '')).toBe('/media/x');
+    });
+    it('never touches absolute, data, blob or non-media sources', () => {
+        expect(resolveTenantMediaUrl('https://cdn/x.png', ORIGIN)).toBe('https://cdn/x.png');
+        expect(resolveTenantMediaUrl('data:image/png;base64,AA', ORIGIN)).toBe('data:image/png;base64,AA');
+        expect(resolveTenantMediaUrl('/static/logo.png', ORIGIN)).toBe('/static/logo.png');
+        expect(resolveTenantMediaUrl('/x/media/y', ORIGIN)).toBe('/x/media/y');
+    });
+    it('is safe on undefined', () => {
+        expect(resolveTenantMediaUrl(undefined, ORIGIN)).toBeUndefined();
+    });
+});

--- a/src/components/FormPluginEditor/resolveTenantMediaUrl.test.ts
+++ b/src/components/FormPluginEditor/resolveTenantMediaUrl.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import { resolveTenantMediaUrl } from './resolveTenantMediaUrl';
 
 vi.mock('../../appConfig', () => ({ tenantServiceURL: 'https://api.oriso-dev.site' }));
-
-import { resolveTenantMediaUrl } from './resolveTenantMediaUrl';
 
 const ORIGIN = 'https://api.oriso-dev.site';
 

--- a/src/components/FormPluginEditor/resolveTenantMediaUrl.ts
+++ b/src/components/FormPluginEditor/resolveTenantMediaUrl.ts
@@ -1,0 +1,16 @@
+/**
+ * Resolves a root-relative tenant media reference (`/media/{id}`, produced by
+ * the editor image upload, WP-3b) against the TenantService origin.
+ *
+ * Stored editor HTML keeps the src relative so it is origin-independent; the
+ * resolving image NodeView shows the absolute URL while authoring (the admin is
+ * served from an origin that may not route `/media` to the TenantService).
+ * Only bare `/media/...` paths are rewritten; absolute/data/blob/other sources
+ * pass through, and an empty origin (dev same-origin proxy) leaves it relative.
+ */
+export const resolveTenantMediaUrl = (src: string | undefined, origin: string): string | undefined => {
+    if (!src || !origin || !src.startsWith('/media/')) {
+        return src;
+    }
+    return `${origin.replace(/\/$/, '')}${src}`;
+};


### PR DESCRIPTION
## Problem
Images inserted in the legal-text editors (WP-3b) are stored as `<img src="/media/{id}">` (relative, origin-independent — Frank's render-time-resolution decision). The admin is served from an origin that may not route `/media` to the TenantService, so the author would see a broken image while editing.

## What changed
- `ResolvingImage` TipTap extension: an editing NodeView shows the src resolved against the TenantService origin (`tenantServiceURL`), while serialization (`getHTML`/save) keeps the stored src **relative**. The document model is untouched → no value/onChange round-trip to keep in sync.
- Both editors (M3 + legacy TiptapEditor) use it in place of the bare `Image` extension.
- `resolveTenantMediaUrl` helper (only bare `/media/…` rewritten; absolute/data/blob/other pass through; empty dev origin stays relative).

Mirrors the frontend render-time resolution (ORISO-Frontend#560) for the anonymous-facing legal pages.

## Verification
- `npm run test` — 942/942 (7 new: resolver matrix + NodeView shows-resolved/saves-relative integration)
- ESLint zero-warnings, Prettier, production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)