### PR TITLE
fix(settings): give the tenant level the designed tab set

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,8 +191,14 @@ export const App = () => {
                                     )}
                                     {can(PermissionAction.Read, Resource.Tenant) && (
                                         <Route
+                                            path={`${routePathNames.themeSettings}/master-data`}
+                                            element={<LazyGeneralSettingsPage section="masterData" />}
+                                        />
+                                    )}
+                                    {can(PermissionAction.Read, Resource.Tenant) && (
+                                        <Route
                                             path={`${routePathNames.themeSettings}/general`}
-                                            element={<LazyGeneralSettingsPage />}
+                                            element={<LazyGeneralSettingsPage section="appearance" />}
                                         />
                                     )}
                                     {can(PermissionAction.Read, Resource.LegalText) && (

--- a/src/components/Tenants/GeneralSettings/index.tsx
+++ b/src/components/Tenants/GeneralSettings/index.tsx
@@ -18,8 +18,16 @@ import { TypeOfLanguage } from './components/TypeOfLanguage';
 import { AppConfigInterface } from '../../../types/AppConfigInterface';
 import styles from './styles.module.scss';
 
+/**
+ * Which card group the page renders. The settings tab bar splits master data and appearance
+ * into two tabs (Figma Admin.ORISO node 465-27854), so the page must be able to render either
+ * half; `all` keeps the combined deck for embedders like the per-tenant theme-settings page.
+ */
+export type GeneralSettingsSection = 'all' | 'appearance' | 'masterData';
+
 interface GeneralSettingsProps {
     tenantId?: string;
+    section?: GeneralSettingsSection;
 }
 
 const APPEARANCE_ALLOWED_STORAGE_KEY = 'oriso:tenantAdminControls.allowedPermissionToggles.appearance';
@@ -41,12 +49,14 @@ const setStoredAppearanceAllowed = (value: boolean) => {
     }
 };
 
-export const GeneralSettings = ({ tenantId }: GeneralSettingsProps) => {
+export const GeneralSettings = ({ tenantId, section = 'all' }: GeneralSettingsProps) => {
     const { t } = useTranslation();
     const { data } = useTenantData();
     const finalTenantId = tenantId || `${data?.id || ''}`;
     const { can } = useUserPermissions();
     const { isSuperAdmin } = useUserRoles();
+    const showAppearance = section === 'all' || section === 'appearance';
+    const showMasterData = section === 'all' || section === 'masterData';
     const { settings, setManualSettings } = useAppConfigContext();
     const { mutate: updateSettings } = useSettingsAdminMutation();
     const appearanceAllowed =
@@ -78,54 +88,62 @@ export const GeneralSettings = ({ tenantId }: GeneralSettingsProps) => {
                 previousLabel={t('tenant.settings.cardDeck.previous')}
                 nextLabel={t('tenant.settings.cardDeck.next')}
             >
-                <CardDeck.Item className={styles.cardSlotImages}>
-                    <LogoAndFavicon tenantId={finalTenantId} readOnly={!isSuperAdmin && !appearanceEditable} />
-                </CardDeck.Item>
-                {can(PermissionAction.Update, Resource.Language) && (
+                {showAppearance && (
+                    <CardDeck.Item className={styles.cardSlotImages}>
+                        <LogoAndFavicon tenantId={finalTenantId} readOnly={!isSuperAdmin && !appearanceEditable} />
+                    </CardDeck.Item>
+                )}
+                {showAppearance && can(PermissionAction.Update, Resource.Language) && (
                     <CardDeck.Item>
                         <Languages tenantId={finalTenantId} readOnly={!isSuperAdmin && !appearanceEditable} />
                     </CardDeck.Item>
                 )}
-                <CardDeck.Item className={styles.cardSlotTheme}>
-                    <ThemeBuilder tenantId={finalTenantId} readOnly={!isSuperAdmin && !appearanceEditable} />
-                </CardDeck.Item>
-                <CardDeck.Item>
-                    <CardEditable
-                        key={`tenant-master-data-editable-${appearanceEditable}`}
-                        allowEdit={isSuperAdmin}
-                        initialValues={tenantAdminControlsInitialValues}
-                        titleKey="settings.masterData.editable.title"
-                        subTitle={t<string>('settings.masterData.editable.subtitle')}
-                        onSave={onSaveTenantAdminControls}
-                        variant="dialog"
-                        editButtonPlacement="footer"
-                        headerIcon={<ManageAccountsOutlinedIcon />}
-                    >
-                        <FormSwitchField
-                            label={
-                                <span className={styles.masterDataToggleCopy}>
-                                    <span className={styles.masterDataToggleTitle}>
-                                        {t('settings.masterData.editable.toggle')}
+                {showAppearance && (
+                    <CardDeck.Item className={styles.cardSlotTheme}>
+                        <ThemeBuilder tenantId={finalTenantId} readOnly={!isSuperAdmin && !appearanceEditable} />
+                    </CardDeck.Item>
+                )}
+                {showAppearance && (
+                    <CardDeck.Item>
+                        <CardEditable
+                            key={`tenant-master-data-editable-${appearanceEditable}`}
+                            allowEdit={isSuperAdmin}
+                            initialValues={tenantAdminControlsInitialValues}
+                            titleKey="settings.masterData.editable.title"
+                            subTitle={t<string>('settings.masterData.editable.subtitle')}
+                            onSave={onSaveTenantAdminControls}
+                            variant="dialog"
+                            editButtonPlacement="footer"
+                            headerIcon={<ManageAccountsOutlinedIcon />}
+                        >
+                            <FormSwitchField
+                                label={
+                                    <span className={styles.masterDataToggleCopy}>
+                                        <span className={styles.masterDataToggleTitle}>
+                                            {t('settings.masterData.editable.toggle')}
+                                        </span>
+                                        <span className={styles.masterDataToggleDescription}>
+                                            {t('settings.masterData.editable.toggle.description')}
+                                        </span>
                                     </span>
-                                    <span className={styles.masterDataToggleDescription}>
-                                        {t('settings.masterData.editable.toggle.description')}
-                                    </span>
-                                </span>
-                            }
-                            name={['tenantAdminControls', 'allowedPermissionToggles', 'appearance']}
-                            inline
-                            disableLabels
-                            disabled={!isSuperAdmin}
-                            className={styles.masterDataToggle}
-                            switchLabel={t('settings.masterData.editable.toggle')}
-                            switchVariant="m3"
-                        />
-                    </CardEditable>
-                </CardDeck.Item>
-                <CardDeck.Item>
-                    <NameAndSlogan tenantId={finalTenantId} readOnly={!isSuperAdmin && !appearanceEditable} />
-                </CardDeck.Item>
-                {can(PermissionAction.Update, Resource.Language) && (
+                                }
+                                name={['tenantAdminControls', 'allowedPermissionToggles', 'appearance']}
+                                inline
+                                disableLabels
+                                disabled={!isSuperAdmin}
+                                className={styles.masterDataToggle}
+                                switchLabel={t('settings.masterData.editable.toggle')}
+                                switchVariant="m3"
+                            />
+                        </CardEditable>
+                    </CardDeck.Item>
+                )}
+                {showMasterData && (
+                    <CardDeck.Item>
+                        <NameAndSlogan tenantId={finalTenantId} readOnly={!isSuperAdmin && !appearanceEditable} />
+                    </CardDeck.Item>
+                )}
+                {showMasterData && can(PermissionAction.Update, Resource.Language) && (
                     <CardDeck.Item>
                         <TypeOfLanguage tenantId={finalTenantId} readOnly={!isSuperAdmin && !appearanceEditable} />
                     </CardDeck.Item>

--- a/src/constants/settingsTabs.test.ts
+++ b/src/constants/settingsTabs.test.ts
@@ -26,11 +26,36 @@ describe('settings tabs', () => {
 
         expect(tabs.map((tab) => tab.to)).toEqual([
             '/settings/global-config',
+            '/settings/master-data',
             '/settings/general',
             '/settings/legal',
             '/settings/smtp',
             '/settings/permissions',
         ]);
+    });
+
+    // Figma Admin.ORISO node 465-27854 ("Subsection Translations German"), level 2:
+    // Stammdaten & Mehr · Erscheinungsbild · Rechtliches · Email Server · Funktionszugriff.
+    it('gives the tenant level the designed tab order including Erscheinungsbild', () => {
+        const tabs = getSettingsTabs(baseContext);
+
+        expect(tabs.map((tab) => ({ to: tab.to, titleKey: tab.titleKey }))).toEqual([
+            { to: '/settings/master-data', titleKey: 'settings.subhead.masterData' },
+            { to: '/settings/general', titleKey: 'settings.subhead.view' },
+            { to: '/settings/legal', titleKey: 'settings.subhead.legal' },
+            { to: '/settings/smtp', titleKey: 'settings.subhead.smtp' },
+            { to: '/settings/permissions', titleKey: 'settings.subhead.functionAccess' },
+            // Not part of the design; kept because it is the only entry point for the
+            // tenant feature toggles. Tracked in #58.
+            { to: '/settings/app-settings', titleKey: 'tenants.edit.tabs.appSettings' },
+        ]);
+    });
+
+    it('keeps master data and appearance on separate routes', () => {
+        const tabs = getSettingsTabs(baseContext);
+        const routes = tabs.map((tab) => tab.to);
+
+        expect(new Set(routes).size, `duplicate settings routes in ${routes.join(', ')}`).toBe(routes.length);
     });
 
     it('hides tenant tabs when the related permission or feature flag is disabled', () => {

--- a/src/constants/settingsTabs.ts
+++ b/src/constants/settingsTabs.ts
@@ -36,6 +36,11 @@ export const getSettingsTabs = ({
                 iconName: 'global_config',
             },
             can(PermissionAction.Update, Resource.Tenant) && {
+                to: `${base}/master-data`,
+                titleKey: 'settings.subhead.masterData',
+                iconName: 'master_data',
+            },
+            can(PermissionAction.Update, Resource.Tenant) && {
                 to: `${base}/general`,
                 titleKey: 'settings.subhead.view',
                 iconName: 'appearance',
@@ -58,18 +63,23 @@ export const getSettingsTabs = ({
         ]);
     }
 
-    // Tenant / Träger settings tab order (P1). Appearance shares the general route until split.
+    // Tenant / Träger tab order per Figma Admin.ORISO node 465-27854, level 2:
+    // Stammdaten & Mehr · Erscheinungsbild · Rechtliches · Email Server · Funktionszugriff.
+    // `app-settings` is not in the design but is the only entry point for the tenant feature
+    // toggles, so it trails the designed set until that is decided (#58).
     return compactTabs([
         shouldShowThemeSettings &&
             can(PermissionAction.Update, Resource.Tenant) && {
-                to: `${base}/general`,
+                to: `${base}/master-data`,
                 titleKey: 'settings.subhead.masterData',
                 iconName: 'master_data',
             },
-        // can(PermissionAction.Update, Resource.Tenant) && {
-        //     to: `${base}/general`,
-        //     titleKey: 'settings.subhead.view',
-        // },
+        shouldShowThemeSettings &&
+            can(PermissionAction.Update, Resource.Tenant) && {
+                to: `${base}/general`,
+                titleKey: 'settings.subhead.view',
+                iconName: 'appearance',
+            },
         (can(PermissionAction.Read, Resource.LegalText) || can(PermissionAction.Update, Resource.LegalText)) && {
             to: `${base}/legal`,
             titleKey: 'settings.subhead.legal',
@@ -80,17 +90,17 @@ export const getSettingsTabs = ({
             titleKey: 'settings.subhead.smtp',
             iconName: 'email_server',
         },
+        can(PermissionAction.Update, Resource.Tenant) && {
+            to: `${base}/permissions`,
+            titleKey: 'settings.subhead.functionAccess',
+            iconName: 'functionality_access',
+        },
         can(PermissionAction.Update, Resource.Tenant) &&
             isTenantSettingsEditEnabled && {
                 to: `${base}/app-settings`,
                 titleKey: `tenants.edit.tabs.${multitenancyWithSingleDomainEnabled ? 'globalSettings' : 'appSettings'}`,
                 iconName: multitenancyWithSingleDomainEnabled ? 'global_settings' : 'functionalities',
             },
-        can(PermissionAction.Update, Resource.Tenant) && {
-            to: `${base}/permissions`,
-            titleKey: 'settings.subhead.functionAccess',
-            iconName: 'functionality_access',
-        },
     ]);
 };
 

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1102,7 +1102,7 @@
     "settings.subhead.globalConfig": "Globale Konfigurationen",
     "settings.subhead.view": "Erscheinungsbild",
     "settings.subhead.legal": "Rechtliches",
-    "settings.subhead.smtp": "SMTP-Server",
+    "settings.subhead.smtp": "Email Server",
     "settings.subhead.permissions": "Berechtigungen",
     "settings.subhead.functionAccess": "Funktionszugriff",
     "settings.masterData.editable.title": "Stammdaten des Trägers",

--- a/src/pages/TenantSettings/GeneralSettings/index.tsx
+++ b/src/pages/TenantSettings/GeneralSettings/index.tsx
@@ -1,11 +1,11 @@
-import { GeneralSettings } from '../../../components/Tenants/GeneralSettings';
+import { GeneralSettings, type GeneralSettingsSection } from '../../../components/Tenants/GeneralSettings';
 import { useTenantData } from '../../../hooks/useTenantData.hook';
 import { useUserRoles } from '../../../hooks/useUserRoles.hook';
 
-export const GeneralSettingsPage = () => {
+export const GeneralSettingsPage = ({ section = 'all' }: { section?: GeneralSettingsSection }) => {
     const { data } = useTenantData();
     const { tenantId } = useUserRoles();
     const resolvedTenantId = tenantId && tenantId > 0 ? tenantId : data?.id;
 
-    return <GeneralSettings tenantId={`${resolvedTenantId || ''}`} />;
+    return <GeneralSettings tenantId={`${resolvedTenantId || ''}`} section={section} />;
 };

--- a/src/pages/TenantSettings/SettingsTabs.stories.tsx
+++ b/src/pages/TenantSettings/SettingsTabs.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Page } from '../../components/Page';
+import { getSettingsTabs } from '../../constants/settingsTabs';
+import { PermissionAction } from '../../enums/PermissionAction';
+import { Resource } from '../../enums/Resource';
+
+/**
+ * The settings tab bar per admin level.
+ *
+ * Both stories render the output of the real `getSettingsTabs` resolver, so they are a visual
+ * contract against the design (Figma `Admin.ORISO` node 465-27854) rather than a hand-written
+ * mock that can drift from production — the tenant level lost its `Erscheinungsbild` tab exactly
+ * that way (ORISO-Admin#58).
+ */
+const meta = {
+    title: 'Organisms/SettingsTabs',
+    component: Page,
+    parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof Page>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const allowAll = () => true;
+
+/** Level 1 — platform admin: Globale Konfigurationen · Stammdaten · Erscheinungsbild · Rechtliches · Email Server · Funktionszugriff. */
+export const PlatformAdminLevel: Story = {
+    render: () => (
+        <Page>
+            <Page.Title
+                titleKey="settings.title"
+                subTitleKey="settings.title.text"
+                tabs={getSettingsTabs({
+                    isSuperAdmin: true,
+                    shouldShowThemeSettings: true,
+                    can: allowAll,
+                    isTenantSettingsEditEnabled: true,
+                    multitenancyWithSingleDomainEnabled: false,
+                })}
+            />
+        </Page>
+    ),
+};
+
+/** Level 2 — Träger admin: Stammdaten & Mehr · Erscheinungsbild · Rechtliches · Email Server · Funktionszugriff (+ Funktionalitäten). */
+export const TenantAdminLevel: Story = {
+    render: () => (
+        <Page>
+            <Page.Title
+                titleKey="settings.title"
+                subTitleKey="settings.title.text"
+                tabs={getSettingsTabs({
+                    isSuperAdmin: false,
+                    shouldShowThemeSettings: true,
+                    can: allowAll,
+                    isTenantSettingsEditEnabled: true,
+                    multitenancyWithSingleDomainEnabled: false,
+                })}
+            />
+        </Page>
+    ),
+};
+
+/** Level 2 without the tenant feature toggles — the pure designed set of five tabs. */
+export const TenantAdminLevelWithoutFeatureToggles: Story = {
+    render: () => (
+        <Page>
+            <Page.Title
+                titleKey="settings.title"
+                subTitleKey="settings.title.text"
+                tabs={getSettingsTabs({
+                    isSuperAdmin: false,
+                    shouldShowThemeSettings: true,
+                    can: (action: PermissionAction | PermissionAction[], resource: Resource) =>
+                        resource === Resource.Tenant || resource === Resource.LegalText || Boolean(action),
+                    isTenantSettingsEditEnabled: false,
+                    multitenancyWithSingleDomainEnabled: false,
+                })}
+            />
+        </Page>
+    ),
+};


### PR DESCRIPTION
## Problem

The Träger settings tab bar did not match the design (Figma `Admin.ORISO` node [465-27854](https://www.figma.com/design/QfsgojtHQzBjbzU3Im9Cet/Admin.ORISO?node-id=465-27854)):

- `Erscheinungsbild` was commented out ("Appearance shares the general route until split"), so the tenant level had four tabs instead of five.
- Tab order did not follow the design.
- German `settings.subhead.smtp` read `SMTP-Server`; the design (and the English locale) say `Email Server`.

The platform level already matched and is unchanged apart from the new master-data tab.

## What changed

- `GeneralSettings` takes a `section` prop (`all | appearance | masterData`) and splits its card deck: **appearance** = logo/favicon, languages, colours + the super-admin toggle that governs tenant appearance edits; **master data** = name & slogan, form of address.
- New route `/admin/theme-settings/master-data`; `/general` now renders the appearance half. The per-tenant theme-settings page keeps the combined deck (`section` defaults to `all`).
- Tenant tab order: `Stammdaten & Mehr · Erscheinungsbild · Rechtliches · Email Server · Funktionszugriff`. The platform level gains the master-data tab so name & slogan stay reachable after the split.
- German `settings.subhead.smtp` → `Email Server`.
- `settingsTabs.test.ts` asserts both tab sets and that no two tabs share a route; new `Organisms/SettingsTabs` stories render real `getSettingsTabs` output per level.

## Verification

- `npx vitest run src/constants/settingsTabs.test.ts` → 2 failures before (missing `master-data`, missing tenant `Erscheinungsbild`), 6 passed after.
- `npx vitest run` → 984 passed. `npm run build`, `npx eslint . --max-warnings=0`, `npx prettier . --check`, `npm run typecheck:storybook` → clean.
- Visual: Storybook `Organisms/SettingsTabs → TenantAdminLevel` renders `Master Data · Appearance · Legal · Email Server · Functionality Access · Functionalities`.

## Open point for review

`Funktionalitäten` / `Globale Einstellungen` (`/app-settings`) is **not** in the design but is the only entry point for the tenant feature toggles, so it now trails the designed five. Figma level 3 (`Stammdaten & Mehr · Rechtliches · Funktionszugriff`) is deliberately not implemented — it would mean giving agency admins a settings surface, which is a permission decision (see the issue).

Refs #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)
