### PR TITLE
fix(select): let the multi-select outline grow with its tags

### DIFF
--- a/src/components/FloatingLabelSelect/floatingLabelSelect.module.scss
+++ b/src/components/FloatingLabelSelect/floatingLabelSelect.module.scss
@@ -30,6 +30,20 @@
     composes: outline from '../FloatingLabelInput/floatingLabelInput.module.scss';
 }
 
+/*
+ * The shared M3 shell fixes `.outline` at 56px, which is right for a single-value
+ * field. A multi-select's tags wrap onto further rows, so the box has to grow with
+ * them — otherwise the tags spill out of their own border and overlap whatever sits
+ * below (reported with all 16 topics selected on an agency).
+ *
+ * Applied on the field root rather than inside `.select`, because the height belongs
+ * to the outline shell, not to the antd painting.
+ */
+.hasMultiSelect .outline {
+    height: auto;
+    min-height: 56px;
+}
+
 .label {
     composes: label from '../FloatingLabelInput/floatingLabelInput.module.scss';
 }
@@ -71,7 +85,9 @@
 
     /* Multi-select: grow with the selected tags instead of clipping them at a
        fixed height. Only reachable once a value exists, at which point the
-       label is already floated — no "resting label on a tall field" case. */
+       label is already floated — no "resting label on a tall field" case.
+       NOTE: this alone is not enough — the shared `.outline` shell is a fixed
+       56px, so a grown selector escapes it. See `.hasMultiSelect` below. */
     &:global(.ant-select-multiple) :global(.ant-select-selector) {
         height: auto !important;
         min-height: 100%;

--- a/src/components/FloatingLabelSelect/index.tsx
+++ b/src/components/FloatingLabelSelect/index.tsx
@@ -93,6 +93,8 @@ export const FloatingLabelSelect = <
                     [styles.fieldDisabled]: isDisabled,
                     [styles.labelFloating]: floating,
                     [styles.hasLeadingIcon]: Boolean(leadingIcon),
+                    // Tags wrap onto further rows; the 56px outline has to grow with them.
+                    [styles.hasMultiSelect]: mode === 'multiple' || mode === 'tags',
                 },
                 className,
             )}

--- a/src/components/FloatingLabelSelect/multiSelectOutline.test.ts
+++ b/src/components/FloatingLabelSelect/multiSelectOutline.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const styles = readFileSync(resolve(__dirname, './floatingLabelSelect.module.scss'), 'utf8');
+const component = readFileSync(resolve(__dirname, './index.tsx'), 'utf8');
+
+/**
+ * The M3 shell fixes the outline at 56px, which is right for a single value. A multi-select's
+ * tags wrap onto further rows — with all 16 topics selected on an agency they escaped their own
+ * border and overlapped the fields below. The selector was already allowed to grow; the outline
+ * around it was not.
+ */
+describe('FloatingLabelSelect — multi-select outline', () => {
+    it('lets the outline grow with wrapped tags instead of clipping at 56px', () => {
+        const rule = styles.match(/\.hasMultiSelect\s+\.outline\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+
+        expect(rule).toMatch(/height:\s*auto/);
+        expect(rule).toMatch(/min-height:\s*56px/);
+    });
+
+    it('keeps the single-value outline at the fixed M3 height', () => {
+        // The growth must be opt-in: a normal select still has to line up with the text fields
+        // beside it, which are a fixed 56px.
+        const selectorRule = styles.match(/&:global\(\.ant-select-multiple\)[\s\S]*?\n {4}}/)?.[0] ?? '';
+        const baseOutlineRule = styles.match(/\n\.outline\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+
+        expect(selectorRule).toMatch(/height:\s*auto/);
+        // The unqualified `.outline` only composes the shared shell — it must not relax the height
+        // for every select, or single-value fields stop lining up with the inputs beside them.
+        expect(baseOutlineRule).not.toMatch(/height/);
+    });
+
+    it('applies the growing outline only in multiple/tags mode', () => {
+        expect(component).toMatch(/hasMultiSelect\]:\s*mode === 'multiple' \|\| mode === 'tags'/);
+    });
+});


### PR DESCRIPTION
## Problem

Re-enabling the multi-select topic picker (#554, merged) exposed a layout defect. The shared M3 shell fixes `.outline` at 56px. The inner antd selector was already allowed to grow (`height: auto`), but the border around it was not — so with all 16 topics selected on an agency the tags escaped their own outline and overlapped the `Formal language` and `Supervisor` rows below.

Reported with a screenshot from pre-dev.

## What changed

- `.hasMultiSelect .outline` grows (`height: auto; min-height: 56px`).
- The class is applied only in `multiple`/`tags` mode, so single-value selects keep the fixed 56px and still line up with the text inputs beside them.
- Style test pins both halves: the outline grows for multi, and the unqualified `.outline` never relaxes its height.

## Verification

`vitest` 8 passed in FloatingLabelSelect · `tsc --noEmit` clean · `eslint --max-warnings=0` clean · `prettier --check` clean

Refs OpenResilienceInitiative/ORISO-Admin#554

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-select and tag fields so their outlined containers expand when selected items wrap onto multiple lines.
  * Preserved the standard fixed height for single-value fields.

* **Tests**
  * Added coverage to verify expandable outlines and mode-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->