### PR TITLE
Fix platform admins appearing as tenant admins

### DIFF
--- a/src/hooks/useTenantUserAdminsData.test.tsx
+++ b/src/hooks/useTenantUserAdminsData.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('../utils/fetchUserSearchWithSortFallback', () => ({
+    fetchUserSearchWithSortFallback: vi.fn(),
+}));
+
+import { fetchUserSearchWithSortFallback } from '../utils/fetchUserSearchWithSortFallback';
+import { useTenantAdminsData } from './useTenantUserAdminsData';
+
+const fetchMock = vi.mocked(fetchUserSearchWithSortFallback);
+
+const createWrapper = () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+};
+
+describe('useTenantAdminsData', () => {
+    beforeEach(() => {
+        fetchMock.mockReset();
+    });
+
+    it('excludes platform administrators and paginates the tenant-scoped result', async () => {
+        fetchMock.mockResolvedValue({
+            total: 3,
+            data: [
+                { id: 'platform', tenantId: '0' },
+                { id: 'tenant-one', tenantId: '1' },
+                { id: 'tenant-two', tenantId: '2' },
+            ],
+        } as never);
+
+        const { result } = renderHook(() => useTenantAdminsData({ current: 2, pageSize: 1 }), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: expect.stringContaining('page=1&perPage=1000'),
+            }),
+        );
+        expect(result.current.data).toEqual({
+            total: 2,
+            data: [expect.objectContaining({ id: 'tenant-two', tenantId: '2' })],
+        });
+    });
+});

--- a/src/hooks/useTenantUserAdminsData.ts
+++ b/src/hooks/useTenantUserAdminsData.ts
@@ -10,6 +10,12 @@ import { ResponseList } from '../types/ResponseList';
 import { fetchUserSearchWithSortFallback } from '../utils/fetchUserSearchWithSortFallback';
 import { TENANT_ADMINS_QUERY_KEY } from './useTenantUserAdminData';
 
+// Platform administrators share the tenant-admin API representation but use
+// the reserved platform tenant id 0. Fetch the bounded admin set once so the
+// client can classify records before calculating page totals.
+const TENANT_ADMINS_FETCH_SIZE = 1000;
+const PLATFORM_TENANT_ID = '0';
+
 interface TenantUserAdminDataProps extends Omit<UseQueryOptions<ResponseList<CounselorData>>, 'queryKey' | 'queryFn'> {
     search?: string;
     current?: number;
@@ -23,15 +29,27 @@ export const useTenantAdminsData = (
 ) => {
     return useQuery({
         queryKey: [TENANT_ADMINS_QUERY_KEY, search, current, sortBy, order, pageSize],
-        queryFn: () =>
-            fetchUserSearchWithSortFallback({
-                url: `${tenantAdminsSearchEndpoint}?query=${encodeURIComponent(search || '*')}&page=${
-                    current || 1
-                }&perPage=${pageSize || 10}`,
+        queryFn: async () => {
+            const response = await fetchUserSearchWithSortFallback({
+                url: `${tenantAdminsSearchEndpoint}?query=${encodeURIComponent(
+                    search || '*',
+                )}&page=1&perPage=${TENANT_ADMINS_FETCH_SIZE}`,
                 sortBy: sortBy || USER_TABLE_DEFAULT_SORT,
                 order: order || USER_TABLE_DEFAULT_ORDER,
                 normalizeSortField: normalizeTenantAdminSortField,
-            }),
+            });
+            const tenantAdmins = (response.data || []).filter(
+                (record) => String(record.tenantId) !== PLATFORM_TENANT_ID,
+            );
+            const page = current || 1;
+            const perPage = pageSize || 10;
+
+            return {
+                ...response,
+                total: tenantAdmins.length,
+                data: tenantAdmins.slice((page - 1) * perPage, page * perPage),
+            };
+        },
         ...(options as object),
         retry: false,
         refetchOnMount: 'always',


### PR DESCRIPTION
## Summary

- exclude `tenantId = 0` platform administrators from the Tenant Admin list
- calculate tenant-admin pagination after role classification
- add a hook regression test for classification, totals, and paging

Closes #603

## Verification

- `npx vitest run src/hooks/useTenantUserAdminsData.test.tsx src/hooks/useConsultantsOrAdminsData.test.tsx`
- `npx tsc --noEmit`
- `npx eslint src/hooks/useTenantUserAdminsData.ts src/hooks/useTenantUserAdminsData.test.tsx`
- `npx prettier --check src/hooks/useTenantUserAdminsData.ts src/hooks/useTenantUserAdminsData.test.tsx`
- `npm test -- --run` — 220 files, 1339 tests passed
- `npm run build`

## Runtime evidence

PreDev currently shows the synthetic `abe.simpson@dreambau.de` platform account in both role sections because both consume the shared tenant-admin representation. After deployment, the browser retest will verify that Abe remains in **Platform Admin** and disappears from **Tenant Admin**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tenant administrator results now exclude platform administrator accounts.
  * Pagination now correctly reflects the filtered tenant administrator list.
  * Improved consistency of total counts and displayed results across pages.

* **Tests**
  * Added coverage for filtering platform administrators and validating pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->