### PR TITLE
fix(statistic): stop the search menu opening on load and overlaying on scroll

### DIFF
--- a/src/components/GlobalSearch/GlobalSearchBar.test.tsx
+++ b/src/components/GlobalSearch/GlobalSearchBar.test.tsx
@@ -82,6 +82,23 @@ describe('GlobalSearchBar', () => {
         expect(input).toHaveAttribute('name', 'search');
     });
 
+    it('does not focus the input on mount when it starts expanded', () => {
+        const onInputFocus = vi.fn();
+        render(<GlobalSearchBar defaultExpanded onInputFocus={onInputFocus} />);
+
+        expect(screen.getByRole('textbox')).not.toHaveFocus();
+        expect(onInputFocus).not.toHaveBeenCalled();
+    });
+
+    it('focuses the input once the user expands the search', async () => {
+        const user = userEvent.setup();
+        render(<GlobalSearchBar />);
+
+        await user.click(screen.getByRole('button', { name: 'Suche ausklappen' }));
+
+        expect(screen.getByRole('textbox')).toHaveFocus();
+    });
+
     it('renders the row inside the horizontal-scroll container with its children', () => {
         const { container } = render(
             <GlobalSearchBar>

--- a/src/components/GlobalSearch/GlobalSearchBar.tsx
+++ b/src/components/GlobalSearch/GlobalSearchBar.tsx
@@ -72,10 +72,19 @@ export const GlobalSearchBar = ({
     const [expanded, setExpanded] = useState(defaultExpanded);
     const [internalValue, setInternalValue] = useState('');
     const inputRef = useRef<InputRef>(null);
+    const hasMountedRef = useRef(false);
     const isControlled = value !== undefined;
     const searchValue = isControlled ? value : internalValue;
 
+    // Focus follows a user-driven expand only. Pages that render with
+    // `defaultExpanded` must not steal focus on mount — that fires their
+    // `onInputFocus` hook and pops suggestion menus open unprompted (#417).
     useEffect(() => {
+        if (!hasMountedRef.current) {
+            hasMountedRef.current = true;
+            return;
+        }
+
         if (expanded) {
             inputRef.current?.focus({ preventScroll: true });
         }

--- a/src/styles/components/statistic.less
+++ b/src/styles/components/statistic.less
@@ -21,9 +21,8 @@
 }
 
 .statisticDashboard__filterBar {
-    position: sticky;
-    z-index: 850;
-    top: 99px;
+    position: relative;
+    z-index: 55;
     display: grid;
     align-items: start;
     justify-content: start;
@@ -1338,12 +1337,6 @@
         strong {
             font-size: 34px;
             line-height: 40px;
-        }
-    }
-
-    @media (max-width: 768px) {
-        .statisticDashboard__filterBar {
-            top: 84px;
         }
     }
 


### PR DESCRIPTION
## Problem

On `/admin/statistics` the tenant/agency suggestion menu opened on page load without any user interaction, and the filter bar scrolled over the statistics cards.

## What changed

- `GlobalSearchBar` focused its input in a mount-time effect whenever it started expanded. That fired the page's `onInputFocus` hook and popped the menu open. Focus now follows a user-driven expand only (first-mount ref guard).
- Fixed in the component, so `EditableTable` and `InactiveAccountAuditLogs` (also `defaultExpanded`) benefit too.
- `.statisticDashboard__filterBar` was `position: sticky; z-index: 850` with a transparent background — now in-flow. The suggestion dropdown still paints above the cards.
- Dropped the now-dead `top: 84px` mobile override.
- Added regression tests for both mount and user-expand focus behaviour.

## Verification

- `npx vitest run src/components/GlobalSearch/GlobalSearchBar.test.tsx` — 7/7 pass; the new mount test fails without the component fix (checked by stashing it).
- Admin Storybook: `ExpandedEmpty` mounts unfocused; `Minimized` → "Expand search" focuses the input.
- `npx eslint`, `npx prettier --check` — clean on all three files.

Demo: https://cap.dreambau.com/s/1jdxm0dqacdmsxt

Closes #417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved global search behavior so the input does not focus automatically when the search loads expanded.
  * Search input now focuses only after users expand a collapsed search field.

* **Style**
  * Updated dashboard filter bar positioning for more consistent layout behavior across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->