### PR TITLE
Stabilize OTP guidance and the mobile login layout

### DIFF
--- a/src/pages/Login/Login.test.tsx
+++ b/src/pages/Login/Login.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Login } from './Login';
+
+vi.mock('./LoginForm', () => ({
+    default: () => <div data-testid="login-form" />,
+}));
+
+vi.mock('./Stage', () => ({
+    default: () => <div data-testid="login-stage" />,
+}));
+
+vi.mock('../../components/Layout/PublicPageLayoutWrapper', () => ({
+    default: ({ children, className }: React.PropsWithChildren<{ className?: string }>) => (
+        <main className={className}>{children}</main>
+    ),
+}));
+
+vi.mock('../../components/LanguageSelector', () => ({
+    LanguageSelector: () => <div data-testid="language-selector" />,
+}));
+
+vi.mock('../../api/auth/auth', () => ({
+    bootstrapAuthSession: () =>
+        new Promise(() => {
+            // Keep the bootstrap pending so the component stays on the login route.
+        }),
+    getAccessTokenForRequests: () => '',
+}));
+
+vi.mock('../../api/auth/accessSessionLocalStorage', () => ({
+    getTokenExpiryFromLocalStorage: () => ({
+        accessTokenValidUntilTime: 0,
+        refreshTokenValidUntilTime: 0,
+    }),
+}));
+
+vi.mock('../../hooks/useUserRoles.hook', () => ({
+    useUserRoles: () => ({
+        hasRole: () => false,
+        isTechnicalAccount: false,
+    }),
+}));
+
+vi.mock('../../hooks/usePublicTenantData.hook', () => ({
+    usePublicTenantData: () => ({ data: undefined }),
+}));
+
+vi.mock('../../context/useAppConfig', () => ({
+    useAppConfigContext: () => ({
+        settings: { mainTenantSubdomainForSingleDomainMultitenancy: '' },
+    }),
+}));
+
+describe('Login responsive layout', () => {
+    it('gives the login form almost the full mobile grid width', () => {
+        render(
+            <MemoryRouter>
+                <Login />
+            </MemoryRouter>,
+        );
+
+        const loginColumn = screen.getByTestId('login-form').parentElement;
+
+        expect(loginColumn).toHaveClass('ant-col-xs-22', 'ant-col-xs-offset-1');
+    });
+});

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -96,7 +96,7 @@ export const Login = () => {
             </div>
             <Stage logo={tenantData?.theming?.logo} claim={tenantData?.content?.claim} />
             <Row align="middle" style={{ flex: '1 0 auto' }}>
-                <Col xs={{ span: 10, offset: 1 }} md={{ span: 6, offset: 3 }} xl={{ span: 4, offset: 6 }}>
+                <Col xs={{ span: 22, offset: 1 }} md={{ span: 6, offset: 3 }} xl={{ span: 4, offset: 6 }}>
                     <LoginForm />
                 </Col>
             </Row>

--- a/src/pages/Login/LoginForm.test.tsx
+++ b/src/pages/Login/LoginForm.test.tsx
@@ -203,4 +203,21 @@ describe('LoginForm', () => {
 
         expect(await screen.findByText('Please enter one-time password')).toBeInTheDocument();
     });
+
+    it('shows the generic OTP guidance when the authentication response omits the OTP type', async () => {
+        mocks.login.mockImplementationOnce((_values, options) =>
+            options.onError({
+                message: FETCH_ERRORS.BAD_REQUEST,
+                options: { data: {} },
+            }),
+        );
+        render(<LoginForm />);
+        const user = await fillRequiredFields();
+
+        await user.click(screen.getByRole('button', { name: 'Sign in' }));
+
+        expect(await screen.findByPlaceholderText('One-time password')).toBeInTheDocument();
+        expect(screen.getByText('Please enter one-time password')).toBeInTheDocument();
+        expect(screen.queryByText('message.form.login.otp.')).not.toBeInTheDocument();
+    });
 });

--- a/src/pages/Login/LoginForm.tsx
+++ b/src/pages/Login/LoginForm.tsx
@@ -28,6 +28,8 @@ const LoginForm = () => {
     const [postLoading, setPostLoading] = useState(false);
     const [otpDisabled, setOtpDisabled] = useState(true);
     const [twoFactorType, setTwoFactorType] = useState(TwoFactorType.None);
+    const otpHelpTextKey =
+        twoFactorType === TwoFactorType.None ? 'message.form.login.otp' : `message.form.login.otp.${twoFactorType}`;
 
     // Function gets fired on Form Submit
     const onFinish = async (values: any) => {
@@ -88,7 +90,7 @@ const LoginForm = () => {
                             label={t('otp')}
                             placeholder={t('otp')}
                             startAdornment={startIcon(<VerifiedUserOutlined fontSize="small" />)}
-                            helpText={t(`message.form.login.otp.${twoFactorType}`)}
+                            helpText={t(otpHelpTextKey)}
                             rules={[{ required: !otpDisabled, message: t('message.form.login.otp') }]}
                         />
                     )}

--- a/src/styles/components/loginForm.less
+++ b/src/styles/components/loginForm.less
@@ -1,4 +1,14 @@
 .loginForm {
+    /*
+     * MUI helper/error text is part of the TextField. Keep a token-based gap
+     * before the next field so multi-line validation messages never collide
+     * with the following floating label on narrow screens.
+     */
+
+    > .ant-form > .MuiTextField-root {
+        margin-bottom: @spacing-s;
+    }
+
     .ant-form-item-label > label {
         &.ant-form-item-required:not(.ant-form-item-required-mark-optional):before,
         &:after {


### PR DESCRIPTION
## Summary

- fall back to generic OTP guidance when the server omits the OTP type
- widen the mobile login column and keep helper text clear of the next field
- add focused login rendering and responsive-layout regression coverage

Closes OpenResilienceInitiative/ORISO-Admin#427

## Verification

- focused login suite — 2 files, 9 tests passed
- `npm run test` — 174 files, 955 tests passed
- `npm run lint:js`
- `npx stylelint --custom-syntax postcss-less src/styles/components/loginForm.less`
- `npm run build`
- Real-browser desktop, mobile, and OTP-required failure evidence is recorded in E2E run `e2e-20260719-1711` and the [Slack evidence canvas](https://sunflowercare.slack.com/docs/T03BZU8ADLM/F0BJQBA0GP6).

## Known repository gate

The repository-wide `npm run lint:css` command is currently broken on `origin/pre-dev`: it invokes Stylelint with `--fix` without the Less/SCSS custom syntaxes and reports hundreds of existing parser and CSS-module errors. The changed Less file passes with `postcss-less` explicitly selected.

## Scope

This remains separate from Admin PR #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
