### PR TITLE
fix(settings): restore widths and align legacy controls

### DIFF
--- a/src/components/GlobalSettings/TranslationApiKeysCard/TranslationApiKeysCard.test.tsx
+++ b/src/components/GlobalSettings/TranslationApiKeysCard/TranslationApiKeysCard.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TranslationApiKeysCard } from './index';
+import m3ButtonStyles from '../../M3Button/styles.module.scss';
 
 vi.mock('react-i18next', () => ({
     useTranslation: () => ({
@@ -63,5 +64,24 @@ describe('TranslationApiKeysCard', () => {
         });
         // Still visible: the ORISO rule is disable, not hide.
         expect(screen.getByText('legal.translation.settings.provider.openrouter')).toBeInTheDocument();
+    });
+
+    it('renders save actions with the shared transparent outlined button', () => {
+        render(<TranslationApiKeysCard keys={{}} onSave={() => undefined} />);
+
+        screen.getAllByRole('button', { name: saveButtonName }).forEach((button) => {
+            expect(button).toHaveClass(m3ButtonStyles.outlined);
+        });
+    });
+
+    it('keeps a visible and disabled progress state only on the provider being saved', () => {
+        render(<TranslationApiKeysCard keys={{}} onSave={() => undefined} savingProvider="openrouter" />);
+
+        const [openrouterSave, mistralSave] = screen.getAllByRole('button', { name: saveButtonName });
+        expect(openrouterSave).toBeDisabled();
+        expect(openrouterSave).toHaveAttribute('aria-busy', 'true');
+        expect(openrouterSave.querySelector('[role="progressbar"]')).toBeInTheDocument();
+        expect(mistralSave).toBeEnabled();
+        expect(mistralSave).not.toHaveAttribute('aria-busy');
     });
 });

--- a/src/components/GlobalSettings/TranslationApiKeysCard/index.tsx
+++ b/src/components/GlobalSettings/TranslationApiKeysCard/index.tsx
@@ -1,8 +1,9 @@
-import { Button, Form, Typography, message } from 'antd';
+import { Form, Typography, message } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { ThemeProvider } from '@mui/material/styles';
 import TranslateOutlinedIcon from '@mui/icons-material/TranslateOutlined';
 import { Card } from '../../Card';
+import { M3Button } from '../../M3Button';
 import { MuiPasswordFormField } from '../../mui/MuiFormField';
 import { orisoMuiTheme } from '../../../theme/orisoMuiTheme';
 import { TRANSLATION_PROVIDERS, TranslationKeys, TranslationProvider } from '../../../types/translation';
@@ -75,13 +76,14 @@ export const TranslationApiKeysCard = ({
                                 autoComplete="new-password"
                                 disabled={disabled}
                             />
-                            <Button
+                            <M3Button
+                                variant="outlined"
                                 loading={savingProvider === provider}
                                 disabled={disabled}
                                 onClick={() => save(provider)}
                             >
                                 {t('legal.translation.settings.save')}
-                            </Button>
+                            </M3Button>
                         </div>
                     ))}
                 </Form>

--- a/src/components/GlobalSettings/TranslationApiKeysCard/styles.module.scss
+++ b/src/components/GlobalSettings/TranslationApiKeysCard/styles.module.scss
@@ -1,7 +1,4 @@
 .card {
-    --input-bg: transparent;
-    --input-autofill-surface: var(--admin-form-card-surface, var(--m3-surface-container-high, #eae7e8));
-
     width: 100%;
     min-height: 0;
     overflow: visible;

--- a/src/components/GlobalSettings/TranslationApiKeysCard/styles.module.scss
+++ b/src/components/GlobalSettings/TranslationApiKeysCard/styles.module.scss
@@ -1,4 +1,7 @@
 .card {
+    --input-bg: transparent;
+    --input-autofill-surface: var(--admin-form-card-surface, var(--m3-surface-container-high, #eae7e8));
+
     width: 100%;
     min-height: 0;
     overflow: visible;
@@ -85,12 +88,4 @@
 .provider :global(.ant-form-item) {
     width: 100%;
     margin-bottom: 8px;
-}
-
-.provider :global(.ant-btn) {
-    min-width: 120px;
-    height: 40px;
-    border-radius: 4px;
-    font-family: var(--m3-body-font-family);
-    font-weight: 700;
 }

--- a/src/components/M3Button/M3Button.stories.tsx
+++ b/src/components/M3Button/M3Button.stories.tsx
@@ -36,6 +36,7 @@ export const Outlined: Story = {
 export const Filled: Story = { args: { variant: 'filled', icon: <UploadIcon />, children: 'Upload' } };
 export const Tonal: Story = { args: { variant: 'tonal', children: 'Batch Mode' } };
 export const Disabled: Story = { args: { variant: 'filled', disabled: true, children: 'Upload' } };
+export const Loading: Story = { args: { variant: 'outlined', loading: true, children: 'Save' } };
 
 export const AllVariants: StoryObj = {
     render: () => (

--- a/src/components/M3Button/index.tsx
+++ b/src/components/M3Button/index.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import classNames from 'classnames';
+import CircularProgress from '@mui/material/CircularProgress';
 import styles from './styles.module.scss';
 
 export type M3ButtonVariant = 'text' | 'outlined' | 'filled' | 'tonal';
@@ -11,6 +12,8 @@ export interface M3ButtonProps {
     icon?: ReactNode;
     onClick?: () => void;
     disabled?: boolean;
+    /** Disables the action and replaces its icon with an accessible progress indicator. */
+    loading?: boolean;
     type?: 'button' | 'submit';
     /** Stretch to the container width (e.g. "Link OTP App" full-width action). */
     block?: boolean;
@@ -29,17 +32,24 @@ export const M3Button = ({
     icon,
     onClick,
     disabled = false,
+    loading = false,
     type = 'button',
     block = false,
     className,
 }: M3ButtonProps) => (
     <button
         type={type === 'submit' ? 'submit' : 'button'}
-        disabled={disabled}
+        disabled={disabled || loading}
+        aria-busy={loading || undefined}
         onClick={onClick}
         className={classNames(styles.button, styles[variant], { [styles.block]: block }, className)}
     >
-        {icon && (
+        {loading && (
+            <span className={styles.icon}>
+                <CircularProgress size={18} color="inherit" />
+            </span>
+        )}
+        {!loading && icon && (
             <span className={styles.icon} aria-hidden>
                 {icon}
             </span>

--- a/src/components/Tenants/GeneralSettings/components/LogoAndFavicon/index.tsx
+++ b/src/components/Tenants/GeneralSettings/components/LogoAndFavicon/index.tsx
@@ -102,7 +102,7 @@ export const LogoAndFavicon = ({ tenantId, readOnly = false }: { tenantId: strin
                     {!settings.multitenancyWithSingleDomainEnabled && (
                         <div className={styles.faviconBlock}>
                             <FormFileUploaderField
-                                className={`${styles.assetUploader} ${styles.faviconUploader}`}
+                                className={`${styles.assetUploader} ${styles.associationLogoUploader}`}
                                 labelKey="organisation.associationLogo"
                                 name={['theming', 'associationLogo']}
                                 tooltip={t('settings.images.tooltip.associationLogo')}

--- a/src/components/Tenants/GeneralSettings/components/LogoAndFavicon/styles.module.scss
+++ b/src/components/Tenants/GeneralSettings/components/LogoAndFavicon/styles.module.scss
@@ -56,9 +56,8 @@
     }
 }
 
-.faviconUploader {
-    width: 54px;
-
+.faviconUploader,
+.associationLogoUploader {
     :global {
         .ant-upload.ant-upload-select-picture-card {
             aspect-ratio: 1;
@@ -71,6 +70,14 @@
             object-fit: contain;
         }
     }
+}
+
+.faviconUploader {
+    width: 32px;
+}
+
+.associationLogoUploader {
+    width: 54px;
 }
 
 .assetMetaColumn {
@@ -124,7 +131,7 @@
         grid-template-columns: minmax(180px, min(48%, 256px)) 1fr;
     }
 
-    .faviconUploader {
+    .associationLogoUploader {
         width: 64px;
     }
 

--- a/src/components/Tenants/GeneralSettings/components/LogoAndFavicon/styles.test.ts
+++ b/src/components/Tenants/GeneralSettings/components/LogoAndFavicon/styles.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const brandingStyles = readFileSync(resolve(__dirname, './styles.module.scss'), 'utf8');
+const brandingSource = readFileSync(resolve(__dirname, './index.tsx'), 'utf8');
+
+describe('LogoAndFavicon preview size contract', () => {
+    it('renders the 32x32 favicon preview at exactly 32px in every desktop height', () => {
+        const faviconRule = brandingStyles.match(/\.faviconUploader\s*{([^}]*)}/s)?.[1] ?? '';
+
+        expect(faviconRule).toMatch(/width:\s*32px/);
+        expect(brandingStyles).not.toMatch(
+            /@media only screen and \(min-height:\s*1000px\)[\s\S]*?\.faviconUploader\s*{/,
+        );
+    });
+
+    it('does not apply the favicon dimensions to the optional 512x512 association logo', () => {
+        expect(brandingSource).toMatch(
+            /name={\['theming', 'associationLogo']}\}[\s\S]*?className=.*styles\.associationLogoUploader|className=.*styles\.associationLogoUploader[\s\S]*?name={\['theming', 'associationLogo']}/,
+        );
+        expect(brandingStyles).toMatch(/\.associationLogoUploader\s*{[\s\S]*?width:\s*54px/);
+    });
+});

--- a/src/components/Tenants/GeneralSettings/components/LogoAndFavicon/styles.test.ts
+++ b/src/components/Tenants/GeneralSettings/components/LogoAndFavicon/styles.test.ts
@@ -16,9 +16,18 @@ describe('LogoAndFavicon preview size contract', () => {
     });
 
     it('does not apply the favicon dimensions to the optional 512x512 association logo', () => {
-        expect(brandingSource).toMatch(
-            /name={\['theming', 'associationLogo']}\}[\s\S]*?className=.*styles\.associationLogoUploader|className=.*styles\.associationLogoUploader[\s\S]*?name={\['theming', 'associationLogo']}/,
+        const uploaderProps = [...brandingSource.matchAll(/<FormFileUploaderField([\s\S]*?)\/>/g)].map(
+            ([, props]) => props,
         );
+        const associationLogoUploader = uploaderProps.find((props) =>
+            props.includes("name={['theming', 'associationLogo']}"),
+        );
+
+        expect(associationLogoUploader).toContain('styles.associationLogoUploader');
+        expect(associationLogoUploader).not.toContain('styles.faviconUploader');
         expect(brandingStyles).toMatch(/\.associationLogoUploader\s*{[\s\S]*?width:\s*54px/);
+        expect(brandingStyles).toMatch(
+            /@media only screen and \(min-height:\s*1000px\)[\s\S]*?\.associationLogoUploader\s*{\s*width:\s*64px/,
+        );
     });
 });

--- a/src/components/Tenants/GeneralSettings/styles.module.scss
+++ b/src/components/Tenants/GeneralSettings/styles.module.scss
@@ -18,7 +18,7 @@
 }
 
 .cardSlotImages {
-    --card-deck-item-width: 500px;
+    --card-deck-item-width: 392px;
 }
 
 .cardSlotTheme {

--- a/src/components/Tenants/GeneralSettings/styles.test.ts
+++ b/src/components/Tenants/GeneralSettings/styles.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const generalSettingsStyles = readFileSync(resolve(__dirname, './styles.module.scss'), 'utf8');
+
+describe('GeneralSettings appearance card width contract', () => {
+    it('uses the standard 392px desktop width for the individual-images card', () => {
+        const imagesCardRule = generalSettingsStyles.match(/\.cardSlotImages\s*{([^}]*)}/s)?.[1] ?? '';
+
+        expect(imagesCardRule).toMatch(/--card-deck-item-width:\s*392px/);
+    });
+});

--- a/src/components/Tenants/LegalSettings/index.tsx
+++ b/src/components/Tenants/LegalSettings/index.tsx
@@ -86,10 +86,10 @@ export const LegalSettings = ({ tenantId }: LegalSettingsProps) => {
                     </CardEditable>
                 </CardDeck.Item>
             )}
-            <CardDeck.Item>
+            <CardDeck.Item className={styles.documentEditorItem}>
                 <DataProcessingAgreementContainer tenantId={finalTenantId} />
             </CardDeck.Item>
-            <CardDeck.Item>
+            <CardDeck.Item className={styles.documentEditorItem}>
                 <LegalText
                     tenantId={finalTenantId}
                     fieldName={['content', 'impressum']}
@@ -113,7 +113,7 @@ export const LegalSettings = ({ tenantId }: LegalSettingsProps) => {
                     field: ['content', 'confirmTermsAndConditions'],
                 }}
             /> */}
-            <CardDeck.Item>{LegalTextElement}</CardDeck.Item>
+            <CardDeck.Item className={styles.documentEditorItem}>{LegalTextElement}</CardDeck.Item>
         </CardDeck>
     );
 };

--- a/src/components/Tenants/LegalSettings/styles.module.scss
+++ b/src/components/Tenants/LegalSettings/styles.module.scss
@@ -22,6 +22,6 @@
     .documentEditorItem {
         --card-deck-item-min-width: 800px;
         --card-deck-item-width: 800px;
-        --card-deck-item-max-width: 800px;
+        --card-deck-item-max-width: min(800px, calc(100vw - 176px));
     }
 }

--- a/src/components/Tenants/LegalSettings/styles.module.scss
+++ b/src/components/Tenants/LegalSettings/styles.module.scss
@@ -9,10 +9,19 @@
     color: var(--black-60);
 }
 
-// #568: cap the legal cards like the other settings decks. Without the cap a
-// legal card inherits its content's max-content width (the non-wrapping editor
-// toolbar, ~750px) and pushes the imprint and privacy cards off-screen.
+// Compact legal settings cards use the same width as the other settings decks.
 .cardDeck {
     --card-deck-item-width: 425px;
     --card-deck-item-max-width: 425px;
+}
+
+// #605: the M3 document editor is intentionally 800px wide on desktop
+// (Figma 1261-48667). Scope that width to DPA, imprint and privacy so the
+// compact settings card keeps the regular deck width from #582.
+@media (min-width: 768px) {
+    .documentEditorItem {
+        --card-deck-item-min-width: 800px;
+        --card-deck-item-width: 800px;
+        --card-deck-item-max-width: 800px;
+    }
 }

--- a/src/components/Tenants/LegalSettings/styles.test.ts
+++ b/src/components/Tenants/LegalSettings/styles.test.ts
@@ -20,14 +20,24 @@ describe('LegalSettings card deck contract', () => {
 
         expect(documentItemRule).toMatch(/--card-deck-item-min-width:\s*800px/);
         expect(documentItemRule).toMatch(/--card-deck-item-width:\s*800px/);
-        expect(documentItemRule).toMatch(/--card-deck-item-max-width:\s*800px/);
+        expect(documentItemRule).toMatch(/--card-deck-item-max-width:\s*min\(800px,\s*calc\(100vw\s*-\s*176px\)\)/);
     });
 
     it('applies the wider item only to DPA, imprint and privacy', () => {
-        expect(legalSettingsSource.match(/className={styles\.documentEditorItem}/g) ?? []).toHaveLength(3);
-        expect(legalSettingsSource).toMatch(
-            /multitenancyWithSingleDomainEnabled[\s\S]*?<CardDeck\.Item>\s*<CardEditable/,
-        );
+        const deckItems = [...legalSettingsSource.matchAll(/<CardDeck\.Item([^>]*)>([\s\S]*?)<\/CardDeck\.Item>/g)];
+        const findItem = (content: string) => deckItems.find(([, , body]) => body.includes(content));
+        const documentEditorClass = 'className={styles.documentEditorItem}';
+        const privacyEditor = legalSettingsSource.match(/const LegalTextElement = \(([\s\S]*?)\n\s{4}\);/)?.[1] ?? '';
+
+        expect(findItem('<DataProcessingAgreementContainer')?.[1]).toContain(documentEditorClass);
+        expect(findItem('legalType="imprint"')?.[1]).toContain(documentEditorClass);
+        expect(privacyEditor).toContain("fieldName={['content', 'privacy']}");
+        expect(privacyEditor).toContain('legalType="privacy"');
+        expect(findItem('{LegalTextElement}')?.[1]).toContain(documentEditorClass);
+
+        const compactSettingsItem = findItem('<CardEditable');
+        expect(compactSettingsItem?.[1]).not.toContain(documentEditorClass);
+        expect(legalSettingsSource).toMatch(/multitenancyWithSingleDomainEnabled[\s\S]*?<CardDeck\.Item>/);
     });
 
     // Deliberately file-wide: any grow rule on this page's deck items would

--- a/src/components/Tenants/LegalSettings/styles.test.ts
+++ b/src/components/Tenants/LegalSettings/styles.test.ts
@@ -3,15 +3,31 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const legalSettingsStyles = readFileSync(resolve(__dirname, './styles.module.scss'), 'utf8');
+const legalSettingsSource = readFileSync(resolve(__dirname, './index.tsx'), 'utf8');
 
-// #568: without a width cap the legal cards inherit their content's
-// max-content width (the ~750px editor toolbar) and push the imprint and
-// privacy cards off-screen, where nothing marks them as reachable.
+// #605: #582 made every legal card compact. Only the settings card belongs to
+// that contract; the three M3 document editors use their Figma desktop width.
 describe('LegalSettings card deck contract', () => {
-    it('pins the deck item width tokens like the other settings decks', () => {
+    it('keeps the default legal settings card compact', () => {
         const cardDeckRule = legalSettingsStyles.match(/\.cardDeck\s*{([^}]*)}/s)?.[1] ?? '';
         expect(cardDeckRule).toMatch(/--card-deck-item-width:\s*425px/);
         expect(cardDeckRule).toMatch(/--card-deck-item-max-width:\s*425px/);
+    });
+
+    it('gives M3 document editor items their 800px desktop width', () => {
+        const desktopRule = legalSettingsStyles.match(/@media \(min-width:\s*768px\)\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+        const documentItemRule = desktopRule.match(/\.documentEditorItem\s*{([^}]*)}/s)?.[1] ?? '';
+
+        expect(documentItemRule).toMatch(/--card-deck-item-min-width:\s*800px/);
+        expect(documentItemRule).toMatch(/--card-deck-item-width:\s*800px/);
+        expect(documentItemRule).toMatch(/--card-deck-item-max-width:\s*800px/);
+    });
+
+    it('applies the wider item only to DPA, imprint and privacy', () => {
+        expect(legalSettingsSource.match(/className={styles\.documentEditorItem}/g) ?? []).toHaveLength(3);
+        expect(legalSettingsSource).toMatch(
+            /multitenancyWithSingleDomainEnabled[\s\S]*?<CardDeck\.Item>\s*<CardEditable/,
+        );
     });
 
     // Deliberately file-wide: any grow rule on this page's deck items would

--- a/src/components/mui/MuiFormField/MuiFormField.test.tsx
+++ b/src/components/mui/MuiFormField/MuiFormField.test.tsx
@@ -9,6 +9,23 @@ import { MuiFormField, MuiNumberFormField, MuiPasswordFormField } from './index'
 const renderWithForm = (children: React.ReactNode) => render(<Form>{children}</Form>);
 
 describe('MuiFormField', () => {
+    it('uses the surrounding surface only for filled fields', () => {
+        render(
+            <div style={{ '--input-bg': 'rgb(252, 249, 249)' } as React.CSSProperties}>
+                <Form>
+                    <MuiFormField name="outlined" label="Outlined" />
+                    <MuiFormField name="filled" label="Filled" variant="filled" />
+                </Form>
+            </div>,
+        );
+
+        const outlinedRoot = screen.getByLabelText('Outlined').closest('.MuiInputBase-root');
+        const filledRoot = screen.getByLabelText('Filled').closest('.MuiInputBase-root');
+
+        expect(getComputedStyle(outlinedRoot!).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+        expect(getComputedStyle(filledRoot!).backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+    });
+
     it('passes end adornments and native input props through the MUI v9 slot API', () => {
         renderWithForm(
             <MuiFormField

--- a/src/components/mui/MuiFormField/index.tsx
+++ b/src/components/mui/MuiFormField/index.tsx
@@ -74,6 +74,11 @@ const MuiControl = ({
     const form = Form.useFormInstance();
     const isError = status === 'error';
     const errors = form?.getFieldError(fieldName as any) ?? [];
+    const inputSurface = variant === 'outlined' ? 'transparent' : 'var(--input-bg)';
+    const autofillSurface =
+        variant === 'outlined'
+            ? 'var(--input-autofill-surface, var(--input-label-bg, var(--m3-surface-container-highest, #e4e2e2)))'
+            : 'var(--input-autofill-surface, var(--input-bg, #fcf9f9))';
     // Keep height stable: always render a helperText line (' ' when empty).
     // Error matches MUI TextField: `error` + `helperText` message.
     const helperText = (isError && errors[0]) || helpText || ' ';
@@ -146,7 +151,7 @@ const MuiControl = ({
                     minWidth: 0,
                     maxWidth: '100%',
                     boxSizing: 'border-box',
-                    backgroundColor: 'var(--input-bg)',
+                    backgroundColor: inputSurface,
                     color: 'var(--admin-form-field-text)',
                     fontFamily: 'var(--m3-body-font-family)',
                     fontSize: 16,
@@ -172,11 +177,13 @@ const MuiControl = ({
                 // Browser autofill: Chrome/Safari force their own (blue/cream)
                 // fill via a UA !important background. Paint the field's own
                 // surface over it with an inset box-shadow and keep the admin
-                // text colour. `--input-autofill-surface` lets transparent
-                // fields (e.g. login) substitute the page surface instead.
+                // text colour. Outlined controls inherit the surface behind
+                // their floating label; filled controls retain their own fill.
+                // Individual surfaces can override either with
+                // `--input-autofill-surface`.
                 '& .MuiInputBase-input:-webkit-autofill, & .MuiInputBase-input:-webkit-autofill:hover, & .MuiInputBase-input:-webkit-autofill:focus':
                     {
-                        WebkitBoxShadow: 'inset 0 0 0 1000px var(--input-autofill-surface, var(--input-bg, #fcf9f9))',
+                        WebkitBoxShadow: `inset 0 0 0 1000px ${autofillSurface}`,
                         WebkitTextFillColor: 'var(--admin-form-field-text, #1b1b1c)',
                         caretColor: 'var(--admin-form-field-text, #1b1b1c)',
                         transition: 'background-color 9999s ease-out 0s',
@@ -234,7 +241,7 @@ const MuiControl = ({
                 },
                 // Disabled: keep normal colors; opacity on the field dims the control.
                 '& .MuiInputBase-root.Mui-disabled': {
-                    backgroundColor: 'var(--input-bg)',
+                    backgroundColor: inputSurface,
                     color: 'var(--admin-form-field-text)',
                     cursor: 'not-allowed',
                     WebkitTextFillColor: 'var(--admin-form-field-text)',

--- a/src/pages/GlobalSettings/styles.module.scss
+++ b/src/pages/GlobalSettings/styles.module.scss
@@ -1,9 +1,9 @@
 .globalConfigGrid {
     display: grid;
-    max-width: 1120px;
+    max-width: 1164px;
     align-items: start;
     gap: 24px;
-    grid-template-columns: minmax(280px, 340px) minmax(360px, 560px);
+    grid-template-columns: minmax(280px, 340px) minmax(360px, 800px);
 }
 
 .globalConfigCardSlot,


### PR DESCRIPTION
## Problem

PR #582 correctly improved CardDeck discoverability, but its 425px cap also narrowed the M3 legal document editors. DPA, imprint, and privacy intentionally use the 800px Figma desktop width; compact legal settings cards remain 425px.

The individual-images card also rendered its labelled 32x32 favicon preview at 54px or 64px and used a special 500px card width, making the preview and card unnecessarily large.

The machine-translation API-key card still used legacy white Ant save buttons with a local square override. Its outlined MUI password fields also inherited the globally resolved white field surface, and the page grid capped the card at 560px.

## Changes

- scope an 800px desktop item contract to the three M3 document editors, explicitly capped to the viewport
- keep the compact legal settings card at 425px
- preserve CardDeck dots, arrows, scrolling, and narrow/mobile stacking
- render the favicon preview at exactly 32px at every desktop height
- keep the optional 512x512 association-logo preview on its existing independent sizing
- return the individual-images card to the standard 392px CardDeck width
- replace translation-key Ant save buttons with shared outlined M3 buttons
- add an accessible loading state to M3Button and retain per-provider saving feedback
- widen the translation API-key desktop grid track from 560px to 800px
- make shared MUI outlined fields transparent globally, including disabled state, while filled fields retain their surface
- use the surrounding field/card surface for outlined browser autofill instead of a white local override
- add regression coverage and Storybook coverage for the changed contracts

## Verification

- targeted settings/form tests: 14/14
- full Vitest suite: 1364/1364 across 224 files
- ESLint and Prettier: clean
- production build: successful
- Storybook typecheck and production build: successful
- real Storybook browser: translation card 798px rendered width at a 1600px viewport (up from 558px); all outlined states transparent; filled states retain their surface; 0 console errors/warnings
- Stylelint: the repository command still reports the existing repo-wide missing SCSS/LESS custom-syntax baseline; no new diagnostic is attributable to this change

Closes #605
Refs #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)
