### PR TITLE
fix(agency): restore multi-select topics and never clear departments implicitly

### DIFF
--- a/src/api/agency/updateAgencyData.test.ts
+++ b/src/api/agency/updateAgencyData.test.ts
@@ -16,7 +16,7 @@ const agencyModel: any = { id: '55', consultingType: '1' };
 
 const sentBody = () => JSON.parse(mocks.fetchData.mock.calls[0][0].bodyData);
 
-describe('updateAgencyData — ADR-003 single-select topic', () => {
+describe('updateAgencyData — ADR-014 multi-topic departments', () => {
     beforeEach(() => {
         mocks.fetchData.mockReset();
         mocks.fetchData.mockResolvedValue({ _embedded: {} });
@@ -24,7 +24,18 @@ describe('updateAgencyData — ADR-003 single-select topic', () => {
         mocks.updateAgencyPostCodeRange.mockResolvedValue(undefined);
     });
 
-    it('sends the single-select Option as a one-element topicIds array', async () => {
+    it('sends every selected topic, not just the first', async () => {
+        // ADR-014: one Beratungsstelle carries several Fachbereiche. Dropping any of them here
+        // deletes the corresponding agency_topic row — together with that department's published
+        // Impressum and Datenschutzerklärung (orphanRemoval on Agency.agencyTopics).
+        await updateAgencyData(agencyModel, {
+            ...agencyModel,
+            topicIds: [{ value: '3' }, { value: '9' }, { value: '12' }],
+        } as any);
+        expect(sentBody().topicIds).toEqual(['3', '9', '12']);
+    });
+
+    it('still accepts a lone Option from the former single-select shape', async () => {
         await updateAgencyData(agencyModel, {
             ...agencyModel,
             topicIds: { value: '7', label: 'Debt counselling' },
@@ -32,19 +43,20 @@ describe('updateAgencyData — ADR-003 single-select topic', () => {
         expect(sentBody().topicIds).toEqual(['7']);
     });
 
-    it('sends an empty topicIds array when the picker was cleared', async () => {
-        // Regression guard: with the old `|| topics` fallback a cleared [] fell back to the
-        // backend topics and could not be cleared. `?? topics` + normalize keeps it empty.
+    it('sends an empty topicIds array when the picker was explicitly cleared', async () => {
+        // Explicit clearing must stay possible and distinguishable from "field absent" below.
         await updateAgencyData(agencyModel, { ...agencyModel, topicIds: [] } as any);
         expect(sentBody().topicIds).toEqual([]);
     });
 
-    it('still accepts the legacy Option[] shape', async () => {
-        await updateAgencyData(agencyModel, {
-            ...agencyModel,
-            topicIds: [{ value: '3' }, { value: '9' }],
-        } as any);
-        expect(sentBody().topicIds).toEqual(['3', '9']);
+    it('omits topicIds entirely when the form carries no topic field', async () => {
+        // The picker only renders when the topic list loaded (`topics?.length > 0 &&` in
+        // AgencySettings). If that request failed, the field is absent — and sending [] would tell
+        // the backend to clear every department. Omitting the key makes the backend's
+        // AgencyTopicMergeService keep the existing links (null = keep, [] = clear).
+        const withoutTopics: any = { id: '55', consultingType: '1', name: 'Caritas Neukölln' };
+        await updateAgencyData(agencyModel, withoutTopics);
+        expect(sentBody()).not.toHaveProperty('topicIds');
     });
 });
 

--- a/src/api/agency/updateAgencyData.ts
+++ b/src/api/agency/updateAgencyData.ts
@@ -25,14 +25,21 @@ export const updateAgencyData = async (agencyModel: AgencyData, formInput: Agenc
     const consultingTypeId =
         formInput.consultingType !== null ? parseInt(formInput.consultingType, 10) : await getConsultingType4Tenant();
 
-    // ADR-003: topicIds may arrive as a single-select Option, a legacy Option[]/string[], or the
+    // ADR-014: topicIds may arrive as a multi-select Option[], a lone Option, a string[], or the
     // backend `topics` shape — normalise all of them to the string[] the API expects.
-    const topicIds = normalizeTopicIds(formInput?.topicIds ?? formInput?.topics);
+    //
+    // Absent is NOT the same as empty. The picker only renders once the topic list loaded
+    // (`topics?.length > 0 &&` in AgencySettings), and narrow card patches carry no topic data at
+    // all. Sending [] in those cases tells the backend to clear every department — which deletes
+    // the agency_topic rows and, with them, each department's published Impressum and
+    // Datenschutzerklärung. Omitting the key makes AgencyTopicMergeService keep the existing links.
+    const hasTopicField = formInput?.topicIds !== undefined || formInput?.topics !== undefined;
+    const topicIds = hasTopicField ? normalizeTopicIds(formInput.topicIds ?? formInput.topics) : undefined;
 
     const agencyDataRequestBody = withLegacyDioceseId({
         name: formInput.name,
         description: formInput.description,
-        topicIds,
+        ...(hasTopicField ? { topicIds } : {}),
         postcode: formInput.postcode,
         city: formInput.city,
         street: formInput.street,

--- a/src/pages/Agency/Edit/components/AgencySettings/index.tsx
+++ b/src/pages/Agency/Edit/components/AgencySettings/index.tsx
@@ -61,11 +61,13 @@ export const AgencySettings = ({ isEditMode, asFields }: AgencySettingsProps) =>
             )}
 
             {topics?.length > 0 && (
-                // ADR-003: a department is the unique (agency × topic) pairing, so an agency maps to
-                // at most one topic — single-select replaces the former multi-select.
+                // ADR-014: one Beratungsstelle hosts several Fachbereiche. A department is still the
+                // unique (agency × topic) pairing — an agency simply carries more than one of them,
+                // each with its own Impressum and Datenschutzerklärung.
                 <SelectFormField
                     label="topics.title"
                     name="topicIds"
+                    isMulti
                     labelInValue
                     allowClear
                     placeholder="plsSelect"

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -148,7 +148,10 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
         ...counsellingRelationsInitialValues,
         postCodeRangesActive: !hasOnlyDefaultRangeDefined(postCodes || []),
         online: agencyData?.id ? !agencyData?.offline : false,
-        topicIds: convertToOptions(agencyData?.topics, 'name', 'id', true)[0],
+        // ADR-014: load every department, not just the first. Taking [0] here was the entry point
+        // of the data loss — the form then sent that single topic back and the backend deleted the
+        // other agency_topic rows together with their published legal texts.
+        topicIds: convertToOptions(agencyData?.topics, 'name', 'id', true),
         tenantId: agencyTenantId,
     };
 

--- a/src/types/agency.d.ts
+++ b/src/types/agency.d.ts
@@ -44,8 +44,9 @@ export interface AgencyData {
     city: string;
     counsellingRelations: CounsellingRelation[];
     topics: TopicData[];
-    // ADR-003: single-select topic picker — the form field holds a single labelInValue Option
-    // (or undefined when cleared); legacy array shapes stay accepted for backwards compatibility.
+    // ADR-014: multi-select topic picker — the form field holds the agency's departments as
+    // labelInValue Options (or undefined when the field never rendered, which is distinct from an
+    // empty array). The lone-Option shape from the former single-select stays accepted.
     topicIds?: { value: string; label: string } | Array<{ value: string; label: string }> | string[];
     consultantIds?: Array<{ value: string; label: string }> | string[];
     consultantAssignmentFailed?: boolean;


### PR DESCRIPTION
## Problem

Saving any agency with more than one Fachbereich destroyed all but the first — together with each
department's published Impressum and Datenschutzerklärung. The edit form loaded only `topics[0]`,
always sent `topicIds`, and the backend deletes unsent `agency_topic` rows (`orphanRemoval` on
`Agency.agencyTopics`). Editing an unrelated field, e.g. a phone number, was enough. ADR-014
reversed the single-select decision on 2026-07-16; the code was never reverted.

## What changed

- Topic picker is multi-select again (`isMulti`), reversing PR #244.
- The edit form loads **every** department instead of `[0]`.
- `updateAgencyData` omits `topicIds` when the form carries no topic field at all. The picker only
  renders once the topic list loaded (`topics?.length > 0 &&`), and narrow card patches carry no
  topic data — both previously sent `[]`, which tells the backend to clear every department.
  Explicit clearing still sends `[]`.
- `agency.d.ts` comment/type updated to the multi shape; the lone-Option shape stays accepted.

## Verification

- `npm run test` — 983 passed (181 files)
- `npx tsc --noEmit` — clean
- `npx eslint … --max-warnings=0` — clean · `npx prettier --check` — clean

Refs OpenResilienceInitiative/ORISO-Admin#554
Part of epic OpenResilienceInitiative/ORISO-Frontend#86

🤖 Generated with [Claude Code](https://claude.com/claude-code)
