### PR TITLE
fix(login): align login fields with the M3 outlined-field standard

### DIFF
--- a/src/components/mui/MuiFormField/index.tsx
+++ b/src/components/mui/MuiFormField/index.tsx
@@ -126,7 +126,7 @@ const MuiControl = ({
                     : null),
                 // Story / demo: force hover appearance without a real pointer.
                 '&.pseudo-hover .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline': {
-                    borderColor: 'var(--admin-form-field-text, #1b1b1b)',
+                    borderColor: 'var(--input-hover-border-color, var(--admin-form-field-text, #1b1b1b))',
                 },
                 '&.pseudo-hover .MuiFilledInput-root': {
                     backgroundColor: 'var(--input-bg, rgba(0, 0, 0, 0.09))',
@@ -159,13 +159,25 @@ const MuiControl = ({
                     whiteSpace: 'pre-wrap',
                     overflowWrap: 'anywhere',
                 },
+                // Browser autofill: Chrome/Safari force their own (blue/cream)
+                // fill via a UA !important background. Paint the field's own
+                // surface over it with an inset box-shadow and keep the admin
+                // text colour. `--input-autofill-surface` lets transparent
+                // fields (e.g. login) substitute the page surface instead.
+                '& .MuiInputBase-input:-webkit-autofill, & .MuiInputBase-input:-webkit-autofill:hover, & .MuiInputBase-input:-webkit-autofill:focus':
+                    {
+                        WebkitBoxShadow: 'inset 0 0 0 1000px var(--input-autofill-surface, var(--input-bg, #fcf9f9))',
+                        WebkitTextFillColor: 'var(--admin-form-field-text, #1b1b1c)',
+                        caretColor: 'var(--admin-form-field-text, #1b1b1c)',
+                        transition: 'background-color 9999s ease-out 0s',
+                    },
                 '& .MuiInputLabel-root': {
                     maxWidth: 'calc(100% - 24px)',
                     color: 'var(--label-color)',
                     fontFamily: 'var(--m3-body-font-family)',
                 },
                 '& .MuiInputLabel-root.Mui-focused': {
-                    color: 'var(--admin-form-field-text)',
+                    color: 'var(--input-focus-label-color, var(--admin-form-field-text))',
                 },
                 '& .MuiInputLabel-root.Mui-error': {
                     color: 'var(--form-error, #cc0000)',
@@ -180,11 +192,13 @@ const MuiControl = ({
                     fontSize: '0.75em',
                 },
                 '& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline': {
-                    borderColor: 'var(--admin-form-field-text, #1b1b1b)',
+                    borderColor: 'var(--input-hover-border-color, var(--admin-form-field-text, #1b1b1b))',
                 },
-                // Focus: a clean solid black border (no browser outline / glow).
+                // Focus: a clean solid 2px border (no browser outline / glow).
+                // Colour defaults to the admin black; scopes like the login can
+                // switch it to the M3 primary via `--input-focus-border-color`.
                 '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                    borderColor: 'var(--admin-form-field-text, #1b1b1b)',
+                    borderColor: 'var(--input-focus-border-color, var(--admin-form-field-text, #1b1b1b))',
                     borderWidth: 2,
                 },
                 '& .MuiOutlinedInput-root.Mui-focused': {

--- a/src/styles/components/loginForm.less
+++ b/src/styles/components/loginForm.less
@@ -1,5 +1,33 @@
 .loginForm {
     /*
+     * M3 outlined-field standard (see FloatingLabelInput /
+     * floatingLabelInput.module.scss): transparent field surface, m3-outline
+     * resting border, primary focus ring, m3-error state. The MuiFormField sx
+     * consumes these custom properties, so scoping them here restyles only the
+     * login fields. The form sits on the white `.publicContent` page surface
+     * (NOT the dark stage panel), so:
+     *  - the floating label blends through the notched-outline gap with no
+     *    chip background needed, and
+     *  - browser autofill gets painted over with the white page surface
+     *    (a transparent box-shadow could not cover the UA blue fill).
+     */
+    --input-bg: transparent;
+    --input-border-color: var(--m3-outline, #747878);
+    --label-color: var(--m3-on-surface-variant, #444748);
+    --input-hover-border-color: var(--m3-on-surface, #1b1b1c);
+    --input-focus-border-color: var(--m3-primary, #a5000a);
+    --input-focus-label-color: var(--m3-primary, #a5000a);
+    --form-error: var(--m3-error, #ba1a1a);
+    --input-autofill-surface: var(--white, #ffffff);
+
+    /* Leading (person/lock) and trailing (visibility) icons: muted
+     * on-surface-variant. The error icon keeps its inline error colour. */
+
+    .MuiInputAdornment-root .MuiSvgIcon-root {
+        color: var(--m3-on-surface-variant, #444748);
+    }
+
+    /*
      * MUI helper/error text is part of the TextField. Keep a token-based gap
      * before the next field so multi-line validation messages never collide
      * with the following floating label on narrow screens.


### PR DESCRIPTION
## Problem

The login screen's MUI fields still rendered the old look: opaque cream fill (bluish under browser autofill), grey outline, black focus border and label — inconsistent with the M3 outlined fields used everywhere else in the admin.

## What changed

- `MuiFormField`: exposed CSS-variable hooks (hover/focus border, focus label, autofill surface) whose fallbacks are the exact previous values — every other MUI-field page (Tenants/users/Agency Edit, GlobalSettings, PasswordReset) renders pixel-identical. New `-webkit-autofill` rule paints the field surface instead of Chrome's blue.
- `loginForm.less`: scoped M3 values for the login only — transparent field surface, 1px `#747878` outline, focus = 2px `#A5000A` border + primary label, error in `--m3-error`, muted `#444748` adornment icons, white autofill surface (the fields sit on the white `.publicContent`, not the dark branding stage).

Visual only: no changes to submit logic, mutation hooks, 2FA/OTP flow, or field names/values.

## Verification

- `npx tsc --noEmit`, `npx eslint src --max-warnings=0`, `npx prettier --check src` — clean
- `npx vitest run src/pages/Login src/components/mui/MuiFormField` — 14/14 green
- Rendered live (vite, worktree): resting/focused/filled states screenshot-verified; focused/error label colors confirmed via computed styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)