### PR TITLE
test: reset antd message/notification singletons between tests

### DIFF
--- a/src/test/antdNoticeCleanup.test.tsx
+++ b/src/test/antdNoticeCleanup.test.tsx
@@ -1,0 +1,56 @@
+// Guards the antd notice cleanup in ./setup.ts. The assertions live in the test
+// that FOLLOWS the one raising a notice, because the leak this prevents is
+// cross-test: antd's static message/notification singleton portals into
+// document.body, which RTL's cleanup() never touches.
+import '@ant-design/v5-patch-for-react-19';
+import { message, notification } from 'antd';
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('antd static notice cleanup between tests', () => {
+    it('raises a message and a notification', async () => {
+        message.error('LEAKY MESSAGE');
+        notification.success({ message: 'LEAKY NOTIFICATION' });
+
+        expect(await screen.findByText('LEAKY MESSAGE')).toBeInTheDocument();
+        expect(await screen.findByText('LEAKY NOTIFICATION')).toBeInTheDocument();
+    });
+
+    it('starts with a body free of the previous test notices', () => {
+        expect(document.querySelectorAll('.ant-message')).toHaveLength(0);
+        expect(document.querySelectorAll('.ant-notification')).toHaveLength(0);
+        expect(screen.queryByText('LEAKY MESSAGE')).not.toBeInTheDocument();
+        expect(screen.queryByText('LEAKY NOTIFICATION')).not.toBeInTheDocument();
+    });
+
+    it('can still raise its own message after the cleanup ran', async () => {
+        // Removing the container instead of destroying the singleton would leave
+        // antd rendering off-document, and this findByText would time out.
+        message.error('MESSAGE AFTER CLEANUP');
+
+        expect(await screen.findByText('MESSAGE AFTER CLEANUP')).toBeInTheDocument();
+    });
+
+    it('cleans up a notice that was raised without being awaited', () => {
+        message.error('FIRE AND FORGET');
+    });
+
+    it('starts clean after a fire-and-forget notice', () => {
+        expect(screen.queryByText('FIRE AND FORGET')).not.toBeInTheDocument();
+        expect(document.querySelectorAll('.ant-message')).toHaveLength(0);
+    });
+
+    it('leaves a notice on screen with fake timers still installed', async () => {
+        message.error('FAKE TIMER NOTICE');
+        expect(await screen.findByText('FAKE TIMER NOTICE')).toBeInTheDocument();
+
+        // Left installed on purpose: the cleanup hook must not depend on the
+        // test's clock to flush antd's unmount.
+        vi.useFakeTimers();
+    });
+
+    it('starts clean after a test that ended under fake timers', () => {
+        expect(screen.queryByText('FAKE TIMER NOTICE')).not.toBeInTheDocument();
+        expect(document.querySelectorAll('.ant-message')).toHaveLength(0);
+    });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -80,6 +80,39 @@ if (typeof window !== 'undefined') {
     }) as typeof window.getComputedStyle;
 }
 
+// antd's static `message` / `notification` APIs render through a module-level
+// singleton that portals notices into a container appended straight to document.body.
+// RTL's cleanup() only unmounts what render() created, so a notice that has not
+// auto-dismissed yet survives into the next test — a stale "This tenant ID is already
+// taken." toast once broke an unrelated assertion in AccountInvitesTab.test.tsx on CI.
+//
+// destroy() alone does not fix it: it only queues a React update, so the notice is
+// still in the DOM when the next test starts. act() flushes that update synchronously.
+//
+// Do NOT instead remove the .ant-message root from the body (the way stuck
+// .ant-modal-root nodes are swept up): the singleton keeps rendering into the detached
+// container, and every later notice in that file then silently never appears.
+//
+// Registered before the timer hook below so it runs last — Vitest runs afterEach in
+// reverse registration order — and never has to flush against a test's fake clock.
+//
+// antd/react are imported lazily, only when a notice is actually on screen: a static
+// import would pull antd into every test file, and an unconditional destroy() would
+// instantiate the message holder in every single test.
+afterEach(async () => {
+    // `@vitest-environment node` files (e.g. api/fetchData.test.ts) have no DOM.
+    if (typeof document === 'undefined' || !document.querySelector('.ant-message, .ant-notification')) {
+        return;
+    }
+
+    const [{ message, notification }, { act }] = await Promise.all([import('antd'), import('react')]);
+
+    act(() => {
+        message.destroy();
+        notification.destroy();
+    });
+});
+
 // Prevent fake-timer leakage between test files when a test forgets to restore.
 afterEach(() => {
     vi.useRealTimers();


### PR DESCRIPTION
## Problem

antd's static `message`/`notification` APIs render via a module-level singleton that portals notices into a container appended straight to `document.body`. RTL's `cleanup()` only unmounts what `render()` created, so a notice that hasn't auto-dismissed survives into the next test. On CI run 30562241333 a stale "This tenant ID is already taken." toast from an earlier test in `AccountInvitesTab.test.tsx` leaked forward and broke an unrelated assertion — the DOM dump showed two `.ant-message` roots in the body.

## What changed

**`src/test/setup.ts`** — new `afterEach` that destroys the `message`/`notification` singletons inside `act()`, so the unmount flushes synchronously and the body is clean before the next test starts.

- Guarded for `@vitest-environment node` files, which have no DOM.
- antd/react are imported lazily and only when a notice is actually on screen — a static import would pull antd into every test file, and an unconditional `destroy()` would instantiate the message holder in every test.
- Registered before the existing timer hook so it runs last (Vitest runs `afterEach` in reverse order) and never flushes against a test's fake clock.

**`src/test/antdNoticeCleanup.test.tsx`** — regression test covering the awaited, fire-and-forget, and ended-under-fake-timers cases.

Note: `destroy()` alone is **not** enough (it only queues a React update), and removing the `.ant-message` root the way stuck `.ant-modal-root` nodes are swept up actively breaks things — the singleton keeps rendering into the detached container and later notices silently never appear. Both were verified experimentally; the comment records this.

Test infrastructure only, no product code.

## Verification

- `npx vitest run` — 226 files / 1385 tests pass (baseline on `pre-dev`: 225/1378; delta is exactly the 7 new tests).
- Regression test confirmed non-vacuous: disabling the hook turns its 3 "starts clean" assertions red.
- `npx prettier . --check --ignore-unknown` — clean.
- `npx eslint . --max-warnings=0` — clean. `npm run build` — succeeds. Both needed #617 to run at all from a nested worktree; that config fix is independent of this PR and CI is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)