### PR TITLE
fix(legal-settings): cap card deck item width and surface off-screen cards

### DIFF
--- a/src/components/CardDeck/CardDeck.stories.tsx
+++ b/src/components/CardDeck/CardDeck.stories.tsx
@@ -48,16 +48,36 @@ export const MultipleCardsPerItem: Story = {
     ),
 };
 
-/** Several cards overflow the visible width, so the SideScrollerFooter with prev/next arrows appears. */
+/**
+ * Several cards overflow the visible width, so the SideScrollerFooter appears with
+ * prev/next arrows and one position dot per card (#568): the active dots mark the
+ * visible cards, so off-screen cards stay discoverable.
+ */
 export const OverflowingCards: Story = {
     render: (args) => (
-        <div style={{ maxWidth: 480 }}>
+        <div style={{ maxWidth: 900 }}>
             <CardDeck {...args}>
                 {[1, 2, 3, 4].map((n) => (
                     <CardDeck.Item key={n}>
-                        <div style={{ width: 260 }}>
-                            <Card titleKey={`Karte ${n}`}>Inhalt der Karte {n}.</Card>
-                        </div>
+                        <Card titleKey={`Karte ${n}`}>Inhalt der Karte {n}.</Card>
+                    </CardDeck.Item>
+                ))}
+            </CardDeck>
+        </div>
+    ),
+};
+
+/**
+ * With room for less than two cards the deck falls back to the vertical stack
+ * instead of hiding every card but the first behind a horizontal scroller (#568).
+ */
+export const StackedFallback: Story = {
+    render: (args) => (
+        <div style={{ maxWidth: 480 }}>
+            <CardDeck {...args}>
+                {[1, 2, 3].map((n) => (
+                    <CardDeck.Item key={n}>
+                        <Card titleKey={`Karte ${n}`}>Inhalt der Karte {n}.</Card>
                     </CardDeck.Item>
                 ))}
             </CardDeck>

--- a/src/components/CardDeck/index.test.tsx
+++ b/src/components/CardDeck/index.test.tsx
@@ -84,6 +84,50 @@ describe('CardDeck', () => {
         expect(nextButton).toHaveAttribute('aria-controls', scrollGroup.id);
     });
 
+    // #568: off-screen cards must be discoverable without knowing what the
+    // corner arrows do — the footer shows one position dot per card.
+    it('renders a position dot per card and marks the visible ones active', async () => {
+        const { container } = renderDeck(['One', 'Two', 'Three', 'Four']);
+        const deck = container.querySelector('[data-admin-card-deck-scroll]');
+        const firstCard = deck?.querySelector('[data-admin-card-deck-item]');
+
+        setElementMetric(deck!, 'clientWidth', 900);
+        setElementMetric(deck!, 'scrollWidth', 1868);
+        setElementMetric(firstCard!, 'offsetWidth', 425);
+
+        act(() => {
+            fireEvent.scroll(deck!);
+        });
+
+        await waitFor(() => {
+            expect(container.querySelectorAll('[data-admin-card-deck-dot]')).toHaveLength(4);
+        });
+        expect(container.querySelectorAll('[data-admin-card-deck-dot="active"]')).toHaveLength(2);
+        expect(
+            Array.from(container.querySelectorAll('[data-admin-card-deck-dot]')).map((dot) =>
+                dot.getAttribute('data-admin-card-deck-dot'),
+            ),
+        ).toEqual(['active', 'active', 'inactive', 'inactive']);
+    });
+
+    // #568: with room for less than two cards a horizontal scroller hides
+    // everything but the first card — fall back to the vertical stack.
+    it('stacks vertically and drops the scroll footer when fewer than two cards fit', async () => {
+        const { container } = renderDeck();
+        const deck = container.querySelector('[data-admin-card-deck-scroll]');
+
+        setElementMetric(deck!, 'clientWidth', 500);
+
+        act(() => {
+            fireEvent(window, new Event('resize'));
+        });
+
+        await waitFor(() => {
+            expect(container.querySelector('[data-admin-card-deck-stacked]')).toBeInTheDocument();
+        });
+        expect(container.querySelector('[data-admin-card-deck-footer]')).not.toBeInTheDocument();
+    });
+
     it.each([
         { gap: '48px', expectedStep: 473 },
         { gap: '0px', expectedStep: 425 },

--- a/src/components/CardDeck/index.test.tsx
+++ b/src/components/CardDeck/index.test.tsx
@@ -102,12 +102,25 @@ describe('CardDeck', () => {
         await waitFor(() => {
             expect(container.querySelectorAll('[data-admin-card-deck-dot]')).toHaveLength(4);
         });
-        expect(container.querySelectorAll('[data-admin-card-deck-dot="active"]')).toHaveLength(2);
         expect(
             Array.from(container.querySelectorAll('[data-admin-card-deck-dot]')).map((dot) =>
                 dot.getAttribute('data-admin-card-deck-dot'),
             ),
         ).toEqual(['active', 'active', 'inactive', 'inactive']);
+
+        // Scrolled one card step (425px card + 48px gap): the window shifts.
+        Object.defineProperty(deck, 'scrollLeft', { configurable: true, value: 473 });
+        act(() => {
+            fireEvent.scroll(deck!);
+        });
+
+        await waitFor(() => {
+            expect(
+                Array.from(container.querySelectorAll('[data-admin-card-deck-dot]')).map((dot) =>
+                    dot.getAttribute('data-admin-card-deck-dot'),
+                ),
+            ).toEqual(['inactive', 'active', 'active', 'inactive']);
+        });
     });
 
     // #568: with room for less than two cards a horizontal scroller hides

--- a/src/components/CardDeck/index.tsx
+++ b/src/components/CardDeck/index.tsx
@@ -19,6 +19,15 @@ interface CardDeckItemProps {
 }
 
 const SCROLL_EPSILON = 8;
+const DEFAULT_ITEM_WIDTH = 392;
+
+const readListGap = (deck: HTMLElement) => {
+    const list = deck.querySelector('[data-admin-card-deck-list]');
+    const computedStyle = window.getComputedStyle(list ?? deck);
+    const parsedGap = Number.parseFloat(computedStyle.columnGap || computedStyle.gap);
+
+    return Number.isFinite(parsedGap) ? parsedGap : 24;
+};
 
 const CardDeckItem = ({ children, className }: CardDeckItemProps) => (
     <li className={classNames(styles.item, className)} data-admin-card-deck-item>
@@ -41,6 +50,9 @@ const CardDeckRoot = ({
     const [scrollState, setScrollState] = useState({
         canScrollBackward: false,
         canScrollForward: false,
+        firstVisibleCard: 0,
+        stacked: false,
+        visibleCardCount: 1,
     });
 
     const updateScrollState = useCallback(() => {
@@ -50,15 +62,42 @@ const CardDeckRoot = ({
             return;
         }
 
+        const gap = readListGap(deck);
+        const cardElements = deck.querySelectorAll('[data-admin-card-deck-item]');
+        const firstCard = cardElements[0] as HTMLElement | undefined;
+        // The token width, not the rendered width: in stacked mode a card is as
+        // wide as the deck, which would keep the deck stacked forever.
+        const parsedItemWidth = Number.parseFloat(
+            window.getComputedStyle(deck).getPropertyValue('--card-deck-item-width'),
+        );
+        const itemWidth = Number.isFinite(parsedItemWidth) ? parsedItemWidth : DEFAULT_ITEM_WIDTH;
+        // #568: a horizontal scroller with room for a single card hides every
+        // other card — fall back to the vertical stack instead.
+        const stacked = cardElements.length > 1 && deck.clientWidth > 0 && deck.clientWidth < itemWidth * 2 + gap;
+
+        const cardStep = firstCard ? firstCard.offsetWidth + gap : 0;
         const maxScrollLeft = Math.max(0, deck.scrollWidth - deck.clientWidth);
+        const firstVisibleCard =
+            cardStep > 0
+                ? Math.min(Math.max(cardElements.length - 1, 0), Math.max(0, Math.round(deck.scrollLeft / cardStep)))
+                : 0;
+        const visibleCardCount =
+            cardStep > 0 ? Math.max(1, Math.floor((deck.clientWidth + gap) / cardStep)) : cardElements.length;
+
         const nextState = {
-            canScrollBackward: deck.scrollLeft > SCROLL_EPSILON,
-            canScrollForward: deck.scrollLeft < maxScrollLeft - SCROLL_EPSILON,
+            canScrollBackward: !stacked && deck.scrollLeft > SCROLL_EPSILON,
+            canScrollForward: !stacked && deck.scrollLeft < maxScrollLeft - SCROLL_EPSILON,
+            firstVisibleCard,
+            stacked,
+            visibleCardCount,
         };
 
         setScrollState((currentState) =>
             currentState.canScrollBackward === nextState.canScrollBackward &&
-            currentState.canScrollForward === nextState.canScrollForward
+            currentState.canScrollForward === nextState.canScrollForward &&
+            currentState.firstVisibleCard === nextState.firstVisibleCard &&
+            currentState.stacked === nextState.stacked &&
+            currentState.visibleCardCount === nextState.visibleCardCount
                 ? currentState
                 : nextState,
         );
@@ -72,10 +111,7 @@ const CardDeckRoot = ({
                 return;
             }
 
-            const list = deck.querySelector('[data-admin-card-deck-list]');
-            const computedStyle = window.getComputedStyle(list ?? deck);
-            const parsedGap = Number.parseFloat(computedStyle.columnGap || computedStyle.gap);
-            const gap = Number.isFinite(parsedGap) ? parsedGap : 24;
+            const gap = readListGap(deck);
             const firstCard = deck.querySelector('[data-admin-card-deck-item]') as HTMLElement | null;
             const cardStep = firstCard ? firstCard.offsetWidth + gap : deck.clientWidth * 0.86;
 
@@ -132,7 +168,12 @@ const CardDeckRoot = ({
     }, [cards.length, updateScrollState]);
 
     return (
-        <section className={classNames(styles.root, className)} aria-label={ariaLabel} data-admin-card-deck>
+        <section
+            className={classNames(styles.root, { [styles.stacked]: scrollState.stacked }, className)}
+            aria-label={ariaLabel}
+            data-admin-card-deck
+            data-admin-card-deck-stacked={scrollState.stacked || undefined}
+        >
             <div
                 id={deckId}
                 className={classNames(styles.deck, deckClassName)}
@@ -145,7 +186,7 @@ const CardDeckRoot = ({
                     {cards}
                 </ul>
             </div>
-            {cards.length > 1 && (
+            {cards.length > 1 && !scrollState.stacked && (
                 <SideScrollerFooter
                     className={classNames(styles.footer, footerClassName)}
                     controlsId={deckId}
@@ -155,6 +196,9 @@ const CardDeckRoot = ({
                     nextLabel={nextLabel}
                     canScrollBackward={scrollState.canScrollBackward}
                     canScrollForward={scrollState.canScrollForward}
+                    cardCount={cards.length}
+                    firstVisibleCard={scrollState.firstVisibleCard}
+                    visibleCardCount={scrollState.visibleCardCount}
                     onScrollBackward={() => scrollCards(-1)}
                     onScrollForward={() => scrollCards(1)}
                 />

--- a/src/components/CardDeck/styles.module.scss
+++ b/src/components/CardDeck/styles.module.scss
@@ -41,6 +41,7 @@
     // siblings share the row width and crush each other on narrow screens.
     flex-direction: column;
     min-width: min(var(--card-deck-item-min-width, 320px), var(--card-deck-item-max-width, calc(100vw - 176px)));
+
     // #568: without a max-width a growable item contributes its content
     // max-content width to the `min-width: max-content` list, so a wide
     // toolbar silently doubles the card and pushes its siblings off-screen.

--- a/src/components/CardDeck/styles.module.scss
+++ b/src/components/CardDeck/styles.module.scss
@@ -41,11 +41,39 @@
     // siblings share the row width and crush each other on narrow screens.
     flex-direction: column;
     min-width: min(var(--card-deck-item-min-width, 320px), var(--card-deck-item-max-width, calc(100vw - 176px)));
+    // #568: without a max-width a growable item contributes its content
+    // max-content width to the `min-width: max-content` list, so a wide
+    // toolbar silently doubles the card and pushes its siblings off-screen.
+    max-width: min(var(--card-deck-item-width, 392px), var(--card-deck-item-max-width, calc(100vw - 176px)));
     flex: 0 0 min(var(--card-deck-item-width, 392px), var(--card-deck-item-max-width, calc(100vw - 176px)));
     scroll-snap-align: start;
 
     > * {
         width: 100%;
+    }
+}
+
+// #568: with room for less than two cards a horizontal scroller reads as a
+// single-card page — fall back to the same vertical stack as on mobile.
+.stacked {
+    min-height: 0;
+
+    .deck {
+        overflow: visible;
+        padding: var(--card-deck-mobile-padding, 0);
+        scroll-snap-type: none;
+    }
+
+    .list {
+        min-width: 0;
+        flex-direction: column;
+        gap: var(--card-deck-mobile-gap, 24px);
+    }
+
+    .item {
+        width: 100%;
+        max-width: none;
+        flex-basis: auto;
     }
 }
 
@@ -83,6 +111,7 @@
 
     .item {
         width: 100%;
+        max-width: none;
         flex-basis: auto;
     }
 

--- a/src/components/CardDeck/styles.test.ts
+++ b/src/components/CardDeck/styles.test.ts
@@ -22,6 +22,24 @@ describe('CardDeck responsive contract', () => {
         expect(itemRule).not.toMatch(/min-width:\s*0/);
     });
 
+    // #568: a growable deck item contributes its content max-content width
+    // under the list's `min-width: max-content`, letting a wide editor toolbar
+    // blow a card up to ~780px and push sibling cards off-screen.
+    it('caps the item width so card content can never widen the deck', () => {
+        const itemRule = cardDeckStyles.match(/\.item\s*{([^}]*)}/s)?.[1] ?? '';
+        expect(itemRule).toMatch(
+            /max-width:\s*min\(\s*var\(--card-deck-item-width,\s*392px\)\s*,\s*var\(--card-deck-item-max-width/s,
+        );
+    });
+
+    it('releases the item width cap when the deck stacks vertically', () => {
+        const mobileBlock = cardDeckStyles.match(/@media \(max-width: 767px\)\s*{(.*)}/s)?.[1] ?? '';
+        expect(mobileBlock).toMatch(/\.item\s*{[^}]*max-width:\s*none;/s);
+        const stackedBlock = cardDeckStyles.match(/\.stacked\s*{(.*)/s)?.[1] ?? '';
+        expect(stackedBlock).toMatch(/flex-direction:\s*column/);
+        expect(stackedBlock).toMatch(/max-width:\s*none/);
+    });
+
     it('exposes the distance between cards as a deck token', () => {
         const listRule = cardDeckStyles.match(/\.list\s*{([^}]*)}/s)?.[1] ?? '';
         expect(listRule).toMatch(/gap:\s*var\(--card-deck-gap,\s*24px\)/);

--- a/src/components/CardDeck/styles.test.ts
+++ b/src/components/CardDeck/styles.test.ts
@@ -35,9 +35,10 @@ describe('CardDeck responsive contract', () => {
     it('releases the item width cap when the deck stacks vertically', () => {
         const mobileBlock = cardDeckStyles.match(/@media \(max-width: 767px\)\s*{(.*)}/s)?.[1] ?? '';
         expect(mobileBlock).toMatch(/\.item\s*{[^}]*max-width:\s*none;/s);
-        const stackedBlock = cardDeckStyles.match(/\.stacked\s*{(.*)/s)?.[1] ?? '';
-        expect(stackedBlock).toMatch(/flex-direction:\s*column/);
-        expect(stackedBlock).toMatch(/max-width:\s*none/);
+        // The .stacked block ends where the next top-level rule begins.
+        const stackedBlock = cardDeckStyles.match(/\n\.stacked\s*{(.*?)\n}/s)?.[1] ?? '';
+        expect(stackedBlock).toMatch(/\.list\s*{[^}]*flex-direction:\s*column/s);
+        expect(stackedBlock).toMatch(/\.item\s*{[^}]*max-width:\s*none/s);
     });
 
     it('exposes the distance between cards as a deck token', () => {

--- a/src/components/SideScrollerFooter/index.tsx
+++ b/src/components/SideScrollerFooter/index.tsx
@@ -7,26 +7,34 @@ interface SideScrollerFooterProps {
     ariaLabel: string;
     canScrollBackward: boolean;
     canScrollForward: boolean;
+    // #568: one dot per card so off-screen cards stay discoverable without
+    // knowing what the corner arrows do.
+    cardCount?: number;
     className?: string;
     controlsId?: string;
     'data-admin-card-deck-footer'?: boolean;
+    firstVisibleCard?: number;
     nextLabel: string;
     onScrollBackward: () => void;
     onScrollForward: () => void;
     previousLabel: string;
+    visibleCardCount?: number;
 }
 
 export const SideScrollerFooter = ({
     ariaLabel,
     canScrollBackward,
     canScrollForward,
+    cardCount = 0,
     className,
     controlsId,
     'data-admin-card-deck-footer': dataAdminCardDeckFooter,
+    firstVisibleCard = 0,
     nextLabel,
     onScrollBackward,
     onScrollForward,
     previousLabel,
+    visibleCardCount = 1,
 }: SideScrollerFooterProps) => (
     <nav
         className={classNames(styles.footer, className)}
@@ -43,6 +51,23 @@ export const SideScrollerFooter = ({
         >
             <ArrowBackIcon />
         </button>
+        {cardCount > 1 && (
+            // The dots are a purely visual affordance: assistive technology
+            // already reaches every card through the deck's list semantics.
+            <div className={styles.positions} aria-hidden="true">
+                {Array.from({ length: cardCount }, (_, index) => {
+                    const active = index >= firstVisibleCard && index < firstVisibleCard + visibleCardCount;
+
+                    return (
+                        <span
+                            key={`card-position-${index}`}
+                            className={classNames(styles.dot, { [styles.dotActive]: active })}
+                            data-admin-card-deck-dot={active ? 'active' : 'inactive'}
+                        />
+                    );
+                })}
+            </div>
+        )}
         <button
             className={classNames(styles.button, { [styles.active]: canScrollForward })}
             type="button"

--- a/src/components/SideScrollerFooter/styles.module.scss
+++ b/src/components/SideScrollerFooter/styles.module.scss
@@ -13,13 +13,15 @@
 .dot {
     width: 8px;
     height: 8px;
-    border-radius: 50%;
-    background: #bec7d4;
-    transition: background 0.2s ease;
+    border-radius: 4px;
+    background: var(--m3-outline, #747878);
+    transition: background 0.2s ease, width 0.2s ease;
 }
 
+// Active dots widen to a pill so the state is not conveyed by color alone.
 .dotActive {
-    background: #111923;
+    width: 20px;
+    background: var(--m3-on-surface, #1b1b1c);
 }
 
 .button {

--- a/src/components/SideScrollerFooter/styles.module.scss
+++ b/src/components/SideScrollerFooter/styles.module.scss
@@ -1,6 +1,25 @@
 .footer {
     display: flex;
+    align-items: center;
     justify-content: space-between;
+}
+
+.positions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #bec7d4;
+    transition: background 0.2s ease;
+}
+
+.dotActive {
+    background: #111923;
 }
 
 .button {

--- a/src/components/Tenants/LegalSettings/index.tsx
+++ b/src/components/Tenants/LegalSettings/index.tsx
@@ -55,6 +55,7 @@ export const LegalSettings = ({ tenantId }: LegalSettingsProps) => {
     // visible in every view; editing stays restricted by permissions.
     return (
         <CardDeck
+            className={styles.cardDeck}
             ariaLabel={t('settings.subhead.legal')}
             previousLabel={t('legal.cardDeck.previous')}
             nextLabel={t('legal.cardDeck.next')}
@@ -85,10 +86,10 @@ export const LegalSettings = ({ tenantId }: LegalSettingsProps) => {
                     </CardEditable>
                 </CardDeck.Item>
             )}
-            <CardDeck.Item className={styles.cardDeckItem}>
+            <CardDeck.Item>
                 <DataProcessingAgreementContainer tenantId={finalTenantId} />
             </CardDeck.Item>
-            <CardDeck.Item className={styles.cardDeckItem}>
+            <CardDeck.Item>
                 <LegalText
                     tenantId={finalTenantId}
                     fieldName={['content', 'impressum']}
@@ -112,7 +113,7 @@ export const LegalSettings = ({ tenantId }: LegalSettingsProps) => {
                     field: ['content', 'confirmTermsAndConditions'],
                 }}
             /> */}
-            <CardDeck.Item className={styles.cardDeckItem}>{LegalTextElement}</CardDeck.Item>
+            <CardDeck.Item>{LegalTextElement}</CardDeck.Item>
         </CardDeck>
     );
 };

--- a/src/components/Tenants/LegalSettings/styles.module.scss
+++ b/src/components/Tenants/LegalSettings/styles.module.scss
@@ -9,6 +9,10 @@
     color: var(--black-60);
 }
 
-.cardDeckItem {
-    flex-grow: 1;
+// #568: cap the legal cards like the other settings decks. Without the cap a
+// legal card inherits its content's max-content width (the non-wrapping editor
+// toolbar, ~750px) and pushes the imprint and privacy cards off-screen.
+.cardDeck {
+    --card-deck-item-width: 425px;
+    --card-deck-item-max-width: 425px;
 }

--- a/src/components/Tenants/LegalSettings/styles.test.ts
+++ b/src/components/Tenants/LegalSettings/styles.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const legalSettingsStyles = readFileSync(resolve(__dirname, './styles.module.scss'), 'utf8');
+
+// #568: without a width cap the legal cards inherit their content's
+// max-content width (the ~750px editor toolbar) and push the imprint and
+// privacy cards off-screen, where nothing marks them as reachable.
+describe('LegalSettings card deck contract', () => {
+    it('pins the deck item width tokens like the other settings decks', () => {
+        expect(legalSettingsStyles).toMatch(/--card-deck-item-width:\s*425px/);
+        expect(legalSettingsStyles).toMatch(/--card-deck-item-max-width:\s*425px/);
+    });
+
+    it('never lets a deck item grow beyond its token width', () => {
+        expect(legalSettingsStyles).not.toMatch(/flex-grow/);
+    });
+});

--- a/src/components/Tenants/LegalSettings/styles.test.ts
+++ b/src/components/Tenants/LegalSettings/styles.test.ts
@@ -9,10 +9,13 @@ const legalSettingsStyles = readFileSync(resolve(__dirname, './styles.module.scs
 // privacy cards off-screen, where nothing marks them as reachable.
 describe('LegalSettings card deck contract', () => {
     it('pins the deck item width tokens like the other settings decks', () => {
-        expect(legalSettingsStyles).toMatch(/--card-deck-item-width:\s*425px/);
-        expect(legalSettingsStyles).toMatch(/--card-deck-item-max-width:\s*425px/);
+        const cardDeckRule = legalSettingsStyles.match(/\.cardDeck\s*{([^}]*)}/s)?.[1] ?? '';
+        expect(cardDeckRule).toMatch(/--card-deck-item-width:\s*425px/);
+        expect(cardDeckRule).toMatch(/--card-deck-item-max-width:\s*425px/);
     });
 
+    // Deliberately file-wide: any grow rule on this page's deck items would
+    // reintroduce the max-content blow-up, whatever class it hides behind.
     it('never lets a deck item grow beyond its token width', () => {
         expect(legalSettingsStyles).not.toMatch(/flex-grow/);
     });


### PR DESCRIPTION
## Problem

On `/admin/theme-settings/legal` the imprint and privacy cards scrolled off-screen and read as missing: the legal deck items had `flex-grow: 1`, so under the list's `min-width: max-content` sizing each card inherited its content's max-content width (the non-wrapping editor toolbar, ~750px) and only two of four cards fit. The deck hides its scrollbar and its only affordance is the detached corner arrows.

## What changed

- Pin `--card-deck-item-width` / `--card-deck-item-max-width: 425px` on the legal deck (same as SMTP/permissions decks) and drop the `flex-grow: 1`
- Add a `max-width` clamp on `CardDeck` items so content can never drive an item past its token width, regardless of consumer classes
- `SideScrollerFooter` shows one position dot per card; active dots mark the visible cards
- `CardDeck` falls back to the vertical stack when fewer than two cards fit (matching the existing mobile stacking)
- Regression tests: style contracts for the width cap (CardDeck + LegalSettings) and behavioral tests for the dots and the stacked fallback; new `StackedFallback` story, `OverflowingCards` story widened to keep demonstrating the scroller

## Verification

- `npm run test` — 185 files / 1003 tests green (new tests written red-first)
- `npx eslint … --max-warnings=0`, `prettier --check`, `npm run build` — clean
- Storybook (`molecules-carddeck--overflowing-cards`, 1280×800): items exactly 392px, 4 dots tracking scroll positions, all cards reachable, arrows disable at the ends; `stacked-fallback` at 480px stacks vertically without the footer

Pre-dev/dev deploy verification per the issue's acceptance list is still open.

Refs OpenResilienceInitiative/ORISO-Admin#568

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive CardDeck “stacked” mode for narrow layouts, switching from horizontal scrolling to vertical stacking.
  * Added visual position dots to the side-scroller footer to indicate the currently visible card range.
  * Added Storybook examples for overflow and stacked fallback behavior.
* **Bug Fixes**
  * Improved card sizing/overflow handling to prevent cards from expanding and affecting surrounding layout.
  * Updated legal settings deck styling to cap card width and avoid pushing other cards off-screen.
* **Tests**
  * Added coverage for stacked layout behavior, dot visibility states, and responsive CSS contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->