### PR TITLE
fix(onboarding): make the public tenant-admin page usable on mobile

### DIFF
--- a/src/components/Layout/PublicPageLayoutWrapper.tsx
+++ b/src/components/Layout/PublicPageLayoutWrapper.tsx
@@ -21,7 +21,12 @@ const PublicPageLayoutWrapper = ({ children, className = '', hideFooter }: Publi
     }, []);
 
     return (
-        <Layout style={{ minHeight: '100vh' }}>
+        // `publicLayout` bounds the page to the viewport and makes it its own
+        // scroll container — the app shell locks document scrolling, so without
+        // it any public page taller than the viewport is simply truncated
+        // (#569: the tenant-admin onboarding form and its primary action were
+        // unreachable on 390x844). See styles/components/publicLayout.less.
+        <Layout className="publicLayout">
             <Content className={clsx('publicContent', className)}>{children}</Content>
             {!hideFooter && <SiteFooter />}
         </Layout>

--- a/src/components/Layout/publicPageScroll.test.ts
+++ b/src/components/Layout/publicPageScroll.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const publicLayout = readFileSync(resolve(__dirname, '../../styles/components/publicLayout.less'), 'utf8');
+const stage = readFileSync(resolve(__dirname, '../../styles/components/stage.less'), 'utf8');
+const app = readFileSync(resolve(__dirname, '../../styles/App.less'), 'utf8');
+
+/**
+ * jsdom computes no layout, so the scroll behaviour that made the tenant-admin
+ * onboarding page unusable at 390x844 (#569) is asserted on the stylesheets:
+ * the document is deliberately scroll-locked by the app shell, therefore the
+ * public layout has to be a scroll container itself.
+ */
+describe('public page scrolling', () => {
+    it('still locks document scrolling in the app shell', () => {
+        // Guard for the rule below: if this ever changes, the .publicLayout
+        // scroll container may become redundant instead of load-bearing.
+        expect(app).toMatch(/html,\s*\n?body\s*{[\s\S]*?overflow:\s*hidden/);
+    });
+
+    it('bounds the public layout to the viewport and lets it scroll itself', () => {
+        const rule = publicLayout.match(/\n\.publicLayout\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+
+        expect(rule).toMatch(/max-height:\s*100vh/);
+        expect(rule).toMatch(/min-height:\s*100vh/);
+        expect(rule).toMatch(/overflow-y:\s*auto/);
+    });
+
+    it('keeps the content from shrinking back into the viewport instead of scrolling', () => {
+        // antd's `flex: auto` on the content would otherwise squash a tall page
+        // to viewport height and let it spill across the footer.
+        const rule = publicLayout.match(/\n\.publicLayout\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+        const contentRule = rule.match(/>\s*\.publicContent\s*{([\s\S]*?)\n {4}}/)?.[1] ?? '';
+
+        expect(contentRule).toMatch(/flex:\s*1 0 auto/);
+        expect(rule).toMatch(/>\s*\.layoutFooter\s*{[\s\S]*?flex-shrink:\s*0/);
+    });
+
+    it('keeps the branding stage off small screens when it is rendered as a side panel', () => {
+        const rule = stage.match(/\n\.stage--panel\s*{([\s\S]*?)\n}\n/)?.[1] ?? '';
+
+        expect(rule).toMatch(/display:\s*none/);
+        expect(rule).toMatch(/animation:\s*none/);
+        // Only from xl up, where the form column sits clear of the 40vw panel.
+        expect(rule).toMatch(/@media screen and \(min-width: @screen-xl\)[\s\S]*display:\s*flex/);
+    });
+});

--- a/src/pages/Login/Stage.tsx
+++ b/src/pages/Login/Stage.tsx
@@ -13,6 +13,13 @@ export interface StageProps {
     // Tenant branding — falls back to the brand animation when not configured or broken
     logo?: string | null;
     claim?: string | null;
+    /**
+     * `true` (default): branding intro that covers the whole small-screen
+     * viewport before sliding away — right for a short login form.
+     * `false`: desktop-only side panel that never covers the content (#569),
+     * for public pages hosting a tall form.
+     */
+    overlay?: boolean;
 }
 
 /**
@@ -21,7 +28,7 @@ export interface StageProps {
  * configured logo URL fails to load — the ORISO brand Lottie animation plays once
  * (half speed) in its place.
  */
-const Stage = ({ className, hasAnimation, isReady = true, logo, claim }: StageProps) => {
+const Stage = ({ className, hasAnimation, isReady = true, logo, claim, overlay = true }: StageProps) => {
     const { t } = useTranslation();
     const [logoFailed, setLogoFailed] = useState(false);
     const showTenantLogo = Boolean(logo) && !logoFailed;
@@ -29,8 +36,10 @@ const Stage = ({ className, hasAnimation, isReady = true, logo, claim }: StagePr
     return (
         <div
             id="loginLogoWrapper"
-            className={clsx(className, 'stage stage--animated', {
-                'stage--ready': isReady,
+            className={clsx(className, 'stage', {
+                'stage--animated': overlay,
+                'stage--ready': overlay && isReady,
+                'stage--panel': !overlay,
             })}
         >
             {showTenantLogo ? (

--- a/src/pages/PasswordReset/PasswordResetPageLayout.test.tsx
+++ b/src/pages/PasswordReset/PasswordResetPageLayout.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PasswordResetPageLayout } from './PasswordResetPageLayout';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'de' } }),
+}));
+
+vi.mock('../../components/LanguageSelector', () => ({
+    LanguageSelector: () => <div data-testid="language-selector" />,
+}));
+
+vi.mock('../../components/LottieAnimation', () => ({
+    LottieAnimation: () => <div data-testid="stage-animation" />,
+}));
+
+vi.mock('../../hooks/usePublicTenantData.hook', () => ({
+    usePublicTenantData: () => ({ data: undefined }),
+}));
+
+vi.mock('../../context/useAppConfig', () => ({
+    useAppConfigContext: () => ({ settings: {} }),
+}));
+
+vi.mock('../../api/tenant/getPublicTenantData', () => ({
+    default: vi.fn(),
+}));
+
+const stage = () => document.getElementById('loginLogoWrapper');
+
+/**
+ * #569 chain fix: the tenant-admin onboarding page reuses this layout for a
+ * ~1270px tall multi-step form. The app shell locks document scrolling
+ * (html/body overflow hidden), so a public page that does not own a scroll
+ * container simply truncates — on 390x844 the invitee could reach neither the
+ * organisation fields nor the "Continue" button, and the full-viewport branding
+ * stage painted over what was left.
+ */
+describe('PasswordResetPageLayout', () => {
+    it('gives every public page its own scroll container instead of relying on the locked document', () => {
+        render(
+            <PasswordResetPageLayout>
+                <div data-testid="content" />
+            </PasswordResetPageLayout>,
+        );
+
+        expect(screen.getByTestId('content').closest('.publicLayout')).not.toBeNull();
+    });
+
+    it('keeps the animated full-viewport branding intro for the short login-style default', () => {
+        render(
+            <PasswordResetPageLayout>
+                <div data-testid="content" />
+            </PasswordResetPageLayout>,
+        );
+
+        expect(stage()).toHaveClass('stage--animated');
+        expect(stage()).not.toHaveClass('stage--panel');
+    });
+
+    it('renders the stage as a side panel for long forms so it can never cover them on mobile', () => {
+        render(
+            <PasswordResetPageLayout variant="longForm">
+                <div data-testid="content" />
+            </PasswordResetPageLayout>,
+        );
+
+        expect(stage()).toHaveClass('stage--panel');
+        expect(stage()).not.toHaveClass('stage--animated');
+    });
+
+    it('aligns a long form to the top of the column so its first field is the first thing in view', () => {
+        render(
+            <PasswordResetPageLayout variant="longForm">
+                <div data-testid="content" />
+            </PasswordResetPageLayout>,
+        );
+
+        expect(document.querySelector('.ant-row')).toHaveClass('ant-row-top');
+    });
+});

--- a/src/pages/PasswordReset/PasswordResetPageLayout.tsx
+++ b/src/pages/PasswordReset/PasswordResetPageLayout.tsx
@@ -6,16 +6,32 @@ import { usePublicTenantData } from '../../hooks/usePublicTenantData.hook';
 import { orisoMuiTheme } from '../../theme/orisoMuiTheme';
 import Stage from '../Login/Stage';
 
-export const PasswordResetPageLayout = ({ children }: { children: React.ReactNode }) => {
+export interface PasswordResetPageLayoutProps {
+    children: React.ReactNode;
+    /**
+     * `login` (default): short, vertically centred form — the branding stage
+     * plays its full-viewport intro on small screens, as on the login page.
+     *
+     * `longForm`: the page hosts a tall multi-step form (tenant-admin
+     * onboarding, #569). The form is aligned to the top of the column and the
+     * stage is reduced to a desktop-only side panel, so nothing covers the
+     * fields or the primary action on a phone. Scrolling itself is provided by
+     * PublicPageLayoutWrapper for every public page.
+     */
+    variant?: 'login' | 'longForm';
+}
+
+export const PasswordResetPageLayout = ({ children, variant = 'login' }: PasswordResetPageLayoutProps) => {
     const { data: tenantData } = usePublicTenantData();
+    const isLongForm = variant === 'longForm';
 
     return (
         <PublicPageLayoutWrapper className="login flex-col flex">
             <div className="loginLanguageSelector">
                 <LanguageSelector variant="login" ariaLabelKey="language.loginSelectAriaLabel" />
             </div>
-            <Stage logo={tenantData?.theming?.logo} claim={tenantData?.content?.claim} />
-            <Row align="middle" style={{ flex: '1 0 auto' }}>
+            <Stage logo={tenantData?.theming?.logo} claim={tenantData?.content?.claim} overlay={!isLongForm} />
+            <Row align={isLongForm ? 'top' : 'middle'} style={{ flex: '1 0 auto' }}>
                 <Col xs={{ span: 20, offset: 2 }} md={{ span: 8, offset: 2 }} xl={{ span: 6, offset: 5 }}>
                     <ThemeProvider theme={orisoMuiTheme}>{children}</ThemeProvider>
                 </Col>

--- a/src/pages/TenantOnboarding/TenantAdminOnboardingPage.test.tsx
+++ b/src/pages/TenantOnboarding/TenantAdminOnboardingPage.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { TenantAdminOnboardingPage } from './TenantAdminOnboardingPage';
+
+const mocks = vi.hoisted(() => ({
+    layoutProps: [] as { variant?: string }[],
+    onboardingProps: [] as { inviteToken: string }[],
+}));
+
+vi.mock('../PasswordReset/PasswordResetPageLayout', () => ({
+    PasswordResetPageLayout: ({ children, variant }: React.PropsWithChildren<{ variant?: string }>) => {
+        mocks.layoutProps.push({ variant });
+
+        return <div data-testid="public-layout">{children}</div>;
+    },
+}));
+
+vi.mock('./TenantAdminOnboarding', () => ({
+    TenantAdminOnboarding: ({ inviteToken }: { inviteToken: string }) => {
+        mocks.onboardingProps.push({ inviteToken });
+
+        return <div data-testid="onboarding" />;
+    },
+}));
+
+const renderPage = (token: string) =>
+    render(
+        <MemoryRouter initialEntries={[`/admin/tenant-onboarding/${token}`]}>
+            <Routes>
+                <Route path="/admin/tenant-onboarding/:token" element={<TenantAdminOnboardingPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+
+describe('TenantAdminOnboardingPage', () => {
+    it('hosts the tall onboarding flow in the scrollable long-form layout (#569)', () => {
+        renderPage('raw-token');
+
+        expect(screen.getByTestId('onboarding')).toBeInTheDocument();
+        expect(mocks.layoutProps.at(-1)?.variant).toBe('longForm');
+    });
+
+    it('passes the trimmed invite token through', () => {
+        renderPage('raw-token');
+
+        expect(mocks.onboardingProps.at(-1)?.inviteToken).toBe('raw-token');
+    });
+});

--- a/src/pages/TenantOnboarding/TenantAdminOnboardingPage.tsx
+++ b/src/pages/TenantOnboarding/TenantAdminOnboardingPage.tsx
@@ -16,7 +16,11 @@ export const TenantAdminOnboardingPage = () => {
     const { token } = useParams<{ token: string }>();
 
     return (
-        <PasswordResetPageLayout>
+        // `longForm` (#569 chain fix): the onboarding form is ~1270px tall, far
+        // beyond a 390x844 phone viewport. The login-style layout centred it
+        // and let the branding stage cover it, which made the whole flow
+        // unreachable on mobile.
+        <PasswordResetPageLayout variant="longForm">
             <TenantAdminOnboarding inviteToken={token?.trim() ?? ''} />
         </PasswordResetPageLayout>
     );

--- a/src/styles/components/publicLayout.less
+++ b/src/styles/components/publicLayout.less
@@ -1,3 +1,37 @@
+/*
+ * The app shell locks document scrolling (`html, body { overflow: hidden }` in
+ * App.less) because the protected layout brings its own inner scroll area.
+ * Public pages had none, which was invisible as long as they were short login
+ * forms: a tall one (tenant-admin onboarding, #569) lost everything below the
+ * fold at 390x844 — the organisation/DPA fields and the "Continue" button could
+ * not be reached at all. Bounding the layout to the viewport turns it into the
+ * missing scroll container (the fixed branding stage and language selector are
+ * viewport-anchored and stay put while it scrolls).
+ */
+
+.publicLayout {
+    min-height: 100vh;
+    max-height: 100vh;
+    overflow-x: hidden;
+    overflow-y: auto;
+
+    /*
+     * antd gives the content `flex: auto; min-height: 0`. Inside a
+     * viewport-bounded layout that lets a tall page shrink back to the
+     * viewport and spill its content over the footer instead of scrolling —
+     * so grow it on a short page (login keeps its white full-height surface),
+     * but never shrink it.
+     */
+
+    > .publicContent {
+        flex: 1 0 auto;
+    }
+
+    > .layoutFooter {
+        flex-shrink: 0;
+    }
+}
+
 .publicContent {
     background-color: @white;
 

--- a/src/styles/components/stage.less
+++ b/src/styles/components/stage.less
@@ -109,3 +109,23 @@
         }
     }
 }
+
+/*
+ * Non-overlay variant (#569): pages hosting a tall public form use the stage as
+ * pure desktop decoration. The animated variant covers the whole small-screen
+ * viewport for the length of its intro, and even the base panel would sit on
+ * the left 40vw — on the tenant-admin onboarding page that painted over the
+ * form the invitee has to fill in. Below xl there is no room for a side panel,
+ * so it is not shown at all — the same end state the animated stage settles
+ * into once its intro has played.
+ */
+.stage--panel {
+    display: none;
+    animation: none;
+
+    @media screen and (min-width: @screen-xl) {
+        left: 0;
+        display: flex;
+        width: 40vw;
+    }
+}


### PR DESCRIPTION
## Problem

Found while running the tenant-admin onboarding chain end to end: **the public onboarding page was dead on a phone.**

The app shell locks document scrolling (`html`/`body` `overflow: hidden`) because the protected layout owns an inner scroll area. Public pages never supplied a scroll container of their own — which stayed invisible while every public page was a short login form. The tenant-admin onboarding page (#571) reuses that same layout for a ~1270 px form. At 390×844 the page could not scroll at all, and the full-viewport branding stage painted over what was visible, so the invitee reached neither the organisation/DPA fields nor the "Continue" action.

## What changed

- `PublicPageLayoutWrapper`: bound the layout to the viewport and let it scroll itself (`.publicLayout`), so every public page gets a scroll container.
- Keep the content from shrinking back into the viewport — antd's `flex: auto` otherwise squashes a tall page and spills it across the footer.
- `Stage`: new `overlay={false}` variant that renders the branding panel as a desktop-only side panel which can never cover the form.
- `PasswordResetPageLayout`: new `variant="longForm"` (top-aligned column, panel stage), used by `TenantAdminOnboardingPage`.

Short public pages (login, password reset) are deliberately unchanged in behaviour — see the measurement below.

## Testing

- Verified on this branch: `npm run test` — 198 files / 1160 tests green, including the new layout, page-wiring and stylesheet tests (`publicPageScroll.test.ts`, `PasswordResetPageLayout.test.tsx`, `TenantAdminOnboardingPage.test.tsx`).
- Measured in Chromium at 390×844 against the compiled stylesheets — before: 0 scroll containers, primary action out of viewport; after: `.publicLayout` scrolls, the button is in view and hit-tests to itself. Short login pages measure identically before and after.
- **Re-run just now** by the PR author at this exact branch head (byte-identical to the local `avv-fix` integration head), in a clean worktree: `npm run test` → `Test Files 198 passed (198)` / `Tests 1160 passed (1160)`, exit code 0. This is the suite result that backs the "re-verified at the tip of this stack" line in every other PR of this stack.
- Clean-slate end-to-end chain run (all services rebuilt from these branches) covered this as scenario **S6**: mobile 390×844 scrolling plus DPA anchor/TOC navigation. Scenarios **S1–S5** and continuity checks **C1–C6** passed on the same stack head.

## Stack parity

This branch is the top of the TEN-INV Admin stack and is exactly the proven integration head:

```
$ git diff --stat fix/ten-inv-chainfix2-admin..avv-fix
(no output)
```

Part of OpenResilienceInitiative/ORISO-Admin#569
Refs OpenResilienceInitiative/ORISO-Admin#569
Refs OpenResilienceInitiative/ORISO-Admin#571

🤖 Generated with [Claude Code](https://claude.com/claude-code)
