### PR TITLE
feat: let platform admins skip 2FA setup and enable it later

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,7 @@ import {
 import { LogsTabsLayout } from './pages/Logs/LogsTabsLayout';
 import { useUserData } from './hooks/useUserData.hook';
 import { requiresPlatformAdminTwoFactor } from './utils/platformAdminTwoFactorGate';
+import { useTwoFactorSetupDeferral } from './hooks/useTwoFactorSetupDeferral.hook';
 import { MandatoryTwoFactorSetup } from './pages/Profile/MandatoryTwoFactorSetup';
 
 const AgencyInitialMeetingRedirect = () => {
@@ -82,6 +83,9 @@ export const App = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const { hasRole, isSuperAdmin } = useUserRoles();
+    const { isDeferred: isTwoFactorSetupDeferred, deferSetup: deferTwoFactorSetup } = useTwoFactorSetupDeferral(
+        userData?.username,
+    );
     const { can } = useUserPermissions();
     const { isEnabled: isReleaseEnabled } = useReleasesToggle();
 
@@ -135,7 +139,7 @@ export const App = () => {
     const canReadStatistic = can(PermissionAction.Read, Resource.Statistic);
     const showCaseHandoverLogs = canReadCaseHandoverAdmin(isSuperAdmin, hasRole, can);
     const showSupervisorLogs = canSeeSupervisorLogs(isSuperAdmin, hasRole, can);
-    const requiresTwoFactorSetup = requiresPlatformAdminTwoFactor(isSuperAdmin, userData);
+    const requiresTwoFactorSetup = requiresPlatformAdminTwoFactor(isSuperAdmin, userData, isTwoFactorSetupDeferred);
 
     if (isLoading || (isSuperAdmin && isUserDataLoading)) {
         return <Initialization />;
@@ -163,7 +167,7 @@ export const App = () => {
         return (
             <FeatureProvider tenantData={data} publicTenantData={publicTenantData}>
                 <ProtectedPageLayoutWrapper>
-                    <MandatoryTwoFactorSetup />
+                    <MandatoryTwoFactorSetup onSkip={deferTwoFactorSetup} />
                 </ProtectedPageLayoutWrapper>
             </FeatureProvider>
         );

--- a/src/hooks/useTwoFactorSetupDeferral.hook.ts
+++ b/src/hooks/useTwoFactorSetupDeferral.hook.ts
@@ -1,0 +1,23 @@
+import { useCallback, useEffect, useState } from 'react';
+import { deferTwoFactorSetup, isTwoFactorSetupDeferred } from '../utils/twoFactorSetupDeferral';
+
+/**
+ * Tracks whether the current admin skipped the two-factor setup prompt.
+ *
+ * `username` arrives asynchronously with the user data, so the stored value is
+ * re-read whenever it changes instead of only on mount.
+ */
+export const useTwoFactorSetupDeferral = (username?: string) => {
+    const [isDeferred, setIsDeferred] = useState<boolean>(() => isTwoFactorSetupDeferred(username));
+
+    useEffect(() => {
+        setIsDeferred(isTwoFactorSetupDeferred(username));
+    }, [username]);
+
+    const deferSetup = useCallback(() => {
+        deferTwoFactorSetup(username);
+        setIsDeferred(true);
+    }, [username]);
+
+    return { isDeferred, deferSetup };
+};

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1381,7 +1381,7 @@
     "twoFactorAuth.switch.type.label": "Ihr 2. Faktor",
     "twoFactorAuth.title": "Zwei-Faktor-Authentifizierung",
     "twoFactorAuth.required.title": "Plattform-Admin-Konto absichern",
-    "twoFactorAuth.required.subtitle": "Richten Sie die Zwei-Faktor-Authentifizierung ein, bevor Sie den Administrationsbereich weiter nutzen.",
+    "twoFactorAuth.required.subtitle": "Richten Sie die Zwei-Faktor-Authentifizierung ein oder fahren Sie fort und aktivieren Sie sie später in Ihrem Profil.",
     "twoFactorAuth.required.unavailable": "Die Zwei-Faktor-Authentifizierung ist verpflichtend, aber für Plattform-Admins nicht aktiviert. Bitte kontaktieren Sie den Betrieb.",
     "users.allUsers": "Nutzer*innen",
     "agency.cardDeck.next": "Weitere Karte anzeigen",
@@ -1484,5 +1484,7 @@
     "editor.image.upload.failed": "Bild-Upload fehlgeschlagen. Bitte erneut versuchen.",
     "editor.image.upload.uploading": "Lädt hoch…",
     "tenants.appSettings.otherFunctions.teamDiscussion.title": "Team-Besprechung erlauben",
-    "tenants.appSettings.otherFunctions.teamDiscussion.description": "Berater:innen können sich zu einer offenen Anfrage in einem nur für das Team sichtbaren Raum abstimmen, den die ratsuchende Person nie sieht; er schließt bei Annahme der Anfrage."
+    "tenants.appSettings.otherFunctions.teamDiscussion.description": "Berater:innen können sich zu einer offenen Anfrage in einem nur für das Team sichtbaren Raum abstimmen, den die ratsuchende Person nie sieht; er schließt bei Annahme der Anfrage.",
+    "twoFactorAuth.required.skip": "Später einrichten",
+    "twoFactorAuth.required.skipHint": "Sie können die Zwei-Faktor-Authentifizierung jederzeit unter Profil aktivieren."
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -856,7 +856,7 @@
     "twoFactorAuth.subtitle": "Use an additional app to sign in to your Online Counseling & Help account. This makes your account more secure against unauthorized access.",
     "twoFactorAuth.title": "Two-factor authentication",
     "twoFactorAuth.required.title": "Secure your platform-admin account",
-    "twoFactorAuth.required.subtitle": "Set up two-factor authentication before continuing to the administration area.",
+    "twoFactorAuth.required.subtitle": "Set up two-factor authentication, or continue and enable it later from your profile.",
     "twoFactorAuth.required.unavailable": "Two-factor authentication is required but is not enabled for platform administrators. Please contact operations.",
     "users.sectionPills.counsellorAdmins": "Counsellor Admin",
     "users.sectionPills.counsellors": "Counsellors",
@@ -1484,5 +1484,7 @@
     "editor.image.upload.failed": "Image upload failed. Please try again.",
     "editor.image.upload.uploading": "Uploading…",
     "tenants.appSettings.otherFunctions.teamDiscussion.title": "Allow team discussion",
-    "tenants.appSettings.otherFunctions.teamDiscussion.description": "Advisors can coordinate on an open request in a team-only room the advice seeker never sees; it closes when the request is accepted."
+    "tenants.appSettings.otherFunctions.teamDiscussion.description": "Advisors can coordinate on an open request in a team-only room the advice seeker never sees; it closes when the request is accepted.",
+    "twoFactorAuth.required.skip": "Set up later",
+    "twoFactorAuth.required.skipHint": "You can enable two-factor authentication at any time under Profile."
 }

--- a/src/pages/Profile/MandatoryTwoFactorSetup.tsx
+++ b/src/pages/Profile/MandatoryTwoFactorSetup.tsx
@@ -1,11 +1,18 @@
-import { Alert, Col, Row } from 'antd';
+import { Alert, Button, Col, Row, Typography } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { Card } from '../../components/Card';
 import { Page } from '../../components/Page';
 import { useUserData } from '../../hooks/useUserData.hook';
 import TwoFactorAuth from './TwoFactorAuth/TwoFactorAuth';
 
-export const MandatoryTwoFactorSetup = () => {
+const { Paragraph } = Typography;
+
+interface MandatoryTwoFactorSetupProps {
+    // When provided, the admin can leave the prompt and set 2FA up later.
+    onSkip?: () => void;
+}
+
+export const MandatoryTwoFactorSetup = ({ onSkip }: MandatoryTwoFactorSetupProps) => {
     const { t } = useTranslation();
     const { data: userData } = useUserData();
     const setupAvailable = userData?.twoFactorAuth?.isEnabled === true;
@@ -26,6 +33,14 @@ export const MandatoryTwoFactorSetup = () => {
                     <Card titleKey="twoFactorAuth.title" subTitleKey="twoFactorAuth.subtitle">
                         <TwoFactorAuth required />
                     </Card>
+                    {onSkip && (
+                        <div className="mt-m">
+                            <Button type="link" onClick={onSkip} data-cy="two-factor-skip">
+                                {t('twoFactorAuth.required.skip')}
+                            </Button>
+                            <Paragraph type="secondary">{t('twoFactorAuth.required.skipHint')}</Paragraph>
+                        </div>
+                    )}
                 </Col>
             </Row>
         </Page>

--- a/src/utils/platformAdminTwoFactorGate.test.ts
+++ b/src/utils/platformAdminTwoFactorGate.test.ts
@@ -8,7 +8,7 @@ const userData = (isActive: boolean, isToEncourage = true) =>
     } as UserData);
 
 describe('platform-admin two-factor gate', () => {
-    it('blocks a platform admin until 2FA is active', () => {
+    it('prompts a platform admin until 2FA is active', () => {
         expect(requiresPlatformAdminTwoFactor(true, userData(false))).toBe(true);
     });
 
@@ -22,5 +22,17 @@ describe('platform-admin two-factor gate', () => {
 
     it('does not impose the platform policy on tenant-scoped admins', () => {
         expect(requiresPlatformAdminTwoFactor(false, userData(false))).toBe(false);
+    });
+
+    it('lets an admin through once they choose to set 2FA up later', () => {
+        expect(requiresPlatformAdminTwoFactor(true, userData(false), true)).toBe(false);
+    });
+
+    it('keeps prompting an admin who has not skipped', () => {
+        expect(requiresPlatformAdminTwoFactor(true, userData(false), false)).toBe(true);
+    });
+
+    it('still fails closed when data is missing even if setup was skipped', () => {
+        expect(requiresPlatformAdminTwoFactor(true, undefined, true)).toBe(true);
     });
 });

--- a/src/utils/platformAdminTwoFactorGate.ts
+++ b/src/utils/platformAdminTwoFactorGate.ts
@@ -1,8 +1,21 @@
 import { UserData } from '../types/user';
 
-export const requiresPlatformAdminTwoFactor = (isPlatformAdmin: boolean, userData?: UserData): boolean => {
+/**
+ * Decides whether the admin area stays behind the two-factor setup screen.
+ *
+ * 2FA is encouraged, not mandatory: an admin who chooses "set up later"
+ * (`isSetupDeferred`) reaches the normal screens and can enable it from their
+ * profile whenever they want.
+ */
+export const requiresPlatformAdminTwoFactor = (
+    isPlatformAdmin: boolean,
+    userData?: UserData,
+    isSetupDeferred = false,
+): boolean => {
     if (!isPlatformAdmin) return false;
     if (!userData?.twoFactorAuth) return true;
+    if (userData.twoFactorAuth.isActive === true) return false;
+    if (isSetupDeferred) return false;
 
-    return userData.twoFactorAuth.isToEncourage === true && userData.twoFactorAuth.isActive !== true;
+    return userData.twoFactorAuth.isToEncourage === true;
 };

--- a/src/utils/twoFactorSetupDeferral.test.ts
+++ b/src/utils/twoFactorSetupDeferral.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { deferTwoFactorSetup, isTwoFactorSetupDeferred } from './twoFactorSetupDeferral';
+
+describe('two-factor setup deferral', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    it('reports no deferral before the admin skips', () => {
+        expect(isTwoFactorSetupDeferred('chucknorris')).toBe(false);
+    });
+
+    it('remembers that the admin chose to set 2FA up later', () => {
+        deferTwoFactorSetup('chucknorris');
+
+        expect(isTwoFactorSetupDeferred('chucknorris')).toBe(true);
+    });
+
+    it('does not carry one admin deferral over to another account', () => {
+        deferTwoFactorSetup('chucknorris');
+
+        expect(isTwoFactorSetupDeferred('someone-else')).toBe(false);
+    });
+
+    it('ignores a missing username instead of deferring for everyone', () => {
+        deferTwoFactorSetup(undefined);
+
+        expect(sessionStorage.length).toBe(0);
+        expect(isTwoFactorSetupDeferred(undefined)).toBe(false);
+    });
+
+    it('re-prompts once the session storage is cleared, as logout does', () => {
+        deferTwoFactorSetup('chucknorris');
+        sessionStorage.clear();
+
+        expect(isTwoFactorSetupDeferred('chucknorris')).toBe(false);
+    });
+});

--- a/src/utils/twoFactorSetupDeferral.ts
+++ b/src/utils/twoFactorSetupDeferral.ts
@@ -1,0 +1,36 @@
+const STORAGE_KEY = 'oriso.admin.twoFactorSetupDeferredFor';
+
+/**
+ * Remembers that an admin chose "set up later" on the two-factor prompt.
+ *
+ * Scoped to the browser session on purpose: skipping unblocks the admin area
+ * for the rest of this session, and the prompt returns at the next login so
+ * 2FA keeps being encouraged rather than silently dropped forever. The value
+ * is the username, so a different admin signing in on the same browser is
+ * still prompted.
+ *
+ * Logout already calls sessionStorage.clear(), so signing out drops the
+ * deferral without any extra bookkeeping here.
+ *
+ * Storage access is wrapped because sessionStorage throws in some privacy
+ * modes; a failure there must never block the admin area.
+ */
+export const isTwoFactorSetupDeferred = (username?: string): boolean => {
+    if (!username) return false;
+
+    try {
+        return sessionStorage.getItem(STORAGE_KEY) === username;
+    } catch {
+        return false;
+    }
+};
+
+export const deferTwoFactorSetup = (username?: string): void => {
+    if (!username) return;
+
+    try {
+        sessionStorage.setItem(STORAGE_KEY, username);
+    } catch {
+        // Ignored: a browser that refuses storage just re-prompts on reload.
+    }
+};


### PR DESCRIPTION
Closing the two-factor setup dialogue left the card on screen with every admin route still blocked, so a platform admin who did not want 2FA yet could not reach the application at all.

Makes 2FA encouraged rather than mandatory.

- Adds a "Set up later" action to the setup screen.
- Records the choice per username in `sessionStorage`, so the prompt returns at the next login rather than being dismissed forever. `logout` already clears `sessionStorage`, so signing out drops it too.
- Teaches `requiresPlatformAdminTwoFactor` about the deferral. It still fails closed when user data is unavailable, and an active credential still unblocks as before.
- Adds `en`/`de` strings and softens the now-inaccurate "before continuing" subtitle.

2FA stays available any time from Profile, which already renders the same `TwoFactorAuth` component.

**Verification**
- `npx vitest run` on both touched specs: 12 passed (3 new gate cases, 5 new deferral cases).
- `npm run test`: 43 failures, identical to `pre-dev` baseline; +8 passing.
- `npm run build`: clean (0 TS errors).
- `eslint` / `prettier` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Platform administrators can defer two-factor authentication setup and enable it later from their profile.
  * The deferral choice is remembered for the current session and applies only to the selected account.
  * Added guidance and “Set up later” messaging in English and German.

* **Bug Fixes**
  * Two-factor setup requirements continue to enforce platform security policies when required configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->