### PR TITLE
ci: scope the GHA build cache per image to stop stale-bundle publishes

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -15,6 +15,11 @@ inputs:
         type: string
         default: Dockerfile
 
+outputs:
+    digest:
+        description: Immutable digest of the pushed image, for race-proof verification.
+        value: ${{ steps.build.outputs.digest }}
+
 runs:
     using: 'composite'
     steps:

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -48,5 +48,12 @@ runs:
               push: ${{ inputs.push_to_ghcr }}
               tags: ${{ steps.meta.outputs.tags }}
               labels: ${{ steps.meta.outputs.labels }}
-              cache-from: type=gha
-              cache-to: type=gha,mode=max
+              # Scope the GHA cache per image. `oriso-admin` (Dockerfile) and
+              # `oriso-admin-storybook` (Dockerfile.storybook) build from this same
+              # action on every push to pre-dev/dev/main. Without a scope they share
+              # one GHA cache namespace and race, which let one image restore the
+              # other's (or an older) `COPY build` layer — shipping a stale bundle
+              # under a fresh :pre-dev tag (issue #424). image_name is distinct per
+              # image, so this isolates them while keeping push+PR cache reuse.
+              cache-from: type=gha,scope=${{ inputs.image_name }}
+              cache-to: type=gha,mode=max,scope=${{ inputs.image_name }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -34,3 +34,34 @@ jobs:
                   push_to_ghcr: true
                   image_name: oriso-admin
                   github_token: ${{ secrets.GITHUB_TOKEN }}
+
+            # Guard against the stale-bundle class of failure (issue #424): the
+            # image we just published must contain exactly the frontend bundle
+            # this run built, not a cache-restored older one. Green CI + a fresh
+            # image timestamp hid this before, so assert it explicitly.
+            - name: Verify the published image contains the freshly built bundle
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  built="$(cd build/assets && ls index-*.js | head -n1)"
+                  if [ -z "$built" ]; then
+                    echo "::error::npm run build produced no build/assets/index-*.js"
+                    exit 1
+                  fi
+                  case "${GITHUB_REF_NAME}" in
+                    main)    tag=latest ;;
+                    dev)     tag=dev ;;
+                    pre-dev) tag=pre-dev ;;
+                    *)       echo "::error::unexpected ref ${GITHUB_REF_NAME}"; exit 1 ;;
+                  esac
+                  image="${REGISTRY}/${ORG}/oriso-admin:${tag}"
+                  docker pull -q "$image"
+                  shipped="$(docker run --rm --entrypoint sh "$image" \
+                    -c 'ls /usr/share/nginx/html/admin/assets/index-*.js' \
+                    | xargs -n1 basename | head -n1)"
+                  echo "built entry bundle:   ${built}"
+                  echo "shipped entry bundle: ${shipped}"
+                  if [ "${built}" != "${shipped}" ]; then
+                    echo "::error::${image} ships '${shipped}' but this run built '${built}' — stale bundle in image (issue #424)."
+                    exit 1
+                  fi

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -29,6 +29,7 @@ jobs:
                   node_version: '22.12.0'
 
             - name: Create and Publish Docker image
+              id: publish
               uses: ./.github/actions/docker-build-push
               with:
                   push_to_ghcr: true
@@ -38,9 +39,13 @@ jobs:
             # Guard against the stale-bundle class of failure (issue #424): the
             # image we just published must contain exactly the frontend bundle
             # this run built, not a cache-restored older one. Green CI + a fresh
-            # image timestamp hid this before, so assert it explicitly.
+            # image timestamp hid this before, so assert it explicitly. Inspect
+            # the immutable digest, never the mutable :pre-dev tag — a concurrent
+            # push could rewrite the tag between publish and pull.
             - name: Verify the published image contains the freshly built bundle
               shell: bash
+              env:
+                  DIGEST: ${{ steps.publish.outputs.digest }}
               run: |
                   set -euo pipefail
                   built="$(cd build/assets && ls index-*.js | head -n1)"
@@ -48,20 +53,18 @@ jobs:
                     echo "::error::npm run build produced no build/assets/index-*.js"
                     exit 1
                   fi
-                  case "${GITHUB_REF_NAME}" in
-                    main)    tag=latest ;;
-                    dev)     tag=dev ;;
-                    pre-dev) tag=pre-dev ;;
-                    *)       echo "::error::unexpected ref ${GITHUB_REF_NAME}"; exit 1 ;;
-                  esac
-                  image="${REGISTRY}/${ORG}/oriso-admin:${tag}"
-                  docker pull -q "$image"
-                  shipped="$(docker run --rm --entrypoint sh "$image" \
+                  if [ -z "${DIGEST}" ]; then
+                    echo "::error::build step exposed no image digest to verify against"
+                    exit 1
+                  fi
+                  ref="${REGISTRY}/${ORG}/oriso-admin@${DIGEST}"
+                  docker pull -q "$ref"
+                  shipped="$(docker run --rm --entrypoint sh "$ref" \
                     -c 'ls /usr/share/nginx/html/admin/assets/index-*.js' \
                     | xargs -n1 basename | head -n1)"
                   echo "built entry bundle:   ${built}"
                   echo "shipped entry bundle: ${shipped}"
                   if [ "${built}" != "${shipped}" ]; then
-                    echo "::error::${image} ships '${shipped}' but this run built '${built}' — stale bundle in image (issue #424)."
+                    echo "::error::${ref} ships '${shipped}' but this run built '${built}' — stale bundle in image (issue #424)."
                     exit 1
                   fi


### PR DESCRIPTION
Closes #424

**Problem:** `oriso-admin` (`Dockerfile`) and `oriso-admin-storybook` (`Dockerfile.storybook`) both build from the shared `docker-build-push` action on every push to `pre-dev`/`dev`/`main`. The action used `cache-from/to: type=gha` with **no `scope`**, so both images shared one GHA cache namespace and raced — letting one build restore the other's (or an older) `COPY build …` layer. Result: the published `:pre-dev` image shipped a stale frontend bundle while CI was green and the image timestamp looked fresh (verified on Pre-Dev: none of that day's merges were in the served assets).

**What changed**
- `docker-build-push/action.yml`: scope the GHA cache per image — `type=gha,scope=${{ inputs.image_name }}` on both `cache-from` and `cache-to`. `image_name` is distinct per image, so the two families are isolated while push+PR builds of the same image still share cache.
- `ci-main.yml`: after publishing, pull the just-tagged image and assert its `/usr/share/nginx/html/admin/assets/index-*.js` matches the `build/assets/index-*.js` this run produced. This makes the failure class fail loudly instead of silently green.

**Verification:** both YAML files parse (`yaml.safe_load`); the new step passes `bash -n`. Final proof is the next `pre-dev` build — the assertion self-checks the image, and the cache scopes can be confirmed in the buildx logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image caching to prevent stale or incorrect build layers from being reused across different images.
  * Added validation to ensure published images contain the frontend bundle generated by the current build.
  * Builds now fail when a published image contains an outdated frontend asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->