### PR TITLE
chore(eslint): mark the project config as root

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "extends": [
         "plugin:react-hooks/recommended",
         "airbnb",


### PR DESCRIPTION
## Problem

`.eslintrc.json` does not set `"root": true`, so ESLint walks up past the project directory and merges any `.eslintrc.json` it finds above it.

That is harmless in a plain checkout, but a git worktree created under the repo directory (`.claude/worktrees/*`) sits *below* the main checkout's config, so both are loaded and ESLint aborts:

```
ESLint couldn't determine the plugin "import" uniquely.
- <worktree>/node_modules/eslint-plugin-import/lib/index.js (loaded in ".eslintrc.json")
- <main checkout>/node_modules/eslint-plugin-import/lib/index.js (loaded in "../../../.eslintrc.json")
```

This breaks `npx eslint .` and — because `vite-plugin-eslint` runs inside the build — also `npm run build` in any such worktree.

## What changed

- Add `"root": true` to `.eslintrc.json` (one line).

CI checks out clean and has nothing above the project root, so linting behaviour there is unchanged. No product code, no rule changes.

## Verification

Run from a worktree under `.claude/worktrees/`, where both previously failed:

- `npx eslint . --max-warnings=0` — exit 0, no output (previously aborted with the error above; only worked with `--resolve-plugins-relative-to .`).
- `npm run build` — exit 0, built in ~25s (previously failed in `vite-plugin-eslint`).
- `npx prettier .eslintrc.json --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)