### PR TITLE
feat: add reusable email template preview

### DIFF
--- a/src/components/EmailTemplatePreview/EmailTemplatePreview.stories.tsx
+++ b/src/components/EmailTemplatePreview/EmailTemplatePreview.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { EmailTemplatePreview } from '.';
+
+const meta = {
+    title: 'Organisms/Email/EmailTemplatePreview',
+    component: EmailTemplatePreview,
+    parameters: {
+        layout: 'centered',
+        docs: {
+            description: {
+                component:
+                    'The shared visual contract for ORISO transactional email. The same shell previews 2FA codes, tenant invitations and agency/counsellor invitations without copying layout or using live credentials.',
+            },
+        },
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: 'min(760px, calc(100vw - 32px))' }}>
+                <Story />
+            </div>
+        ),
+    ],
+    args: {
+        previewLabel: 'E-Mail-Vorschau',
+        subject: 'Ihr Zugang zu ORISO',
+        body: 'Hallo {{firstName}},\n\nIhre Einladung ist bereit.',
+    },
+} satisfies Meta<typeof EmailTemplatePreview>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TwoFactorCode: Story = {
+    args: {
+        subject: 'Ihr ORISO 2FA-Code',
+        body: 'Geben Sie diesen Code im geöffneten ORISO-Fenster ein.',
+        code: '123456',
+        codeLabel: 'Beispielhafter 2FA-Code: 123456',
+        supportingText: 'Der Beispielcode ist 15 Minuten gültig. Er ist kein echter Einmalcode.',
+    },
+};
+
+export const TenantInvite: Story = {
+    args: {
+        subject: 'Ihre Einladung als Träger-Admin',
+        body: 'Hallo {{firstName}} {{lastName}},\n\nrichten Sie jetzt den Zugang für Ihren Träger ein.',
+        action: {
+            label: 'Träger-Einladung annehmen',
+            href: 'https://admin.example.invalid/invite/tenant-demo',
+        },
+        supportingText: 'Dieser Storybook-Link ist synthetisch und kann keine Einladung aktivieren.',
+    },
+};
+
+export const AgencyInvite: Story = {
+    args: {
+        subject: 'Ihre Einladung zur Beratungsstelle',
+        body: 'Hallo {{firstName}},\n\nSie wurden einer Beratungsstelle im Träger {{tenantId}} zugeordnet.',
+        action: {
+            label: 'Einladung zur Beratungsstelle annehmen',
+            href: 'https://app.example.invalid/invite/agency-demo',
+        },
+        supportingText: 'Dieser Storybook-Link ist synthetisch und kann kein Konto freischalten.',
+    },
+};
+
+export const LongContentMobile: Story = {
+    args: {
+        subject: 'Ihre Einladung zur Beratungsplattform',
+        body:
+            'Hallo {{firstName}} {{lastName}},\n\nmit dieser Einladung richten Sie Ihren Zugang ein. ' +
+            'Prüfen Sie anschließend die Angaben zu Ihrer Organisation und schließen Sie die erforderlichen Schritte ab.\n\n' +
+            'Die Einladung gehört zu {{email}} und dem Träger {{tenantId}}.',
+        action: {
+            label: 'Einladung öffnen',
+            href: 'https://admin.example.invalid/invite/long-demo',
+        },
+        supportingText:
+            'Wenn Sie diese Einladung nicht erwartet haben, können Sie die E-Mail ignorieren. Der Beispiel-Link ist nicht aktiv.',
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: 390, maxWidth: 'calc(100vw - 24px)' }}>
+                <Story />
+            </div>
+        ),
+    ],
+};

--- a/src/components/EmailTemplatePreview/index.test.tsx
+++ b/src/components/EmailTemplatePreview/index.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EmailTemplatePreview, EmailTemplatePreviewProps } from '.';
+
+const baseProps: EmailTemplatePreviewProps = {
+    previewLabel: 'Email preview',
+    subject: 'Your ORISO invitation',
+    body: 'Hello {{firstName}}, your invitation is ready.',
+};
+
+describe('EmailTemplatePreview', () => {
+    it('keeps template placeholders visible without interpreting them as HTML', () => {
+        render(<EmailTemplatePreview {...baseProps} />);
+
+        const preview = screen.getByRole('region', { name: 'Email preview' });
+        expect(within(preview).getByText('{{firstName}}')).toBeInTheDocument();
+        expect(within(preview).queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('renders a 2FA code as one accessible selectable value', () => {
+        const otpProps = {
+            ...baseProps,
+            subject: 'Your ORISO 2FA code',
+            code: '123456',
+            codeLabel: 'Your 2FA code: 123456',
+            supportingText: 'The code is valid for 15 minutes.',
+        } as EmailTemplatePreviewProps & {
+            code: string;
+            codeLabel: string;
+            supportingText: string;
+        };
+
+        render(<EmailTemplatePreview {...otpProps} />);
+
+        const code = screen.getByLabelText('Your 2FA code: 123456');
+        expect(code).toHaveTextContent('123456');
+        expect(code.className).toMatch(/code/);
+        expect(screen.getByText('The code is valid for 15 minutes.')).toBeInTheDocument();
+    });
+
+    it('renders an invite action with its explicit label and safe example URL', () => {
+        const inviteProps = {
+            ...baseProps,
+            action: {
+                label: 'Accept tenant invitation',
+                href: 'https://admin.example.invalid/invite/tenant-demo',
+            },
+        } as EmailTemplatePreviewProps & {
+            action: { label: string; href: string };
+        };
+
+        render(<EmailTemplatePreview {...inviteProps} />);
+
+        expect(screen.getByRole('link', { name: 'Accept tenant invitation' })).toHaveAttribute(
+            'href',
+            'https://admin.example.invalid/invite/tenant-demo',
+        );
+    });
+});

--- a/src/components/EmailTemplatePreview/index.tsx
+++ b/src/components/EmailTemplatePreview/index.tsx
@@ -1,0 +1,63 @@
+import styles from './styles.module.scss';
+
+export interface EmailTemplatePreviewProps {
+    subject: string;
+    body: string;
+    previewLabel: string;
+    code?: string;
+    codeLabel?: string;
+    supportingText?: string;
+    action?: {
+        label: string;
+        href: string;
+    };
+}
+
+const renderBody = (body: string) =>
+    body.split(/({{[^{}]+}})/g).map((part, index) =>
+        /^{{[^{}]+}}$/.test(part) ? (
+            <code className={styles.token} key={`${part}-${index}`}>
+                {part}
+            </code>
+        ) : (
+            part
+        ),
+    );
+
+export const EmailTemplatePreview = ({
+    subject,
+    body,
+    previewLabel,
+    code,
+    codeLabel,
+    supportingText,
+    action,
+}: EmailTemplatePreviewProps) => (
+    <section className={styles.preview} aria-label={previewLabel}>
+        <div className={styles.meta}>
+            <span className={styles.metaLabel}>Subject</span>
+            <strong>{subject || '—'}</strong>
+        </div>
+        <div className={styles.canvas}>
+            <article className={styles.email}>
+                <header className={styles.brand}>ORISO</header>
+                <div className={styles.content}>
+                    <h2>{subject || 'Email subject'}</h2>
+                    <p className={styles.body}>{body ? renderBody(body) : 'Email body'}</p>
+                    {code && (
+                        <div className={styles.code} aria-label={codeLabel}>
+                            {code}
+                        </div>
+                    )}
+                    {action && (
+                        <a className={styles.action} href={action.href}>
+                            {action.label}
+                        </a>
+                    )}
+                    {supportingText && <p className={styles.supportingText}>{supportingText}</p>}
+                </div>
+                <footer className={styles.footer}>ORISO</footer>
+            </article>
+        </div>
+    </section>
+);

--- a/src/components/EmailTemplatePreview/styles.module.scss
+++ b/src/components/EmailTemplatePreview/styles.module.scss
@@ -1,0 +1,140 @@
+.preview {
+    overflow: hidden;
+    min-width: 0;
+    border: 1px solid var(--m3-outline-variant, #cac4d0);
+    background: var(--m3-surface, #ffffff);
+    border-radius: 12px;
+    font-family: var(--m3-body-font-family, Inter, Arial, sans-serif);
+}
+
+.meta {
+    display: grid;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--m3-outline-variant, #cac4d0);
+    color: var(--m3-on-surface, #1d1b20);
+    gap: 4px;
+    overflow-wrap: anywhere;
+}
+
+.metaLabel {
+    color: var(--m3-on-surface-variant, #49454f);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.canvas {
+    padding: 24px;
+    background: #f4f6fa;
+}
+
+.email {
+    overflow: hidden;
+    max-width: 600px;
+    border: 1px solid #e5e7eb;
+    margin: 0 auto;
+    background: #ffffff;
+    border-radius: 10px;
+    box-shadow: 0 12px 32px rgb(15 59 143 / 8%);
+    color: #1f2937;
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+.brand {
+    padding: 20px 24px;
+    background: #0f3b8f;
+    color: #ffffff;
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-align: center;
+}
+
+.content {
+    padding: 28px;
+
+    h2 {
+        margin: 0 0 16px;
+        color: #111827;
+        font-size: 22px;
+        line-height: 1.3;
+    }
+}
+
+.body {
+    margin: 0;
+    color: #4b5563;
+    font-size: 15px;
+    line-height: 1.65;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+}
+
+.token {
+    display: inline;
+    padding: 2px 5px;
+    background: #eef3ff;
+    border-radius: 4px;
+    color: #0f3b8f;
+    font-family: SFMono-Regular, Consolas, 'Liberation Mono', monospace;
+    font-size: 0.9em;
+    font-weight: 700;
+}
+
+.code {
+    padding: 20px 16px;
+    border: 1px solid #c7d6fa;
+    margin: 24px 0 12px;
+    background: #eef3ff;
+    border-radius: 9px;
+    color: #0f3b8f;
+    font-family: SFMono-Regular, Consolas, 'Liberation Mono', monospace;
+    font-size: clamp(26px, 6vw, 36px);
+    font-weight: 700;
+    letter-spacing: 0.22em;
+    line-height: 1;
+    text-align: center;
+    user-select: all;
+    white-space: nowrap;
+}
+
+.action {
+    display: table;
+    padding: 12px 20px;
+    margin: 24px 0 12px;
+    background: #0f3b8f;
+    border-radius: 7px;
+    color: #ffffff;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 1.4;
+    text-decoration: none;
+}
+
+.supportingText {
+    padding-top: 16px;
+    border-top: 1px solid #e5e7eb;
+    margin: 16px 0 0;
+    color: #6b7280;
+    font-size: 13px;
+    line-height: 1.55;
+}
+
+.footer {
+    padding: 16px 24px;
+    background: #f9fafb;
+    color: #6b7280;
+    font-size: 12px;
+    text-align: center;
+}
+
+@media (max-width: 720px) {
+    .canvas {
+        padding: 12px;
+    }
+
+    .content {
+        padding: 22px 18px;
+    }
+}

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -289,6 +289,7 @@
     "links.bulk.sendSummaryPartial": "{{sent}} gesendet, {{failed}} fehlgeschlagen: {{emails}}",
     "links.templates.manage": "Vorlagen verwalten",
     "links.templates.dialogTitle": "E-Mail-Vorlagen",
+    "links.templates.previewLabel": "E-Mail-Vorschau",
     "links.templates.close": "Schließen",
     "links.templates.back": "Zurück",
     "links.templates.save": "Speichern",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -344,6 +344,7 @@
     "links.bulk.sendSummaryPartial": "{{sent}} sent, {{failed}} failed: {{emails}}",
     "links.templates.manage": "Manage templates",
     "links.templates.dialogTitle": "Email templates",
+    "links.templates.previewLabel": "Email preview",
     "links.templates.close": "Close",
     "links.templates.back": "Back",
     "links.templates.save": "Save",

--- a/src/pages/Links/EmailTemplatesDialog.module.scss
+++ b/src/pages/Links/EmailTemplatesDialog.module.scss
@@ -1,9 +1,27 @@
 /* Right-aligned action row; the shared Modal supplies the surrounding padding.
    `listingTableStyles.actionGroup` isn't used here — it's inline-flex without
    right-alignment (fine for a table-row action cell, wrong for a dialog footer). */
+
 .footerActions {
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;
     gap: 8px;
+}
+
+.formAndPreview {
+    display: grid;
+    align-items: start;
+    gap: 24px;
+    grid-template-columns: minmax(320px, 0.9fr) minmax(360px, 1.1fr);
+}
+
+.formFields {
+    min-width: 0;
+}
+
+@media (max-width: 920px) {
+    .formAndPreview {
+        grid-template-columns: 1fr;
+    }
 }

--- a/src/pages/Links/EmailTemplatesDialog.test.tsx
+++ b/src/pages/Links/EmailTemplatesDialog.test.tsx
@@ -168,6 +168,26 @@ describe('EmailTemplatesDialog', () => {
         await waitFor(() => expect(mocks.listInviteEmailTemplates).toHaveBeenCalledTimes(6));
     });
 
+    it('renders a live email preview from the subject and body fields', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+
+        await waitFor(() => expect(screen.getAllByTestId('template-row')).toHaveLength(2));
+        await user.click(screen.getByRole('button', { name: 'New template' }));
+
+        const dialog = screen.getByRole('dialog');
+        const withinDialog = within(dialog);
+        await user.type(withinDialog.getByLabelText('Subject'), 'Welcome to ORISO');
+        fireEvent.change(withinDialog.getByLabelText('Body'), {
+            target: { value: 'Hello Hugo,\n\nUse {{inviteLink}} to finish setup.' },
+        });
+
+        const preview = withinDialog.getByRole('region', { name: 'Email preview' });
+        expect(within(preview).getByRole('heading', { name: 'Welcome to ORISO' })).toBeInTheDocument();
+        expect(within(preview).getByText(/Hello Hugo/)).toBeInTheDocument();
+        expect(within(preview).getByText('{{inviteLink}}')).toBeInTheDocument();
+    });
+
     it('opens a prefilled edit form on row double-click and updates the template', async () => {
         const user = userEvent.setup();
         mocks.updateInviteEmailTemplate.mockResolvedValue({ ...tenantTemplate, subject: 'Servus' });

--- a/src/pages/Links/EmailTemplatesDialog.tsx
+++ b/src/pages/Links/EmailTemplatesDialog.tsx
@@ -10,6 +10,7 @@ import {
     TemplateRequestDTO,
     updateInviteEmailTemplate,
 } from '../../api/accountInvites/accountInvites';
+import { EmailTemplatePreview } from '../../components/EmailTemplatePreview';
 import { ListingTable, listingTableStyles } from '../../components/ListingTable';
 import { Modal, DialogButton } from '../../components/Modal';
 import styles from './EmailTemplatesDialog.module.scss';
@@ -57,6 +58,8 @@ export const EmailTemplatesDialog = ({
     const [submitting, setSubmitting] = useState(false);
     const [view, setView] = useState<'list' | 'form'>('list');
     const [editingTemplate, setEditingTemplate] = useState<InviteEmailTemplateDTO | null>(null);
+    const previewSubject = Form.useWatch('subject', form) ?? '';
+    const previewBody = Form.useWatch('body', form) ?? '';
 
     const kindLabel = useCallback((kind: InviteEmailTemplateKind) => t(`links.templates.kind.${kind}`, kind), [t]);
 
@@ -252,7 +255,7 @@ export const EmailTemplatesDialog = ({
             icon={<EmailOutlinedIcon />}
             onClose={onClose}
             footer={view === 'list' ? listFooter : formFooter}
-            width={860}
+            width={1180}
         >
             {view === 'list' ? (
                 <ListingTable
@@ -268,70 +271,83 @@ export const EmailTemplatesDialog = ({
                 />
             ) : (
                 <Form form={form} layout="vertical" onFinish={onSubmit} initialValues={{ active: true }}>
-                    <Form.Item
-                        name="kind"
-                        label={t('links.templates.field.kind', 'Kind')}
-                        rules={[{ required: true, message: t('plsSelect') }]}
-                    >
-                        <Select options={TEMPLATE_KINDS.map((kind) => ({ value: kind, label: kindLabel(kind) }))} />
-                    </Form.Item>
-                    <Form.Item
-                        name="name"
-                        label={t('links.templates.field.name', 'Name')}
-                        rules={[
-                            {
-                                required: true,
-                                whitespace: true,
-                                message: t('links.templates.field.nameRequired', 'Name is required'),
-                            },
-                        ]}
-                    >
-                        <Input />
-                    </Form.Item>
-                    <Form.Item name="language" label={t('links.templates.field.language', 'Language')}>
-                        <Input placeholder="de" />
-                    </Form.Item>
-                    <Form.Item
-                        name="subject"
-                        label={t('links.templates.field.subject', 'Subject')}
-                        rules={[
-                            {
-                                required: true,
-                                whitespace: true,
-                                message: t('links.templates.field.subjectRequired', 'Subject is required'),
-                            },
-                        ]}
-                    >
-                        <Input />
-                    </Form.Item>
-                    <Form.Item
-                        name="body"
-                        label={t('links.templates.field.body', 'Body')}
-                        rules={[
-                            {
-                                required: true,
-                                whitespace: true,
-                                message: t('links.templates.field.bodyRequired', 'Body is required'),
-                            },
-                        ]}
-                        extra={
-                            <>
-                                {t('links.templates.field.bodyHelp', 'Available placeholders:')}{' '}
-                                {/* Placeholder tokens are literal template syntax, not prose — kept out of
+                    <div className={styles.formAndPreview}>
+                        <div className={styles.formFields}>
+                            <Form.Item
+                                name="kind"
+                                label={t('links.templates.field.kind', 'Kind')}
+                                rules={[{ required: true, message: t('plsSelect') }]}
+                            >
+                                <Select
+                                    options={TEMPLATE_KINDS.map((kind) => ({ value: kind, label: kindLabel(kind) }))}
+                                />
+                            </Form.Item>
+                            <Form.Item
+                                name="name"
+                                label={t('links.templates.field.name', 'Name')}
+                                rules={[
+                                    {
+                                        required: true,
+                                        whitespace: true,
+                                        message: t('links.templates.field.nameRequired', 'Name is required'),
+                                    },
+                                ]}
+                            >
+                                <Input />
+                            </Form.Item>
+                            <Form.Item name="language" label={t('links.templates.field.language', 'Language')}>
+                                <Input placeholder="de" />
+                            </Form.Item>
+                            <Form.Item
+                                name="subject"
+                                label={t('links.templates.field.subject', 'Subject')}
+                                rules={[
+                                    {
+                                        required: true,
+                                        whitespace: true,
+                                        message: t('links.templates.field.subjectRequired', 'Subject is required'),
+                                    },
+                                ]}
+                            >
+                                <Input />
+                            </Form.Item>
+                            <Form.Item
+                                name="body"
+                                label={t('links.templates.field.body', 'Body')}
+                                rules={[
+                                    {
+                                        required: true,
+                                        whitespace: true,
+                                        message: t('links.templates.field.bodyRequired', 'Body is required'),
+                                    },
+                                ]}
+                                extra={
+                                    <>
+                                        {t('links.templates.field.bodyHelp', 'Available placeholders:')}{' '}
+                                        {/* Placeholder tokens are literal template syntax, not prose — kept out of
                                     i18next's t() so its {{var}} interpolation does not try to substitute them. */}
-                                <code>{'{{inviteLink}}, {{email}}, {{firstName}}, {{lastName}}, {{tenantId}}'}</code>
-                            </>
-                        }
-                    >
-                        <Input.TextArea rows={8} />
-                    </Form.Item>
-                    <Form.Item
-                        name="active"
-                        label={t('links.templates.field.active', 'Active')}
-                        valuePropName="checked"
-                    >
-                        <Switch />
-                    </Form.Item>
+                                        <code>
+                                            {'{{inviteLink}}, {{email}}, {{firstName}}, {{lastName}}, {{tenantId}}'}
+                                        </code>
+                                    </>
+                                }
+                            >
+                                <Input.TextArea rows={8} />
+                            </Form.Item>
+                            <Form.Item
+                                name="active"
+                                label={t('links.templates.field.active', 'Active')}
+                                valuePropName="checked"
+                            >
+                                <Switch />
+                            </Form.Item>
+                        </div>
+                        <EmailTemplatePreview
+                            subject={previewSubject}
+                            body={previewBody}
+                            previewLabel={t('links.templates.previewLabel', 'Email preview')}
+                        />
+                    </div>
                 </Form>
             )}
         </Modal>


### PR DESCRIPTION
## Summary

- add a reusable ORISO transactional-email preview component to Storybook
- cover 2FA codes, tenant invites, agency invites, and long mobile content
- embed the same live preview in the existing email-template editor
- keep placeholder tokens visible and use synthetic `.invalid` links only

## Verification

- `npm test` — 185 files, 1001 tests passed
- `npm run lint:js`
- targeted Stylelint — 0 errors
- `npm run typecheck:storybook`
- `npm run build-storybook`
- `npm run build`
- browser-checked the 2FA desktop and long-content mobile stories

Closes OpenResilienceInitiative/ORISO-Admin#585
Refs OpenResilienceInitiative/ORISO-Admin#584

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live email preview to the email template create and edit dialog.
  * Preview updates instantly as the subject and message content are entered.
  * Template placeholders remain visible and clearly highlighted.
  * Added support for previewing verification codes, invite actions, and supporting text.
  * Added responsive layouts for desktop and mobile displays.
* **Documentation**
  * Added Storybook examples covering common email templates and long mobile content.
* **Tests**
  * Added coverage for placeholder rendering, verification codes, links, and live preview updates.
* **Localization**
  * Added English and German labels for the email preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->