### PR TITLE
feat(tenant-settings): Team-Besprechung toggle in Other Functions

### DIFF
--- a/src/components/Tenants/AppSettings/OtherFunctionsSettings/OtherFunctionsSettings.test.tsx
+++ b/src/components/Tenants/AppSettings/OtherFunctionsSettings/OtherFunctionsSettings.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => {
+    // react-i18next returns a hybrid: an array [t, i18n, ready] that also carries
+    // t/i18n as properties, so both `const { t } =` and `const [t] =` work.
+    const t = (key: string) => key;
+    const i18n = { language: 'en' };
+    const result: any = [t, i18n, true];
+    result.t = t;
+    result.i18n = i18n;
+    result.ready = true;
+    return { useTranslation: () => result };
+});
+
+vi.mock('../../../../hooks/useSingleTenantData', () => ({
+    useSingleTenantData: () => ({ data: { settings: {} }, isLoading: false }),
+}));
+
+vi.mock('../../../../hooks/useTenantAdminDataMutation.hook', () => ({
+    useTenantAdminDataMutation: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('../../../../context/useAppConfig', () => ({
+    useAppConfigContext: () => ({ settings: { multitenancyWithSingleDomainEnabled: false } }),
+}));
+
+import { OtherFunctionsSettings } from './index';
+
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    })),
+});
+
+describe('OtherFunctionsSettings', () => {
+    it('renders the Team-Besprechung toggle bound to featureTeamDiscussionEnabled', () => {
+        render(<OtherFunctionsSettings tenantId="1" />);
+
+        expect(screen.getByText('tenants.appSettings.otherFunctions.teamDiscussion.title')).toBeInTheDocument();
+        expect(screen.getByText('tenants.appSettings.otherFunctions.teamDiscussion.description')).toBeInTheDocument();
+    });
+});

--- a/src/components/Tenants/AppSettings/OtherFunctionsSettings/index.tsx
+++ b/src/components/Tenants/AppSettings/OtherFunctionsSettings/index.tsx
@@ -69,6 +69,15 @@ export const OtherFunctionsSettings = ({
                     <p className={styles.checkInfo}>{t('tenants.appSettings.otherFunctions.groupChat.description')}</p>
                 </div>
             )}
+            <div className={styles.checkGroup}>
+                <FormSwitchField
+                    labelKey="tenants.appSettings.otherFunctions.teamDiscussion.title"
+                    name={['settings', 'featureTeamDiscussionEnabled']}
+                    inline
+                    disableLabels
+                />
+                <p className={styles.checkInfo}>{t('tenants.appSettings.otherFunctions.teamDiscussion.description')}</p>
+            </div>
         </CardEditable>
     );
 };

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1481,5 +1481,7 @@
     "editor.image.upload.unsupportedType": "Nur PNG-, JPEG- oder WebP-Bilder sind erlaubt.",
     "editor.image.upload.tooLarge": "Das Bild ist zu groß (max. 2 MB).",
     "editor.image.upload.failed": "Bild-Upload fehlgeschlagen. Bitte erneut versuchen.",
-    "editor.image.upload.uploading": "Lädt hoch…"
+    "editor.image.upload.uploading": "Lädt hoch…",
+    "tenants.appSettings.otherFunctions.teamDiscussion.title": "Team-Besprechung erlauben",
+    "tenants.appSettings.otherFunctions.teamDiscussion.description": "Berater:innen können sich zu einer offenen Anfrage in einem nur für das Team sichtbaren Raum abstimmen, den die ratsuchende Person nie sieht; er schließt bei Annahme der Anfrage."
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1481,5 +1481,7 @@
     "editor.image.upload.unsupportedType": "Only PNG, JPEG or WebP images are allowed.",
     "editor.image.upload.tooLarge": "The image is too large (max. 2 MB).",
     "editor.image.upload.failed": "Image upload failed. Please try again.",
-    "editor.image.upload.uploading": "Uploading…"
+    "editor.image.upload.uploading": "Uploading…",
+    "tenants.appSettings.otherFunctions.teamDiscussion.title": "Allow team discussion",
+    "tenants.appSettings.otherFunctions.teamDiscussion.description": "Advisors can coordinate on an open request in a team-only room the advice seeker never sees; it closes when the request is accepted."
 }

--- a/src/types/tenant.d.ts
+++ b/src/types/tenant.d.ts
@@ -6,6 +6,7 @@ export interface TenantSettings {
     topicsInRegistrationEnabled?: boolean | null;
     featureStatisticsEnabled?: boolean | null;
     featureGroupChatV2Enabled?: boolean | null;
+    featureTeamDiscussionEnabled?: boolean | null;
     featureCentralDataProtectionTemplateEnabled?: boolean | null;
     featureAnonymousChatEnabled?: boolean | null;
     featureCallsEnabled?: boolean | null;


### PR DESCRIPTION
## Problem

The Team-Besprechung (ADR-016) is now a per-tenant flag (`featureTeamDiscussionEnabled`, ORISO-TenantService#98 + ORISO-UserService#532), but there was no way for a tenant admin to toggle it.

## What changed

- `OtherFunctionsSettings`: a `FormSwitchField` bound to `['settings','featureTeamDiscussionEnabled']`, mirroring the group-chat toggle.
- `tenant.d.ts`: `featureTeamDiscussionEnabled?: boolean | null`.
- en/de i18n title + description.

## Verification

- `OtherFunctionsSettings` render test: toggle present + labels (RED→GREEN).
- `tsc` clean, `eslint --max-warnings=0` clean, `prettier --check` clean, full suite **960 green**.

Part of the Team-Besprechung epic (OpenResilienceInitiative/ORISO-Frontend#512). Pairs with ORISO-TenantService#98 (flag) and ORISO-UserService#532 (gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Team Discussion” setting that can be enabled or disabled alongside other tenant functionality.
  * Added English and German translations describing the new setting.

* **Tests**
  * Added coverage verifying that the Team Discussion setting displays its title and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->