### PR TITLE
fix(users): stop clipping agency chips and pushing identity columns out of sight

### DIFF
--- a/src/pages/users/List/UserManagement.stories.tsx
+++ b/src/pages/users/List/UserManagement.stories.tsx
@@ -71,6 +71,59 @@ export const Filled: Story = {
     parameters: { msw: { handlers: [http.get(CONSULTANTS_ENDPOINT, () => consultantsResponse(CONSULTANTS))] } },
 };
 
+/**
+ * Real Pre-Dev data shapes: long agency and city names plus a consultant assigned to several
+ * agencies. Guards the agency chips against mid-word clipping and the trailing identity columns
+ * against being pushed out of sight (ORISO-Admin#99).
+ */
+export const LongAgencyNames: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.get(CONSULTANTS_ENDPOINT, () =>
+                    consultantsResponse([
+                        {
+                            ...CONSULTANTS[0],
+                            id: 'c-long',
+                            key: 'c-long',
+                            firstname: 'Shanzae',
+                            lastname: 'Imran',
+                            email: 'shanzaeimran2@example.org',
+                            username: 'shanzae-consultant',
+                            agencies: [
+                                {
+                                    id: '201',
+                                    name: 'Codex PreDev E2E 20260625222629',
+                                    postcode: '10115',
+                                    city: 'Berlin-Charlottenburg-Wilmersdorf',
+                                },
+                            ],
+                            agencyIds: ['201'],
+                        },
+                        {
+                            ...CONSULTANTS[1],
+                            id: 'c-multi',
+                            key: 'c-multi',
+                            firstname: 'Nikunj',
+                            lastname: 'Consultant',
+                            agencies: [
+                                { id: '202', name: 'Caritas Agency 2', postcode: '13055', city: 'Berlin' },
+                                {
+                                    id: '203',
+                                    name: 'Beratungsstelle für Familien und Alleinerziehende',
+                                    postcode: '12345',
+                                    city: 'Frankfurt am Main',
+                                },
+                            ],
+                            agencyIds: ['202', '203'],
+                        },
+                    ]),
+                ),
+            ],
+        },
+    },
+};
+
 /** No consultants yet — the table shows its empty state. */
 export const Empty: Story = {
     parameters: { msw: { handlers: [http.get(CONSULTANTS_ENDPOINT, () => consultantsResponse([]))] } },

--- a/src/pages/users/management/UserManagementTable.module.scss
+++ b/src/pages/users/management/UserManagementTable.module.scss
@@ -181,6 +181,9 @@
     .counselorList__agencyChip {
         display: inline-flex;
         flex: 0 1 auto;
+        // Flex items refuse to shrink below their content width by default, which pushed long
+        // chips past the column edge and clipped them mid-word.
+        min-width: 0;
         max-width: 100%;
         min-height: 26px;
         overflow: hidden;
@@ -196,6 +199,14 @@
         font-weight: 500;
         line-height: 18px;
         text-align: center;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .counselorList__agencyChipLabel {
+        display: block;
+        min-width: 0;
+        overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
     }

--- a/src/pages/users/management/agencyColumn.test.tsx
+++ b/src/pages/users/management/agencyColumn.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useUserTableColumns } from './useUserTableColumns';
+import { getVisibleColumns } from './userTableConfigs';
+import { TypeOfUser } from '../../../enums/TypeOfUser';
+import { CounselorData } from '../../../types/counselor';
+
+// The agency cell renders three chips per agency inside a fixed-width column. Long agency
+// names used to be sliced mid-word because `text-overflow: ellipsis` does not apply to the
+// anonymous flex item of an `inline-flex` chip — the label needs its own truncating element
+// and every chip needs an accessible full value (ORISO-Admin#99).
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const LONG_AGENCY = {
+    id: 'a-1',
+    name: 'Codex PreDev E2E 20260625222629 Beratungsstelle Nord',
+    postcode: '10115',
+    city: 'Berlin-Charlottenburg-Wilmersdorf',
+};
+
+const columnsProps = {
+    sectionId: TypeOfUser.Consultants,
+    showTenant: false,
+    showSubdomain: false,
+    openRows: [],
+    onToggleRow: () => undefined,
+    onEditUser: () => undefined,
+    onDeleteUser: () => undefined,
+    onEditTenant: () => undefined,
+    onDeleteTenant: () => undefined,
+    canEditOrDelete: () => true,
+    mainTenantSubdomain: '',
+    sortBy: undefined,
+    order: undefined,
+} as any;
+
+const renderAgencyCell = (row: Partial<CounselorData>) => {
+    const Probe = () => {
+        const columns = useUserTableColumns(columnsProps);
+        const column: any = columns.find((c: any) => c.key === 'agency');
+        expect(column).toBeDefined();
+        return <div data-testid="cell">{column.render(row.agencies, { id: 'u1', ...row } as CounselorData)}</div>;
+    };
+    render(<Probe />);
+    return screen.getByTestId('cell');
+};
+
+describe('agency column', () => {
+    it('truncates every chip label in its own element instead of clipping the text', () => {
+        const cell = renderAgencyCell({ agencies: [LONG_AGENCY] as any });
+
+        const labels = cell.querySelectorAll('.counselorList__agencyChipLabel');
+        expect(labels).toHaveLength(3);
+        expect([...labels].map((label) => label.textContent)).toEqual([
+            LONG_AGENCY.postcode,
+            LONG_AGENCY.name,
+            LONG_AGENCY.city,
+        ]);
+    });
+
+    it('exposes the full value of every chip via title, not only the agency name', () => {
+        const cell = renderAgencyCell({ agencies: [LONG_AGENCY] as any });
+
+        const titles = [...cell.querySelectorAll('.counselorList__agencyChip')].map((chip) =>
+            chip.getAttribute('title'),
+        );
+        expect(titles).toEqual([LONG_AGENCY.postcode, LONG_AGENCY.name, LONG_AGENCY.city]);
+    });
+
+    it('keeps the identity columns within a 1440px content width', () => {
+        // Sidebar rail (96px) + table padding leave ~1310px; the sum of the fixed column
+        // widths must fit so no column is pushed out of sight without an affordance.
+        const widths = getVisibleColumns(TypeOfUser.Consultants, { showTenant: true, showSubdomain: false }).map(
+            (column) => column.width ?? 0,
+        );
+        const total = widths.reduce((sum, width) => sum + width, 0);
+
+        expect(total).toBeLessThanOrEqual(1310);
+    });
+});

--- a/src/pages/users/management/useUserTableColumns.tsx
+++ b/src/pages/users/management/useUserTableColumns.tsx
@@ -109,15 +109,22 @@ export const useUserTableColumns = ({
             const isOpen = openRows.includes(record.id);
             const visibleAgencies = isOpen ? agencies : [agencies[0]];
 
+            // Each chip label lives in its own element: `text-overflow: ellipsis` is ignored on
+            // the anonymous flex item of an `inline-flex` chip, which sliced long names mid-word.
+            const chip = (variant: 'postcode' | 'name' | 'city', value?: string) => (
+                <span
+                    className={`counselorList__agencyChip counselorList__agencyChip--${variant}`}
+                    title={value || undefined}
+                >
+                    <span className="counselorList__agencyChipLabel">{value}</span>
+                </span>
+            );
+
             return visibleAgencies.filter(Boolean).map((agencyItem) => (
                 <div key={agencyItem.id} className="counselorList__agencies">
-                    <span className="counselorList__agencyChip counselorList__agencyChip--postcode">
-                        {agencyItem.postcode}
-                    </span>
-                    <span className="counselorList__agencyChip counselorList__agencyChip--name" title={agencyItem.name}>
-                        {agencyItem.name}
-                    </span>
-                    <span className="counselorList__agencyChip counselorList__agencyChip--city">{agencyItem.city}</span>
+                    {chip('postcode', agencyItem.postcode)}
+                    {chip('name', agencyItem.name)}
+                    {chip('city', agencyItem.city)}
                 </div>
             ));
         };

--- a/src/pages/users/management/userTableConfigs.ts
+++ b/src/pages/users/management/userTableConfigs.ts
@@ -52,9 +52,12 @@ const col = (key: UserTableColumnKey, visible: boolean, sortable = false, width?
     width,
 });
 
+// Width budget: at 1440px the sidebar rail and the table padding leave ~1310px, so the fixed
+// widths of a section must stay inside that. Anything wider silently pushes the trailing
+// columns (Träger, "also …" checkmark, actions) out of sight (ORISO-Admin#99).
 const baseIdentityColumns = (): UserTableColumnConfig[] => [
-    col('lastUpdated', true, true, 210),
-    col('status', true, false, 120),
+    col('lastUpdated', true, true, 150),
+    col('status', true, false, 80),
     col('lastname', true, true, 130),
     col('firstname', true, true, 120),
     col('email', true, true, 150),
@@ -62,8 +65,8 @@ const baseIdentityColumns = (): UserTableColumnConfig[] => [
 ];
 
 const tenantAdminIdentityColumns = (): UserTableColumnConfig[] => [
-    col('lastUpdated', true, true, 210),
-    col('status', true, false, 120),
+    col('lastUpdated', true, true, 150),
+    col('status', true, false, 80),
     col('lastname', true, true, 130),
     col('firstname', true, true, 120),
     col('email', true, true, 150),
@@ -115,10 +118,10 @@ export const USER_TABLE_CONFIGS: Record<TypeOfUser, UserTableSectionConfig> = {
         searchPlaceholderKey: 'consultant-search-placeholder',
         columns: [
             ...baseIdentityColumns(),
-            col('agency', true, false, 250),
-            col('hasOtherIdentity', true, false, 160),
-            col('tenant', true, false, 100),
-            col('actions', true, false, 100),
+            col('agency', true, false, 220),
+            col('hasOtherIdentity', true, false, 110),
+            col('tenant', true, false, 120),
+            col('actions', true, false, 80),
         ],
     },
     [TypeOfUser.AgencyAdmins]: {
@@ -134,10 +137,10 @@ export const USER_TABLE_CONFIGS: Record<TypeOfUser, UserTableSectionConfig> = {
         searchPlaceholderKey: 'consultant-search-placeholder',
         columns: [
             ...baseIdentityColumns(),
-            col('agency', true, false, 250),
-            col('hasOtherIdentity', true, false, 160),
-            col('tenant', true, false, 100),
-            col('actions', true, false, 100),
+            col('agency', true, false, 220),
+            col('hasOtherIdentity', true, false, 110),
+            col('tenant', true, false, 120),
+            col('actions', true, false, 80),
         ],
     },
     [TypeOfUser.TenantAdmins]: {
@@ -153,10 +156,10 @@ export const USER_TABLE_CONFIGS: Record<TypeOfUser, UserTableSectionConfig> = {
         searchPlaceholderKey: 'consultant-search-placeholder',
         columns: [
             ...tenantAdminIdentityColumns(),
-            col('subdomain', true, false, 200),
-            col('hasOtherIdentity', true, false, 160),
-            col('tenant', true, false, 100),
-            col('actions', true, false, 100),
+            col('subdomain', true, false, 160),
+            col('hasOtherIdentity', true, false, 110),
+            col('tenant', true, false, 120),
+            col('actions', true, false, 80),
         ],
     },
     [TypeOfUser.PlatformAdmins]: {
@@ -170,7 +173,7 @@ export const USER_TABLE_CONFIGS: Record<TypeOfUser, UserTableSectionConfig> = {
         showStatus: true,
         editPathPrefix: routePathNames.platformAdmins,
         searchPlaceholderKey: 'consultant-search-placeholder',
-        columns: [...tenantAdminIdentityColumns(), col('actions', true, false, 100)],
+        columns: [...tenantAdminIdentityColumns(), col('actions', true, false, 80)],
     },
     [TypeOfUser.Users]: {
         sectionId: TypeOfUser.Users,


### PR DESCRIPTION
## Problem

Two display defects in the user-management tables, both reproduced on Pre-Dev (`/admin/users/consultants`, 2026-07-28):

1. **Agency chips were sliced mid-word** — `agenc t`, `Shazia`, `odex PreDev E2E 202`. The chip is `display: inline-flex`, and `text-overflow: ellipsis` does not apply to the anonymous flex item of a flex container, so the text was hard-clipped instead of ellipsised. Flex items also refuse to shrink below their content width without `min-width: 0`.
2. **The trailing identity columns were effectively invisible** — the fixed widths summed to **1490px** for the consultant section, so `Also Tenant Admin` and `Träger` sat outside a 1440px window behind an unmarked horizontal scroll.

## What changed

- Chip labels render inside their own truncating element; **every** chip (postcode, name, city) now carries its full value as `title`, not just the name.
- `min-width: 0` on the chip so it shrinks inside the column instead of overflowing it.
- Column widths rebalanced to a **1310px budget** (1440px minus the sidebar rail and table padding) for the consultant, agency-admin, tenant-admin and platform-admin sections: last updated 210→150, status 120→80, agency 250→220, other-identity 160→110, Träger 100→120, actions 100→80.
- `agencyColumn.test.tsx`: label truncation, per-chip titles, and the width budget.
- `UserManagement` story `LongAgencyNames` reproduces the Pre-Dev data shapes (long agency + city name, consultant with two agencies).

## Verification

- `npx vitest run src/pages/users/management/agencyColumn.test.tsx` → 3 failures before (`expected 1490 to be less than or equal to 1310`, no label elements, `title` null on 2 of 3 chips), all pass after.
- `npx vitest run` → 985 passed. `npm run build`, `npx eslint . --max-warnings=0`, `npx prettier . --check`, `npm run typecheck:storybook` → clean.
- Visual: `Organisms/Pages/Users/UserManagement → LongAgencyNames` shows `Codex PreDev E2E 202…` and `Berlin-Charlottenburg-…` with real ellipses, and `Also Tenant Admin` / `Träger` inside the frame at 1600px.

## Correction to the issue

The third point in #99 ("row-expand caret appears at random") is **not a bug**: `canExpand` is `showAgencyExpand && agencies.length > 1`, and on Pre-Dev only one of the eleven rows actually had two agencies. Left unchanged; the issue is updated accordingly.

Refs #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)
