### PR TITLE
Fix tenant-onboarding TOTP secret encoding

### DIFF
--- a/src/components/TwoFactorSetup/ProfileTwoFactorSetup.tsx
+++ b/src/components/TwoFactorSetup/ProfileTwoFactorSetup.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
 import { Typography } from 'antd';
 import { useTranslation } from 'react-i18next';
-import { encode } from 'hi-base32';
 import { M3Switch } from '../M3Switch';
 import { FETCH_ERRORS } from '../../api/fetchData';
 import { OVERLAY_FUNCTIONS, OverlayItem, OverlayWrapper, Overlay } from '../overlay/Overlay';
@@ -27,6 +26,7 @@ import { isStringValidEmail } from '../../utils/validateEmailString';
 import { TwoFactorAuthEmailCodeInput } from './TwoFactorAuthEmailCodeInput';
 import { TwoFactorAuthEmailConfirmation } from './TwoFactorAuthEmailConfirmation';
 import { OTP_LENGTH, isOtpValid } from './twoFactorSetupFlow';
+import { toBase32Secret } from '../../utils/totpSecret';
 
 const { Paragraph } = Typography;
 
@@ -327,9 +327,7 @@ export const ProfileTwoFactorSetup = ({ required = false }: ProfileTwoFactorSetu
     // stores the raw secret; the canonical component expects it base32-encoded.
     const appLink = useMemo(
         () => ({
-            secretBase32: userData?.twoFactorAuth?.secret
-                ? encode(userData.twoFactorAuth.secret).replace(/={1,8}$/, '')
-                : '',
+            secretBase32: toBase32Secret(userData?.twoFactorAuth?.secret),
             qrCodeBase64: userData?.twoFactorAuth?.qrCode || null,
         }),
         [userData?.twoFactorAuth?.secret, userData?.twoFactorAuth?.qrCode],

--- a/src/components/TwoFactorSetup/TwoFactorSetup.test.tsx
+++ b/src/components/TwoFactorSetup/TwoFactorSetup.test.tsx
@@ -59,4 +59,23 @@ describe('TwoFactorSetup (profile context)', () => {
             expect(screen.queryByText('twoFactorAuth.activate.step1.title')).not.toBeInTheDocument();
         });
     });
+
+    it('shows the app-connect step with the raw stored secret converted to base32, never the raw value', async () => {
+        // userData.twoFactorAuth.secret is 'secret' — Keycloak's raw HMAC key.
+        // An authenticator needs the base32 form; regression guard for the
+        // switch from the inline hi-base32 call to the shared toBase32Secret.
+        const user = userEvent.setup({ delay: null });
+        render(<TwoFactorSetup context="profile" required />);
+
+        expect(await screen.findByText('twoFactorAuth.activate.step1.title')).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'twoFactorAuth.overlayButton.next' }));
+
+        expect(await screen.findByText('twoFactorAuth.activate.app.step2.title')).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'twoFactorAuth.overlayButton.next' }));
+
+        expect(await screen.findByText('twoFactorAuth.activate.app.step3.title')).toBeInTheDocument();
+        const shown = screen.getByTestId('totp-secret');
+        expect(shown).toHaveTextContent('ONSWG4TFOQ');
+        expect(shown.textContent).not.toBe('secret');
+    });
 });

--- a/src/pages/TenantOnboarding/TenantAdminOnboarding.test.tsx
+++ b/src/pages/TenantOnboarding/TenantAdminOnboarding.test.tsx
@@ -100,8 +100,11 @@ describe('TenantAdminOnboarding', () => {
             ),
         );
 
-        // Step 3: 2FA.
-        expect(await screen.findByTestId('totp-secret')).toHaveTextContent('SECRET234567ABCDEFG');
+        // Step 3: 2FA. The screen must show the base32 form of the stored
+        // secret — the raw value would produce codes Keycloak rejects.
+        // The shared helper intentionally emits unpadded Base32.
+        const shown = await screen.findByTestId('totp-secret');
+        expect(shown.textContent).toBe('KNCUGUSFKQZDGNBVGY3UCQSDIRCUMRY');
         await user.type(screen.getByLabelText('twoFactorSetup.otp.label'), '123456');
         await user.click(screen.getByRole('button', { name: 'twoFactorSetup.submit' }));
 

--- a/src/pages/TenantOnboarding/TwoFactorStep.test.tsx
+++ b/src/pages/TenantOnboarding/TwoFactorStep.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { TwoFactorStep } from './TwoFactorStep';
 
 vi.mock('react-i18next', () => ({
@@ -10,6 +11,14 @@ vi.mock('react-i18next', () => ({
 
 const RAW_SECRET = 'ORISOSECRET234567ABCDEFGHIJKLMNO';
 const BASE32_SECRET = 'J5JESU2PKNCUGUSFKQZDGNBVGY3UCQSDIRCUMR2IJFFEWTCNJZHQ';
+
+const baseProps = {
+    result: { tenantId: 7, twoFactor: { secret: RAW_SECRET, qrCodeBase64: null }, resumed: false },
+    busy: false,
+    showCodeError: false,
+    showServiceError: false,
+    onSubmit: () => {},
+};
 
 describe('TwoFactorStep', () => {
     it('shows the base32 form of the secret, not the raw value the service stores', () => {
@@ -42,5 +51,72 @@ describe('TwoFactorStep', () => {
         );
 
         expect(screen.queryByTestId('totp-secret')).not.toBeInTheDocument();
+    });
+
+    it('passes the QR code through untouched alongside the encoded secret', () => {
+        render(
+            <TwoFactorStep
+                {...baseProps}
+                result={{
+                    tenantId: 7,
+                    twoFactor: { secret: RAW_SECRET, qrCodeBase64: 'aGVsbG8=' },
+                    resumed: false,
+                }}
+            />,
+        );
+
+        expect(screen.getByTestId('totp-secret')).toHaveTextContent(BASE32_SECRET);
+        expect(screen.getByRole('img', { name: 'twoFactorSetup.connect.qrAlt' })).toHaveAttribute(
+            'src',
+            'data:image/png;base64,aGVsbG8=',
+        );
+    });
+
+    it('shows the onboarding-specific title and description copy', () => {
+        render(<TwoFactorStep {...baseProps} />);
+
+        expect(screen.getByText('tenantOnboarding.twoFactor.title')).toBeInTheDocument();
+        expect(screen.getByText('tenantOnboarding.twoFactor.description')).toBeInTheDocument();
+    });
+
+    it('shows the resumed hint when reentering via a consumed-but-pending link', () => {
+        render(<TwoFactorStep {...baseProps} result={{ tenantId: 7, twoFactor: null, resumed: true }} />);
+
+        expect(screen.getByTestId('two-factor-resumed-hint')).toBeInTheDocument();
+    });
+
+    it('maps a rejected one-time code to the invalid-code alert', () => {
+        render(<TwoFactorStep {...baseProps} showCodeError />);
+
+        expect(screen.getByRole('alert')).toHaveTextContent('twoFactorSetup.otp.invalid');
+    });
+
+    it('maps a technical activation failure to the service-error alert', () => {
+        render(<TwoFactorStep {...baseProps} showServiceError />);
+
+        expect(screen.getByRole('alert')).toHaveTextContent('twoFactorSetup.error.service');
+    });
+
+    it('prioritizes the code error over the service error when both are set', () => {
+        render(<TwoFactorStep {...baseProps} showCodeError showServiceError />);
+
+        expect(screen.getByRole('alert')).toHaveTextContent('twoFactorSetup.otp.invalid');
+    });
+
+    it('disables the submit action while an activation is in flight', () => {
+        render(<TwoFactorStep {...baseProps} busy />);
+
+        expect(screen.getByRole('button', { name: 'twoFactorSetup.submit' })).toBeDisabled();
+    });
+
+    it('calls onSubmit with the entered one-time code', async () => {
+        const onSubmit = vi.fn();
+        const user = userEvent.setup();
+        render(<TwoFactorStep {...baseProps} onSubmit={onSubmit} />);
+
+        await user.type(screen.getByLabelText('twoFactorSetup.otp.label'), '654321');
+        await user.click(screen.getByRole('button', { name: 'twoFactorSetup.submit' }));
+
+        expect(onSubmit).toHaveBeenCalledWith('654321');
     });
 });

--- a/src/pages/TenantOnboarding/TwoFactorStep.test.tsx
+++ b/src/pages/TenantOnboarding/TwoFactorStep.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TwoFactorStep } from './TwoFactorStep';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string) => key,
+    }),
+}));
+
+const RAW_SECRET = 'ORISOSECRET234567ABCDEFGHIJKLMNO';
+const BASE32_SECRET = 'J5JESU2PKNCUGUSFKQZDGNBVGY3UCQSDIRCUMR2IJFFEWTCNJZHQ';
+
+describe('TwoFactorStep', () => {
+    it('shows the base32 form of the secret, not the raw value the service stores', () => {
+        // Keycloak uses the raw characters as the HMAC key; an authenticator
+        // needs their base32 form. Handing out the raw value produces codes
+        // that never match, which is indistinguishable from "2FA is broken".
+        render(
+            <TwoFactorStep
+                result={{ tenantId: 7, twoFactor: { secret: RAW_SECRET, qrCodeBase64: null }, resumed: false }}
+                busy={false}
+                showCodeError={false}
+                showServiceError={false}
+                onSubmit={() => {}}
+            />,
+        );
+
+        const shown = screen.getByTestId('totp-secret').textContent ?? '';
+        expect(shown).toBe(BASE32_SECRET);
+    });
+
+    it('renders the verify-only variant when a resumed link reissued no secret', () => {
+        render(
+            <TwoFactorStep
+                result={{ tenantId: 7, twoFactor: null, resumed: true }}
+                busy={false}
+                showCodeError={false}
+                showServiceError={false}
+                onSubmit={() => {}}
+            />,
+        );
+
+        expect(screen.queryByTestId('totp-secret')).not.toBeInTheDocument();
+    });
+});

--- a/src/pages/TenantOnboarding/TwoFactorStep.tsx
+++ b/src/pages/TenantOnboarding/TwoFactorStep.tsx
@@ -1,4 +1,5 @@
 import { TwoFactorSetup, TwoFactorSetupInlineError } from '../../components/TwoFactorSetup/TwoFactorSetup';
+import { toBase32Secret } from '../../utils/totpSecret';
 import { TwoFactorStepData } from './useTenantAdminOnboardingFlow';
 
 interface TwoFactorStepProps {
@@ -36,7 +37,7 @@ export const TwoFactorStep = ({ result, busy, showCodeError, showServiceError, o
             appLink={
                 result.twoFactor
                     ? {
-                          secretBase32: result.twoFactor.secret,
+                          secretBase32: toBase32Secret(result.twoFactor.secret),
                           qrCodeBase64: result.twoFactor.qrCodeBase64,
                       }
                     : null

--- a/src/utils/totpSecret.test.ts
+++ b/src/utils/totpSecret.test.ts
@@ -12,6 +12,24 @@ describe('toBase32Secret', () => {
         expect(toBase32Secret('a')).toBe('ME');
     });
 
+    it('drops padding regardless of how many bytes are left over in the final block', () => {
+        // Base32 pads 1/2/3/4 leftover bytes with 6/4/3/1 '=' respectively —
+        // every one of those trailing runs has to be stripped, not just the
+        // single-'=' and 6-'=' cases already covered above.
+        expect(toBase32Secret('ab')).toBe('MFRA');
+        expect(toBase32Secret('abcd')).toBe('MFRGGZA');
+    });
+
+    it('leaves an already-unpadded encoding (byte length a multiple of 5) untouched', () => {
+        const result = toBase32Secret('abcde');
+        expect(result).toBe('MFRGGZDF');
+        expect(result.endsWith('=')).toBe(false);
+    });
+
+    it('produces only characters from the RFC 4648 base32 alphabet', () => {
+        expect(toBase32Secret('ORISOSECRET234567ABCDEFGHIJKLMNO')).toMatch(/^[A-Z2-7]+$/);
+    });
+
     it('yields an empty string for a missing secret', () => {
         expect(toBase32Secret(null)).toBe('');
         expect(toBase32Secret(undefined)).toBe('');

--- a/src/utils/totpSecret.test.ts
+++ b/src/utils/totpSecret.test.ts
@@ -1,0 +1,20 @@
+import { toBase32Secret } from './totpSecret';
+
+describe('toBase32Secret', () => {
+    it('encodes the raw secret so an authenticator derives the same HMAC key', () => {
+        expect(toBase32Secret('ORISOSECRET234567ABCDEFGHIJKLMNO')).toBe(
+            'J5JESU2PKNCUGUSFKQZDGNBVGY3UCQSDIRCUMR2IJFFEWTCNJZHQ',
+        );
+    });
+
+    it('drops the padding an authenticator will not accept', () => {
+        expect(toBase32Secret('abc')).toBe('MFRGG');
+        expect(toBase32Secret('a')).toBe('ME');
+    });
+
+    it('yields an empty string for a missing secret', () => {
+        expect(toBase32Secret(null)).toBe('');
+        expect(toBase32Secret(undefined)).toBe('');
+        expect(toBase32Secret('')).toBe('');
+    });
+});

--- a/src/utils/totpSecret.ts
+++ b/src/utils/totpSecret.ts
@@ -1,0 +1,14 @@
+import { encode } from 'hi-base32';
+
+/**
+ * The user service stores the TOTP shared secret as raw characters and Keycloak
+ * uses exactly those bytes as the HMAC key. An authenticator app, however, is
+ * given the base32 form of the same bytes — so every screen that shows the key
+ * to a human has to convert it. Showing the raw value hands out a key that
+ * silently produces wrong codes, which reads as "2FA is broken".
+ *
+ * Both the profile overlay and the public tenant-admin onboarding go through
+ * here so the two cannot drift apart again.
+ */
+export const toBase32Secret = (rawSecret: string | null | undefined): string =>
+    rawSecret ? encode(rawSecret).replace(/={1,8}$/, '') : '';


### PR DESCRIPTION
## Problem

Tenant-admin onboarding passed the raw UserService TOTP secret to a component that presents it as Base32. Authenticator apps therefore generated codes that Keycloak rejected, while profile enrollment encoded the same secret correctly.

## Changes

- add one shared raw-secret-to-unpadded-Base32 helper
- use the helper in profile and public tenant onboarding
- add regression coverage for exact displayed values and resumed onboarding

## Verification

- `npm test` — 216 files, 1,292 tests passed
- focused ESLint and Prettier checks passed
- `npm run build` passed
- CodeRabbit CLI review passed with no remaining findings
- repository-wide Stylelint remains blocked by the existing untouched stylesheet baseline

Closes OpenResilienceInitiative/ORISO-Admin#599
Refs Storypapst/dreambau#12
Refs Storypapst/dreambau#24

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved two-factor authentication setup by displaying secrets in the Base32 format expected by authenticator apps.
  - Ensured QR code and app-link setup flows use the correctly encoded secret.
  - Preserved the verify-only experience when resuming onboarding without generating a new secret.

- **Tests**
  - Added coverage for Base32 conversion, empty values, onboarding setup, and resumed verification flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->