### PR TITLE
fix(admin): survive a redeploy instead of dying in the ErrorBoundary

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,8 +20,31 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # The SPA shell names every asset by content hash, so it must never be served from cache:
+    # a stale index.html points at chunk names the redeployed server no longer has, and every
+    # not-yet-loaded route dies in the ErrorBoundary. "no-cache" still allows a cheap 304 via ETag.
     location / {
+        add_header Cache-Control "no-cache" always;
         try_files /admin/index.html =404;
+    }
+
+    # Runtime configuration, rewritten by docker-entrypoint.sh on every container start.
+    location = /env.js {
+        add_header Cache-Control "no-store" always;
+        access_log off;
+    }
+
+    location = /admin/env.js {
+        add_header Cache-Control "no-store" always;
+        access_log off;
+    }
+
+    # Content-hashed build output: a given URL can never change, so cache it hard. "^~" wins over
+    # the generic static regex below. No "always" on purpose — a 404 during a deploy race must not
+    # be cached for a year, or the route stays broken even after the client reloads.
+    location ^~ /admin/assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        access_log off;
     }
 
     location ~* \.(?:css(\.map)?|js(\.map)?|jpe?g|png|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv)$ {

--- a/src/pages/lazyNamed.test.ts
+++ b/src/pages/lazyNamed.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { CHUNK_RELOAD_FLAG, isChunkLoadError, loadChunk } from './lazyNamed';
+import { CHUNK_RELOAD_FLAG, RELOAD_FALLBACK_MS, isChunkLoadError, loadChunk } from './lazyNamed';
 
 const chunkError = () => new Error('Failed to fetch dynamically imported module: /admin/assets/Edit-BFwFo16b.js');
 
@@ -96,6 +96,34 @@ describe('loadChunk', () => {
         await loadChunk(factory);
 
         expect(window.sessionStorage.getItem(CHUNK_RELOAD_FLAG)).toBeNull();
+    });
+
+    it('does not reload when sessionStorage is unavailable — Safari private mode', async () => {
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+            throw new Error('SecurityError');
+        });
+        const factory = vi.fn().mockRejectedValue(chunkError());
+
+        // Without storage there is no loop protection, so reloading at all would risk a loop.
+        await expect(loadChunk(factory)).rejects.toThrow(/Failed to fetch dynamically imported module/);
+        expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('gives up after the fallback timeout if the reload silently did nothing', async () => {
+        vi.useFakeTimers();
+        try {
+            const factory = vi.fn().mockRejectedValue(chunkError());
+            // Attach the rejection handler before advancing, or the rejection lands unhandled.
+            const settled = expect(loadChunk(factory)).rejects.toThrow(/Failed to fetch dynamically imported module/);
+
+            await vi.advanceTimersByTimeAsync(RELOAD_FALLBACK_MS);
+            await settled;
+            expect(reload).toHaveBeenCalledTimes(1);
+            // Guard released, so the user's own retry is allowed to reload again.
+            expect(window.sessionStorage.getItem(CHUNK_RELOAD_FLAG)).toBeNull();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('rethrows a genuine error from inside the module instead of reloading', async () => {

--- a/src/pages/lazyNamed.test.ts
+++ b/src/pages/lazyNamed.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CHUNK_RELOAD_FLAG, isChunkLoadError, loadChunk } from './lazyNamed';
+
+const chunkError = () => new Error('Failed to fetch dynamically imported module: /admin/assets/Edit-BFwFo16b.js');
+
+describe('isChunkLoadError', () => {
+    it.each([
+        'Failed to fetch dynamically imported module: /admin/assets/Edit-BFwFo16b.js',
+        'error loading dynamically imported module',
+        'Importing a module script failed.',
+        'Loading chunk 42 failed.',
+    ])('recognises %s', (message) => {
+        expect(isChunkLoadError(new Error(message))).toBe(true);
+    });
+
+    it('recognises webpack-style ChunkLoadError by name', () => {
+        const error = new Error('boom');
+        error.name = 'ChunkLoadError';
+        expect(isChunkLoadError(error)).toBe(true);
+    });
+
+    it('does not mistake a genuine error inside the module for a chunk failure', () => {
+        expect(isChunkLoadError(new TypeError("Cannot read properties of undefined (reading 'map')"))).toBe(false);
+    });
+
+    it('tolerates nullish errors', () => {
+        expect(isChunkLoadError(undefined)).toBe(false);
+    });
+});
+
+describe('loadChunk', () => {
+    let reload: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        window.sessionStorage.clear();
+        reload = vi.fn();
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { ...window.location, reload },
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns the module when the import succeeds', async () => {
+        const factory = vi.fn().mockResolvedValue({ Page: 'component' });
+
+        await expect(loadChunk(factory)).resolves.toEqual({ Page: 'component' });
+        expect(factory).toHaveBeenCalledTimes(1);
+        expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('retries once so a transient network blip does not reach the ErrorBoundary', async () => {
+        const factory = vi.fn().mockRejectedValueOnce(chunkError()).mockResolvedValueOnce({ Page: 'component' });
+
+        await expect(loadChunk(factory)).resolves.toEqual({ Page: 'component' });
+        expect(factory).toHaveBeenCalledTimes(2);
+        expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('reloads once when the chunk is gone for good — the stale-index.html case', async () => {
+        const factory = vi.fn().mockRejectedValue(chunkError());
+
+        let settled = false;
+        loadChunk(factory).then(
+            () => {
+                settled = true;
+            },
+            () => {
+                settled = true;
+            },
+        );
+        await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+
+        expect(factory).toHaveBeenCalledTimes(2);
+        expect(window.sessionStorage.getItem(CHUNK_RELOAD_FLAG)).toBe('1');
+        // The promise must never settle, or the ErrorBoundary flashes before the reload lands.
+        await Promise.resolve();
+        expect(settled).toBe(false);
+    });
+
+    it('does not reload a second time — a broken chunk must not loop', async () => {
+        window.sessionStorage.setItem(CHUNK_RELOAD_FLAG, '1');
+        const factory = vi.fn().mockRejectedValue(chunkError());
+
+        await expect(loadChunk(factory)).rejects.toThrow(/Failed to fetch dynamically imported module/);
+        expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('clears the guard after a successful load so the next deploy can reload again', async () => {
+        window.sessionStorage.setItem(CHUNK_RELOAD_FLAG, '1');
+        const factory = vi.fn().mockResolvedValue({ Page: 'component' });
+
+        await loadChunk(factory);
+
+        expect(window.sessionStorage.getItem(CHUNK_RELOAD_FLAG)).toBeNull();
+    });
+
+    it('rethrows a genuine error from inside the module instead of reloading', async () => {
+        const factory = vi.fn().mockRejectedValue(new TypeError('render exploded'));
+
+        await expect(loadChunk(factory)).rejects.toThrow('render exploded');
+        expect(factory).toHaveBeenCalledTimes(2);
+        expect(reload).not.toHaveBeenCalled();
+    });
+});

--- a/src/pages/lazyNamed.ts
+++ b/src/pages/lazyNamed.ts
@@ -6,6 +6,13 @@ import { ComponentType, lazy } from 'react';
  */
 export const CHUNK_RELOAD_FLAG = 'oriso-admin:chunk-reloaded';
 
+/**
+ * How long to wait for `location.reload()` to actually navigate before giving up. A reload can be
+ * blocked by an embedding context or a browser extension without throwing; without this the
+ * Suspense fallback would spin forever with no way out.
+ */
+export const RELOAD_FALLBACK_MS = 10_000;
+
 const CHUNK_ERROR_PATTERNS = [
     // Chrome / Vite
     'failed to fetch dynamically imported module',
@@ -75,9 +82,17 @@ export const loadChunk = async <TModule>(factory: () => Promise<TModule>): Promi
             if (isChunkLoadError(retryError) && !readFlag()) {
                 writeFlag(true);
                 window.location.reload();
-                // Never settles: the page is going away, and resolving here would flash the
-                // ErrorBoundary in the moment before the reload takes effect.
-                return new Promise<TModule>(() => {});
+                // Normally never settles: the page is going away, and resolving here would flash
+                // the ErrorBoundary in the moment before the reload takes effect. The timeout only
+                // fires if the reload silently did nothing — then the ErrorBoundary, with its
+                // "Seite neu laden" button, beats an endless spinner.
+                return new Promise<TModule>((_, reject) => {
+                    window.setTimeout(() => {
+                        // Release the guard so the user's own retry can reload again.
+                        writeFlag(false);
+                        reject(retryError);
+                    }, RELOAD_FALLBACK_MS);
+                });
             }
             throw retryError;
         }

--- a/src/pages/lazyNamed.ts
+++ b/src/pages/lazyNamed.ts
@@ -1,0 +1,90 @@
+import { ComponentType, lazy } from 'react';
+
+/**
+ * Guard flag so a chunk that is genuinely broken (rather than merely stale) cannot put the app into
+ * a reload loop. Cleared again as soon as any lazy chunk loads successfully.
+ */
+export const CHUNK_RELOAD_FLAG = 'oriso-admin:chunk-reloaded';
+
+const CHUNK_ERROR_PATTERNS = [
+    // Chrome / Vite
+    'failed to fetch dynamically imported module',
+    'error loading dynamically imported module',
+    // Safari
+    'importing a module script failed',
+    // Firefox
+    'error resolving module specifier',
+    // webpack-style, still emitted by some bundler plugins
+    'loading chunk',
+];
+
+/**
+ * A hashed chunk that 404s means the deployed build was replaced while this tab was open: the
+ * `index.html` in memory still points at asset names that no longer exist on the server. Reloading
+ * picks up the new `index.html`. A real error *inside* the module must not trigger that.
+ */
+export const isChunkLoadError = (error: unknown): boolean => {
+    if (!error) return false;
+    if (typeof error === 'object' && (error as { name?: string }).name === 'ChunkLoadError') return true;
+
+    const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+    return CHUNK_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+};
+
+// sessionStorage throws in Safari private mode and is absent in non-browser test environments.
+const readFlag = (): boolean => {
+    try {
+        return window.sessionStorage.getItem(CHUNK_RELOAD_FLAG) === '1';
+    } catch {
+        return true; // no storage means no loop protection — do not reload at all
+    }
+};
+
+const writeFlag = (value: boolean): void => {
+    try {
+        if (value) {
+            window.sessionStorage.setItem(CHUNK_RELOAD_FLAG, '1');
+        } else {
+            window.sessionStorage.removeItem(CHUNK_RELOAD_FLAG);
+        }
+    } catch {
+        // storage unavailable — the flag is best-effort
+    }
+};
+
+/**
+ * Loads a lazy route chunk, surviving the two ways the import can fail:
+ *
+ * 1. transient network blip → one retry;
+ * 2. stale `index.html` after a redeploy → one full reload, guarded against looping.
+ *
+ * Without this, any deploy turns every not-yet-loaded route into the app-level ErrorBoundary
+ * ("Etwas ist schiefgelaufen") for every user who had a tab open.
+ */
+export const loadChunk = async <TModule>(factory: () => Promise<TModule>): Promise<TModule> => {
+    try {
+        const module = await factory();
+        writeFlag(false);
+        return module;
+    } catch (firstError) {
+        try {
+            const module = await factory();
+            writeFlag(false);
+            return module;
+        } catch (retryError) {
+            if (isChunkLoadError(retryError) && !readFlag()) {
+                writeFlag(true);
+                window.location.reload();
+                // Never settles: the page is going away, and resolving here would flash the
+                // ErrorBoundary in the moment before the reload takes effect.
+                return new Promise<TModule>(() => {});
+            }
+            throw retryError;
+        }
+    }
+};
+
+export const lazyNamed = <TModule extends Record<string, ComponentType<any>>>(
+    factory: () => Promise<TModule>,
+    exportName: keyof TModule,
+) => lazy(() => loadChunk(factory).then((module) => ({ default: module[exportName] })));

--- a/src/pages/lazyPages.ts
+++ b/src/pages/lazyPages.ts
@@ -1,9 +1,4 @@
-import { ComponentType, lazy } from 'react';
-
-const lazyNamed = <TModule extends Record<string, ComponentType<any>>>(
-    factory: () => Promise<TModule>,
-    exportName: keyof TModule,
-) => lazy(() => factory().then((module) => ({ default: module[exportName] })));
+import { lazyNamed } from './lazyNamed';
 
 export const LazyTenantSettingsLayout = lazyNamed(() => import('./TenantSettings'), 'TenantSettingsLayout');
 export const LazyTopicList = lazyNamed(() => import('./Topics/List/TopicList'), 'TopicList');


### PR DESCRIPTION
Closes #592

## Problem

A deploy replaces the content-hashed assets, so a tab still holding the previous `index.html` requests chunk names the server no longer has. Every route not yet loaded then failed its dynamic import and hit the app-level ErrorBoundary — seen on `/theme-settings/permissions`, `/agency/add` and `/users/tenant-admins/add` minutes after a deploy, while already-loaded routes kept working.

## Changes

- `lazyNamed` moves to `src/pages/lazyNamed.ts`; it retries the import once, then reloads the page once — **only** for chunk-load errors, so a genuine error inside a module still reaches the ErrorBoundary.
- A `sessionStorage` flag guards against a reload loop and is cleared after any successful load, so the next deploy can recover too.
- The reload path returns a promise that never settles, so the ErrorBoundary does not flash before the reload lands.
- nginx: the SPA shell becomes `no-cache` (still 304s via ETag), `/admin/assets/` becomes `immutable` for a year, `env.js` becomes `no-store` — the entrypoint rewrites it on every container start, so caching it delayed config changes by a day.
- The assets header deliberately omits `always`, so a 404 during a deploy race is not cached for a year.

## Verification

- `npx vitest run` — 188 files, 1025 tests pass (13 new)
- `npx eslint src/pages/lazyNamed*.ts src/pages/lazyPages.ts --max-warnings=0`
- `npx tsc --noEmit`
- `npm run build` — code splitting intact, 94 chunks
- `nginx:alpine` with the new conf: shell `no-cache` + 304 on `If-None-Match`, assets `immutable`, missing chunk 404 uncached, `env.js` `no-store`

## Note for review

`admin.oriso-dev.site` resolves to `91.99.183.160`, not the Pre-Dev IP `46.224.170.69`. That did not affect this diagnosis (the host is actively deployed to), but it is worth confirming which environment that hostname actually points at.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved loading of lazily loaded pages, including automatic recovery from temporary chunk-loading failures.
  * Automatically refreshes the page when deployed assets are outdated, while preventing repeated refresh loops.

* **Bug Fixes**
  * Genuine application errors continue to surface normally without triggering a page reload.
  * Improved handling of named exports for lazy-loaded route components.

* **Tests**
  * Added coverage for chunk error detection, retries, reload safeguards, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->