### PR TITLE
test(links): wait for the selected template before importing a CSV

### DIFF
--- a/src/pages/Links/AccountInvitesTab.test.tsx
+++ b/src/pages/Links/AccountInvitesTab.test.tsx
@@ -224,9 +224,24 @@ describe('TenantInvitesTab Träger-ID field', () => {
  */
 describe('CSV import payload per tab', () => {
     const importCsv = async (user: ReturnType<typeof userEvent.setup>, content: string) => {
-        await user.click(await screen.findByRole('button', { name: 'Weitere Aktionen' }));
+        // In direct send mode the composer refuses a CSV while no template is
+        // selected (`links.accountInvites.templateRequired`) and never reports the
+        // parse result, so the preview modal never opens. Waiting for the fetch
+        // call alone is not enough — wait for the auto-selected template to reach
+        // the pill, otherwise the upload races the selection (green locally, red
+        // on a loaded runner).
+        // findBy's 1s default is the tight budget here: a loaded runner needs
+        // longer for the fetch, the menu and the file read than a warm laptop.
+        const slow = { timeout: 10_000 };
+        await screen.findByRole('button', { name: /Standard/ }, slow);
+        await user.click(await screen.findByRole('button', { name: 'Weitere Aktionen' }, slow));
+        // The hidden file input sits inside the lazily rendered more-menu.
+        await screen.findByText('CSV-Datei importieren', undefined, slow);
         const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
         await user.upload(fileInput, new File([content], 'invites.csv', { type: 'text/csv' }));
+        // The file is read asynchronously (File.text / FileReader) and parsed
+        // before the preview modal mounts.
+        await screen.findByRole('dialog', undefined, slow);
     };
 
     beforeEach(() => {

--- a/src/pages/Links/AccountInvitesTab.test.tsx
+++ b/src/pages/Links/AccountInvitesTab.test.tsx
@@ -235,9 +235,16 @@ describe('CSV import payload per tab', () => {
         const slow = { timeout: 10_000 };
         await screen.findByRole('button', { name: /Standard/ }, slow);
         await user.click(await screen.findByRole('button', { name: 'Weitere Aktionen' }, slow));
-        // The hidden file input sits inside the lazily rendered more-menu.
+        // The hidden file input sits inside the lazily rendered more-menu. It has
+        // no accessible name (antd hides it from the a11y tree), so it cannot be
+        // reached by role or label — but a bare cast would hand `user.upload` a
+        // silent null the day the menu changes, so assert it is really mounted.
         await screen.findByText('CSV-Datei importieren', undefined, slow);
-        const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+        const fileInput = await waitFor(() => {
+            const input = document.querySelector<HTMLInputElement>('.ant-upload input[type="file"]');
+            expect(input).not.toBeNull();
+            return input as HTMLInputElement;
+        }, slow);
         await user.upload(fileInput, new File([content], 'invites.csv', { type: 'text/csv' }));
         // The file is read asynchronously (File.text / FileReader) and parsed
         // before the preview modal mounts.


### PR DESCRIPTION
## Problem

`CI - Main` on `pre-dev` went red on the #608 merge commit (run 30562241333), so no `oriso-admin` image was published — pre-dev is still serving a build from 2026-07-30 06:04 UTC. The failure: `AccountInvitesTab.test.tsx` could not find the "2 Empfänger anlegen" confirm button.

Not a product regression. In direct send mode the composer refuses a CSV while no template is selected — it shows `links.accountInvites.templateRequired` and never reports a parse result, so the preview modal never opens. The test helper only waited for `listInviteEmailTemplates` to have been *called*, not for the auto-selected template to reach the pill, so the upload raced the selection. Green on a warm laptop, red on a loaded runner.

## Changes

- `importCsv` waits for the template pill, the lazily rendered more-menu entry and the preview dialog instead of assuming each is already there
- 10s budget on those three barriers — findBy's 1s default is what made this CI-only

## Verification

- Repro: with the template fetch delayed by 3s the old helper fails with exactly the CI error, the new one passes
- `npx vitest run src/pages/Links` — 7 files / 51 tests green
- `npx eslint … --max-warnings=0`, `npx prettier --check` — clean

Unblocks #614.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of CSV import workflows by ensuring template selection, import options, file uploads, and previews are fully ready before continuing.
* **Tests**
  * Strengthened automated coverage for CSV imports, including asynchronous template loading, menu rendering, file selection, and preview display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->