### PR TITLE
fix: create consultants with agency context atomically

### DIFF
--- a/src/api/counselor/addCounselorData.test.ts
+++ b/src/api/counselor/addCounselorData.test.ts
@@ -46,4 +46,24 @@ describe('addCounselorData', () => {
         });
         expect(putAgenciesForCounselor).not.toHaveBeenCalled();
     });
+
+    it('serializes numeric topicIds from quick create', async () => {
+        await addCounselorData({
+            firstname: 'Ada',
+            lastname: 'Lovelace',
+            email: 'ada@example.org',
+            username: 'ada',
+            password: 'StrongPass1!',
+            tenantId: '3',
+            agencyIds: [282],
+            topicIds: [7, 12],
+        });
+
+        expect(fetchData).toHaveBeenCalledTimes(1);
+        const request = vi.mocked(fetchData).mock.calls[0][0];
+        expect(JSON.parse(request.bodyData as string)).toMatchObject({
+            agencyIds: [282],
+            topicIds: [7, 12],
+        });
+    });
 });

--- a/src/api/counselor/addCounselorData.test.ts
+++ b/src/api/counselor/addCounselorData.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchData } from '../fetchData';
+import { putAgenciesForCounselor } from '../agency/putAgenciesForCounselor';
+import { addCounselorData } from './addCounselorData';
+
+vi.mock('../fetchData', () => ({
+    FETCH_ERRORS: {
+        BAD_REQUEST_WITH_RESPONSE: 'BAD_REQUEST_WITH_RESPONSE',
+        CONFLICT: 'CONFLICT',
+        CONFLICT_WITH_RESPONSE: 'CONFLICT_WITH_RESPONSE',
+        CATCH_ALL: 'CATCH_ALL',
+    },
+    FETCH_METHODS: { POST: 'POST' },
+    fetchData: vi.fn(),
+}));
+
+vi.mock('../agency/putAgenciesForCounselor', () => ({
+    putAgenciesForCounselor: vi.fn(),
+}));
+
+describe('addCounselorData', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(fetchData).mockResolvedValue({
+            json: vi.fn().mockResolvedValue({ _embedded: { id: 'consultant-1' } }),
+        } as unknown as Response);
+    });
+
+    it('creates the consultant with agencies and topics in one request', async () => {
+        await addCounselorData({
+            firstname: 'Ada',
+            lastname: 'Lovelace',
+            email: 'ada@example.org',
+            username: 'ada',
+            password: 'StrongPass1!',
+            tenantId: '3',
+            agencyIds: [5, 9],
+            topicIds: [{ value: '7' }, { id: 12 }],
+        });
+
+        expect(fetchData).toHaveBeenCalledTimes(1);
+        const request = vi.mocked(fetchData).mock.calls[0][0];
+        expect(JSON.parse(request.bodyData as string)).toMatchObject({
+            agencyIds: [5, 9],
+            topicIds: [7, 12],
+        });
+        expect(putAgenciesForCounselor).not.toHaveBeenCalled();
+    });
+});

--- a/src/api/counselor/addCounselorData.ts
+++ b/src/api/counselor/addCounselorData.ts
@@ -10,7 +10,9 @@ import { CounselorData } from '../../types/counselor';
 const parseTopicIds = (counselorData: Record<string, any>): number[] | undefined => {
     const topics = counselorData?.topicIds || counselorData?.topics;
     const topicIds = topics
-        ?.map((topic) => (typeof topic === 'string' ? topic : topic?.value || topic?.id))
+        ?.map((topic) =>
+            typeof topic === 'string' || typeof topic === 'number' ? topic : topic?.value || topic?.id,
+        )
         .filter((id) => id != null && !Number.isNaN(Number(id)))
         .map((id) => Number(id));
 

--- a/src/api/counselor/addCounselorData.ts
+++ b/src/api/counselor/addCounselorData.ts
@@ -10,9 +10,7 @@ import { CounselorData } from '../../types/counselor';
 const parseTopicIds = (counselorData: Record<string, any>): number[] | undefined => {
     const topics = counselorData?.topicIds || counselorData?.topics;
     const topicIds = topics
-        ?.map((topic) =>
-            typeof topic === 'string' || typeof topic === 'number' ? topic : topic?.value || topic?.id,
-        )
+        ?.map((topic) => (typeof topic === 'string' || typeof topic === 'number' ? topic : topic?.value || topic?.id))
         .filter((id) => id != null && !Number.isNaN(Number(id)))
         .map((id) => Number(id));
 

--- a/src/api/counselor/addCounselorData.ts
+++ b/src/api/counselor/addCounselorData.ts
@@ -1,7 +1,6 @@
 import { FETCH_ERRORS, FETCH_METHODS, fetchData } from '../fetchData';
 import { counselorEndpoint } from '../../appConfig';
 import { CounselorData } from '../../types/counselor';
-import { putAgenciesForCounselor } from '../agency/putAgenciesForCounselor';
 
 /**
  * add new counselor
@@ -16,6 +15,18 @@ const parseTopicIds = (counselorData: Record<string, any>): number[] | undefined
         .map((id) => Number(id));
 
     return topicIds?.length ? topicIds : undefined;
+};
+
+const parseAgencyIds = (counselorData: Record<string, any>): number[] | undefined => {
+    const agencies = counselorData?.agencyIds || counselorData?.agencies;
+    const agencyIds = agencies
+        ?.map((agency) =>
+            typeof agency === 'string' || typeof agency === 'number' ? agency : agency?.value || agency?.id,
+        )
+        .filter((id) => id != null && !Number.isNaN(Number(id)))
+        .map((id) => Number(id));
+
+    return agencyIds?.length ? [...new Set<number>(agencyIds)] : undefined;
 };
 
 export const addCounselorData = (counselorData: Record<string, any>): Promise<CounselorData> => {
@@ -34,6 +45,7 @@ export const addCounselorData = (counselorData: Record<string, any>): Promise<Co
     } = counselorData;
 
     const topicIds = parseTopicIds(counselorData);
+    const agencyIds = parseAgencyIds(counselorData);
 
     // just use needed data from whole form data
     const strippedCounselor = {
@@ -49,6 +61,7 @@ export const addCounselorData = (counselorData: Record<string, any>): Promise<Co
         tenantId: parseInt(tenantId, 10),
         publicSlug,
         ...(topicIds && { topicIds }),
+        ...(agencyIds && { agencyIds }),
     };
 
     return (
@@ -67,10 +80,5 @@ export const addCounselorData = (counselorData: Record<string, any>): Promise<Co
             .then((response) => response.json())
             // eslint-disable-next-line no-underscore-dangle
             .then((data: { _embedded: CounselorData }) => data?._embedded)
-            .then((data) => {
-                return putAgenciesForCounselor(data?.id, counselorData.agencies?.map(({ value }) => value) || []).then(
-                    () => data,
-                );
-            })
     );
 };

--- a/src/components/CreateConsultantModal/index.test.ts
+++ b/src/components/CreateConsultantModal/index.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { buildQuickCreateConsultantData } from './index';
+
+describe('buildQuickCreateConsultantData', () => {
+    it('binds a quick-created consultant to the current tenant, agency and topics', () => {
+        expect(
+            buildQuickCreateConsultantData({ firstname: 'Ada', lastname: 'Lovelace' }, 84, '282', ['7', 12]),
+        ).toMatchObject({
+            firstname: 'Ada',
+            lastname: 'Lovelace',
+            tenantId: '84',
+            agencyIds: [282],
+            topicIds: [7, 12],
+        });
+    });
+});

--- a/src/components/CreateConsultantModal/index.tsx
+++ b/src/components/CreateConsultantModal/index.tsx
@@ -20,11 +20,38 @@ interface CreateConsultantModalProps {
      * until a tenant is known (superadmins must pick one in the agency form first).
      */
     tenantId?: string | number;
+    agencyId?: string | number;
+    topicIds?: Array<string | number>;
     disabled?: boolean;
+    disabledReasonKey?: string;
     onSuccess: (consultant: CounselorData) => void;
 }
 
-export const CreateConsultantModal = ({ tenantId, disabled, onSuccess }: CreateConsultantModalProps) => {
+const normalizeNumericIds = (values: Array<string | number | undefined>): number[] => [
+    ...new Set(values.map(Number).filter((value) => Number.isFinite(value) && value > 0)),
+];
+
+export const buildQuickCreateConsultantData = (
+    values: Record<string, unknown>,
+    tenantId?: string | number,
+    agencyId?: string | number,
+    topicIds: Array<string | number> = [],
+) => ({
+    ...values,
+    formalLanguage: true,
+    tenantId: `${tenantId}`,
+    agencyIds: normalizeNumericIds([agencyId]),
+    topicIds: normalizeNumericIds(topicIds),
+});
+
+export const CreateConsultantModal = ({
+    tenantId,
+    agencyId,
+    topicIds,
+    disabled,
+    disabledReasonKey,
+    onSuccess,
+}: CreateConsultantModalProps) => {
     const { t } = useTranslation();
     const [form] = Form.useForm();
     const [open, setOpen] = useState(false);
@@ -75,15 +102,11 @@ export const CreateConsultantModal = ({ tenantId, disabled, onSuccess }: CreateC
     const hasTenant = tenantId !== undefined && tenantId !== null && `${tenantId}` !== '' && `${tenantId}` !== '0';
 
     const onFinish = (values: Record<string, unknown>) => {
-        // The create endpoint only needs the form fields plus these defaults;
-        // the mutate signature is typed for the full entity.
-        mutate({
-            ...values,
-            formalLanguage: true,
-            agencies: [],
-            tenantId: `${tenantId}`,
-        } as unknown as CounselorData);
+        mutate(buildQuickCreateConsultantData(values, tenantId, agencyId, topicIds) as unknown as CounselorData);
     };
+
+    const disabledTooltipKey =
+        disabledReasonKey || (!hasTenant ? 'agency.form.registrationSettings.createConsultant.tenantFirst' : undefined);
 
     const button = (
         <Button
@@ -99,8 +122,8 @@ export const CreateConsultantModal = ({ tenantId, disabled, onSuccess }: CreateC
 
     return (
         <>
-            {!hasTenant && !disabled ? (
-                <Tooltip title={t('agency.form.registrationSettings.createConsultant.tenantFirst')}>
+            {disabledTooltipKey ? (
+                <Tooltip title={t(disabledTooltipKey)}>
                     {/* span wrapper so the tooltip also works on the disabled button */}
                     <span style={{ display: 'block' }}>{button}</span>
                 </Tooltip>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -374,6 +374,7 @@
     "agency.form.registrationSettings.createConsultant.title": "Neue:n Berater:in anlegen",
     "agency.form.registrationSettings.createConsultant.confirm": "Anlegen",
     "agency.form.registrationSettings.createConsultant.tenantFirst": "Bitte wählen Sie zuerst die Trägerzuordnung aus, um eine:n neue:n Berater:in anzulegen.",
+    "agency.form.registrationSettings.createConsultant.saveAgencyFirst": "Speichern Sie diese Beratungsstelle zuerst offline und öffnen Sie sie anschließend erneut, um eine:n Berater:in anzulegen und zuzuweisen.",
     "agency.form.registrationSettings.onlineWarning": "Damit die Beratungsstelle in der Registrierung sichtbar gestellt werden kann, weisen Sie dieser eine:n Berater:in zu. Diese Funktion finden Sie unter dem Menüpunkt \"Nutzer\".",
     "agency.form.registrationSettings.onlineDescription": "Die Beratungsstelle in der Registrierung als sichtbar stellen",
     "agency.form.registrationSettings.postCodeTitle": "Für welches Gebiet ist die Beratungsstelle sichtbar in der Registrierung?",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -441,6 +441,7 @@
     "agency.form.registrationSettings.createConsultant.title": "Create new consultant",
     "agency.form.registrationSettings.createConsultant.confirm": "Create",
     "agency.form.registrationSettings.createConsultant.tenantFirst": "Please select a tenant assignment first to create a new consultant.",
+    "agency.form.registrationSettings.createConsultant.saveAgencyFirst": "Save this advice center offline first, then reopen it to create and assign a consultant.",
     "agency.form.registrationSettings.consultants.placeholder": "Select consultants",
     "agency.form.registrationSettings.newPostCodeLabel": "Postal code areas:",
     "agency.form.registrationSettings.onlineWarning": "So that the advice center can be made visible in the registration, assign a consultant to it. You can find this function under the menu item “Users”.",

--- a/src/pages/Agency/Edit/components/RegistrationSettings/index.tsx
+++ b/src/pages/Agency/Edit/components/RegistrationSettings/index.tsx
@@ -16,20 +16,23 @@ import { isActiveRecord } from '../../../../../utils/deleteDate';
 import { CreateConsultantModal } from '../../../../../components/CreateConsultantModal';
 import { parseUserAuthInfo } from '../../../../../utils/parseUserAuthInfo';
 import { resolveAgencyTenantId } from '../../../../../api/agency/addAgencyData';
+import { normalizeTopicIds } from '../../../../../api/agency/normalizeTopicIds';
 
 interface RegistrationSettingsProps {
     asFields?: boolean;
+    editing?: boolean;
 }
 
-export const RegistrationSettings = ({ asFields }: RegistrationSettingsProps) => {
+export const RegistrationSettings = ({ asFields, editing }: RegistrationSettingsProps) => {
     const { t } = useTranslation();
     const { id } = useParams();
     const form = Form.useFormInstance();
     const postCodeRangesActive = Form.useWatch('postCodeRangesActive');
-    const selectedTenantId = Form.useWatch('tenantId');
+    const selectedTenantId = Form.useWatch('tenantId') ?? form.getFieldValue('tenantId');
+    const selectedTopicIds = Form.useWatch('topicIds') ?? form.getFieldValue('topicIds');
     const selectedConsultants = Form.useWatch('consultantIds') || [];
     const hasSelectedConsultants = selectedConsultants.length > 0;
-    const showConsultantAssignment = !asFields;
+    const showConsultantAssignment = !asFields || editing;
     const { data: hasConsultants, isLoading } = useAgencyHasConsultants({ id });
     const { data: consultants, isLoading: isLoadingConsultants } = useConsultantsOrAdminsData({
         typeOfUser: TypeOfUser.Consultants,
@@ -45,6 +48,7 @@ export const RegistrationSettings = ({ asFields }: RegistrationSettingsProps) =>
     const needsConsultantAssignment = id === 'add' ? !hasSelectedConsultants : !hasConsultants;
     // Superadmins pick the tenant in the form; tenant admins carry it in their token.
     const consultantTenantId = resolveAgencyTenantId(selectedTenantId, parseUserAuthInfo().tenantId);
+    const hasPersistedAgency = id !== 'add' && Number.isFinite(Number(id)) && Number(id) > 0;
 
     const onConsultantCreated = (consultant) => {
         const current = form.getFieldValue('consultantIds') || [];
@@ -89,7 +93,18 @@ export const RegistrationSettings = ({ asFields }: RegistrationSettingsProps) =>
                         options={consultantOptions}
                     />
                     <div className={styles.createConsultant}>
-                        <CreateConsultantModal tenantId={consultantTenantId} onSuccess={onConsultantCreated} />
+                        <CreateConsultantModal
+                            tenantId={consultantTenantId}
+                            agencyId={hasPersistedAgency ? id : undefined}
+                            topicIds={normalizeTopicIds(selectedTopicIds)}
+                            disabled={!hasPersistedAgency}
+                            disabledReasonKey={
+                                hasPersistedAgency
+                                    ? undefined
+                                    : 'agency.form.registrationSettings.createConsultant.saveAgencyFirst'
+                            }
+                            onSuccess={onConsultantCreated}
+                        />
                     </div>
                 </>
             )}

--- a/src/pages/Agency/Edit/index.test.tsx
+++ b/src/pages/Agency/Edit/index.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Form } from 'antd';
 import { AgencyPageEdit } from './index';
 import agencyStyles from './styles.module.scss';
 
@@ -28,6 +29,7 @@ const mocks = vi.hoisted(() => ({
     dpaGate: { dpaPublished: true, dpaSigned: true },
     routeId: 'add',
     agencyData: undefined as any,
+    createConsultantProps: undefined as any,
 }));
 
 const translations: Record<string, string> = {
@@ -103,8 +105,14 @@ vi.mock('../../../components/Card', () => ({
 }));
 
 vi.mock('../../../components/CardEditable', () => ({
-    CardEditable: function CardEditable({ children }: { children: React.ReactNode }) {
-        return <div>{children}</div>;
+    CardEditable: function CardEditable({ children, initialValues }: { children: any; initialValues?: object }) {
+        return (
+            <Form initialValues={initialValues}>
+                {typeof children === 'function'
+                    ? children({ editing: true, form: undefined, startEditing: vi.fn() })
+                    : children}
+            </Form>
+        );
     },
 }));
 
@@ -182,7 +190,10 @@ vi.mock('../../../api/tenant/searchTenantData', () => ({
 }));
 
 vi.mock('../../../components/CreateConsultantModal', () => ({
-    CreateConsultantModal: () => <div data-testid="create-consultant-modal" />,
+    CreateConsultantModal: (props: unknown) => {
+        mocks.createConsultantProps = props;
+        return <div data-testid="create-consultant-modal" />;
+    },
 }));
 
 beforeAll(() => {
@@ -231,6 +242,7 @@ describe('AgencyPageEdit create flow', () => {
         mocks.dpaGate = { dpaPublished: true, dpaSigned: true };
         mocks.routeId = 'add';
         mocks.agencyData = undefined;
+        mocks.createConsultantProps = undefined;
     });
 
     it('renders the tenant assignment field for super-admin agency creation', async () => {
@@ -285,6 +297,36 @@ describe('AgencyPageEdit create flow', () => {
 
         expect(screen.getByText('AVV-Unterschrift erforderlich')).toBeInTheDocument();
         expect(screen.queryByLabelText('Name *')).not.toBeInTheDocument();
+    });
+
+    it('requires saving a new agency before quick-creating its consultant', async () => {
+        renderWithClient(<AgencyPageEdit />);
+
+        await waitFor(() => expect(mocks.createConsultantProps).toBeDefined());
+        expect(mocks.createConsultantProps).toMatchObject({
+            disabled: true,
+            disabledReasonKey: 'agency.form.registrationSettings.createConsultant.saveAgencyFirst',
+        });
+    });
+
+    it('passes the persisted agency and its topic into consultant quick-create', async () => {
+        mocks.routeId = '282';
+        mocks.agencyData = {
+            id: 282,
+            name: 'E2E Agency',
+            tenantId: 84,
+            topics: [{ id: 7, name: 'Debt counselling' }],
+        };
+
+        renderWithClient(<AgencyPageEdit />);
+
+        await waitFor(() =>
+            expect(mocks.createConsultantProps).toMatchObject({
+                agencyId: '282',
+                topicIds: ['7'],
+                disabled: false,
+            }),
+        );
     });
 
     it('submits a legal card as a narrow patch so later saves cannot wipe sibling legal data', () => {

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -294,7 +294,7 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
                                 editButtonPlacement="footer"
                                 onSave={onSaveCard}
                             >
-                                <RegistrationSettings asFields />
+                                {({ editing }) => <RegistrationSettings asFields editing={editing} />}
                             </CardEditable>
                         </CardDeck.Item>
                         <CardDeck.Item>


### PR DESCRIPTION
## Summary

- sends agency and topic assignments in the consultant creation request
- removes the follow-up agency assignment call that could leave partial users
- enables Quick Create while editing an existing advice center
- requires a new advice center to be saved offline and reopened before Quick Create

## Verification

- `npm test -- --run src/api/counselor/addCounselorData.test.ts src/components/CreateConsultantModal/index.test.ts src/api/agency/addAgencyData.test.ts src/pages/Agency/Edit/index.test.tsx src/pages/Agency/Edit/notFound.test.tsx` (21 passed)
- focused ESLint on all changed TypeScript files
- `npm run build`

Closes #422
Parent: OpenResilienceInitiative/ORISO-UserService#520
Backend contract: OpenResilienceInitiative/ORISO-UserService#521
Backend PR: OpenResilienceInitiative/ORISO-UserService#525

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick consultant creation with agency and topic assignments.
  * Consultant creation now supports existing saved agencies and normalizes assigned IDs.
  * Added guidance when saving an agency is required before creating a consultant.
  * Improved disabled-state messaging for consultant creation.

* **Bug Fixes**
  * Agency and topic assignments are now submitted together reliably during consultant creation.

* **Tests**
  * Added coverage for consultant payloads, ID normalization, and agency edit workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->