### PR TITLE
fix(public): one-line footer, standalone language control, working legal dialog

### DIFF
--- a/scripts/shootPublicFooter.mjs
+++ b/scripts/shootPublicFooter.mjs
@@ -1,0 +1,112 @@
+/**
+ * Evidence shots for the public-footer / legal-dialog review fixes.
+ *
+ * Runs against the Storybook dev server of THIS worktree and writes one PNG per
+ * review item, so each fix can be checked against the annotated screenshot it
+ * came from instead of "trust me, it works".
+ *
+ *   node scripts/shootPublicFooter.mjs [baseUrl] [outDir]
+ */
+import { mkdir } from 'node:fs/promises';
+import { chromium } from '/Users/frankgerhardt/ORISO/ORISO-E2E/node_modules/playwright/index.mjs';
+
+const BASE = process.argv[2] ?? 'http://localhost:6103';
+const OUT = process.argv[3] ?? 'evidence';
+
+const story = (id) => `${BASE}/iframe.html?id=${id}&viewMode=story`;
+
+const SHOTS = [
+    {
+        name: '01-footer-one-row-1280',
+        id: 'pages-login-publicsurface--desktop',
+        viewport: { width: 1280, height: 800 },
+        clip: { x: 0, y: 620, width: 640, height: 180 },
+    },
+    {
+        name: '02-footer-one-row-1512',
+        id: 'pages-login-publicsurface--desktop',
+        viewport: { width: 1512, height: 900 },
+        clip: { x: 0, y: 700, width: 760, height: 200 },
+    },
+    {
+        name: '03-language-menu-centred-desktop',
+        id: 'pages-login-publicsurface--desktop',
+        viewport: { width: 1280, height: 800 },
+        openLanguage: true,
+        clip: { x: 0, y: 560, width: 640, height: 240 },
+    },
+    {
+        name: '04-language-menu-centred-mobile',
+        id: 'pages-login-publicsurface--mobile',
+        viewport: { width: 390, height: 844 },
+        openLanguage: true,
+    },
+    {
+        name: '05-legal-dialog-imprint',
+        id: 'organisms-legalnoticedialog--imprint',
+        viewport: { width: 1280, height: 800 },
+    },
+    {
+        name: '06-legal-dialog-privacy',
+        id: 'organisms-legalnoticedialog--privacy',
+        viewport: { width: 1280, height: 800 },
+    },
+    {
+        name: '07-legal-dialog-mobile',
+        id: 'organisms-legalnoticedialog--privacy-on-phone',
+        viewport: { width: 390, height: 844 },
+    },
+    {
+        name: '08-legal-dialog-long-text',
+        id: 'organisms-legalnoticedialog--long-published-text',
+        viewport: { width: 1280, height: 800 },
+    },
+    {
+        name: '09-legal-dialog-long-text-mobile',
+        id: 'organisms-legalnoticedialog--long-published-text-on-phone',
+        viewport: { width: 390, height: 844 },
+    },
+];
+
+const run = async () => {
+    await mkdir(OUT, { recursive: true });
+    const browser = await chromium.launch();
+
+    for (const shot of SHOTS) {
+        /* German is the worst case for the footer row — "IMPRESSUM DATENSCHUTZ"
+           is ~25% wider than "IMPRINT PRIVACY" — and it is the locale the
+           review screenshots were taken in. Pin it instead of inheriting the
+           headless browser's default. */
+        const page = await browser.newPage({
+            viewport: shot.viewport,
+            deviceScaleFactor: 2,
+            locale: 'de-DE',
+        });
+        await page.addInitScript(() => {
+            globalThis.localStorage.setItem('oriso-admin.language', 'de');
+            document.cookie = 'oriso-admin.language=de;path=/';
+        });
+        /* Storybook's dev server keeps an HMR socket open, so `networkidle`
+           never fires — wait for the rendered story instead. */
+        await page.goto(story(shot.id), { waitUntil: 'domcontentloaded' });
+        await page.waitForSelector(shot.waitFor ?? '.layoutFooter, .ant-modal');
+        /* The stage panel slides in over ~2s before it settles at 40vw. */
+        await page.waitForTimeout(2600);
+
+        if (shot.openLanguage) {
+            await page.getByRole('button', { name: /Anwendungssprache|Select application language/ }).click();
+            await page.waitForTimeout(600);
+        }
+
+        await page.screenshot({ path: `${OUT}/${shot.name}.png`, clip: shot.clip });
+        console.log(`wrote ${OUT}/${shot.name}.png`);
+        await page.close();
+    }
+
+    await browser.close();
+};
+
+run().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/src/components/Layout/FooterLanguageMenu.tsx
+++ b/src/components/Layout/FooterLanguageMenu.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import { Dropdown } from 'antd';
+import type { MenuProps } from 'antd';
+import { useTranslation } from 'react-i18next';
+import CheckIcon from '@mui/icons-material/Check';
+import { ReactComponent as LanguageIcon } from '../../resources/img/svg/navbar/languages_active.svg';
+import { useLanguage } from '../../hooks/useLanguage';
+import { isSupportedLanguage } from '../../utils/language';
+import styles from './footerLanguageMenu.module.scss';
+
+/**
+ * The language control of the public footer.
+ *
+ * It used to be a *submenu entry* of the footer's antd `Menu` — a language
+ * combobox smuggled in as a menu item. That is what produced the three
+ * defects in the 100%-zoom review:
+ *
+ *  - the entry carried the full `(DE) Deutsch` label plus a submenu arrow, so
+ *    the three-entry row no longer fitted the 40vw stage panel and wrapped
+ *    onto a second line;
+ *  - opening it painted antd's horizontal-menu active bar — the red underline
+ *    under the entry, which reads as a validation error on a login screen;
+ *  - the submenu popup is anchored to the *left edge* of its entry, so the
+ *    options floated off to the side of the trigger instead of over it.
+ *
+ * It is now its own control with a fixed footprint: a real `button` with the
+ * globe and the language code, and a `Dropdown` anchored `top` — antd centres
+ * `top` on the trigger, which is exactly the "menu centred over the button"
+ * the review asked for. The full language names stay where they belong: in
+ * the options, with a check mark on the active one.
+ */
+export const FooterLanguageMenu = () => {
+    const { t } = useTranslation();
+    const { language, options, changeLanguage } = useLanguage();
+    const [open, setOpen] = useState(false);
+
+    const current = options.find((option) => option.value === language);
+
+    const items: MenuProps['items'] = options.map((option) => ({
+        key: option.value,
+        label: (
+            <span className={styles.option}>
+                <span className={styles.optionCheck} aria-hidden>
+                    {option.value === language && <CheckIcon fontSize="inherit" />}
+                </span>
+                {option.label}
+            </span>
+        ),
+    }));
+
+    const handleClick: MenuProps['onClick'] = ({ key }) => {
+        if (isSupportedLanguage(key)) {
+            changeLanguage(key);
+        }
+        setOpen(false);
+    };
+
+    return (
+        <Dropdown
+            open={open}
+            onOpenChange={setOpen}
+            trigger={['click']}
+            /* `top` is the centred placement in antd; `topLeft` is the anchored
+               one the old submenu effectively used. */
+            placement="top"
+            overlayClassName={styles.popup}
+            menu={{ items, selectedKeys: [language], onClick: handleClick }}
+        >
+            <button
+                type="button"
+                /* `footerLanguage` is the stable, unhashed hook the footer's
+                   own stylesheet uses to give this control the typography of
+                   the row it sits in (white + bold + uppercase on the stage
+                   panel, plain on the in-flow footer). */
+                className={`footerLanguage ${styles.trigger}`}
+                /* antd's Dropdown only clones `className`/`disabled`/`ref` onto
+                   its trigger — it does NOT add the popup state. Declaring it
+                   here is what tells a screen reader the button opens a menu
+                   and whether it is open, and it is what the open-state style
+                   below hangs off. Same pattern as `components/PillSelect`. */
+                aria-haspopup="menu"
+                aria-expanded={open}
+                /* The trigger shows the code so the row keeps a fixed, narrow
+                   footprint; the accessible name still carries the full name. */
+                aria-label={`${t('language.selectAriaLabel')}: ${current?.label ?? language}`}
+                title={current?.label ?? language}
+            >
+                <LanguageIcon className={styles.icon} aria-hidden />
+                <span className={styles.code}>{language.toUpperCase()}</span>
+            </button>
+        </Dropdown>
+    );
+};
+
+export default FooterLanguageMenu;

--- a/src/components/Layout/LegalNoticeDialog.stories.tsx
+++ b/src/components/Layout/LegalNoticeDialog.stories.tsx
@@ -48,12 +48,12 @@ const LONG_BODY = Array.from(
 ).join('\n\n');
 
 const withLongBody = (Story: () => ReactNode) => {
-    /* `keySeparator: false` (see src/i18n.ts) — the dots are part of the key,
-       and the placeholder body is already in the bundle, so the resource has to
-       be overwritten explicitly. */
+    /* The dots are part of the key: src/i18n.ts sets `keySeparator: false`
+       globally and `addResource` inherits it, so `footer.legal.privacy.body` is
+       a single flat key. The placeholder body is already in the bundle, so the
+       resource has to be overwritten explicitly. */
     ['de', 'en'].forEach((language) => {
         i18n.addResource(language, 'translations', 'footer.legal.privacy.body', LONG_BODY, {
-            keySeparator: false,
             silent: true,
         });
     });

--- a/src/components/Layout/LegalNoticeDialog.stories.tsx
+++ b/src/components/Layout/LegalNoticeDialog.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactNode } from 'react';
+import i18n from 'i18next';
+import { PHONE_390 } from '../DpaLegalForm/dpaStoryText';
+import { LegalNoticeDialog } from './LegalNoticeDialog';
+
+/**
+ * The text box behind the footer's Imprint / Privacy entries.
+ *
+ * Two things were wrong in the 100%-zoom review and are pinned here: the hero
+ * icon was a generic MUI gavel instead of the product's own legal icons, and
+ * the close action was wired to `btn.close` — a key that exists in no locale,
+ * so it rendered the raw key to every visitor.
+ */
+const meta = {
+    title: 'Organisms/LegalNoticeDialog',
+    component: LegalNoticeDialog,
+    parameters: { layout: 'fullscreen' },
+    args: { onClose: () => {} },
+} satisfies Meta<typeof LegalNoticeDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Imprint: Story = { args: { kind: 'imprint' } };
+
+export const Privacy: Story = { args: { kind: 'privacy' } };
+
+export const PrivacyOnPhone: Story = {
+    args: { kind: 'privacy' },
+    parameters: { layout: 'fullscreen', ...PHONE_390.parameters },
+    globals: PHONE_390.globals,
+};
+
+/**
+ * ⚠️ The acceptance case. The placeholder copy is three paragraphs; the
+ * PUBLISHED imprint and privacy notice are pages, and that is what this dialog
+ * will show once `legalNoticeContent` is wired to the stored texts. The sheet
+ * must stay inside the viewport with the title and the close action visible —
+ * only the text scrolls.
+ */
+const LONG_BODY = Array.from(
+    { length: 24 },
+    (_, index) =>
+        `§ ${index + 1} — Dies ist ein Absatz in der Länge, die ein veröffentlichter Rechtstext tatsächlich hat. ` +
+        'Er beschreibt Zwecke, Rechtsgrundlagen, Speicherdauer und Empfänger personenbezogener Daten und ist ' +
+        'bewusst so lang, dass der Text im Dialog scrollen muss, statt den Dialog über den Bildschirmrand zu schieben.',
+).join('\n\n');
+
+const withLongBody = (Story: () => ReactNode) => {
+    /* `keySeparator: false` (see src/i18n.ts) — the dots are part of the key,
+       and the placeholder body is already in the bundle, so the resource has to
+       be overwritten explicitly. */
+    ['de', 'en'].forEach((language) => {
+        i18n.addResource(language, 'translations', 'footer.legal.privacy.body', LONG_BODY, {
+            keySeparator: false,
+            silent: true,
+        });
+    });
+    return <Story />;
+};
+
+export const LongPublishedText: Story = {
+    args: { kind: 'privacy' },
+    decorators: [withLongBody],
+};
+
+export const LongPublishedTextOnPhone: Story = {
+    args: { kind: 'privacy' },
+    decorators: [withLongBody],
+    parameters: { layout: 'fullscreen', ...PHONE_390.parameters },
+    globals: PHONE_390.globals,
+};

--- a/src/components/Layout/LegalNoticeDialog.test.tsx
+++ b/src/components/Layout/LegalNoticeDialog.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LegalNoticeDialog } from './LegalNoticeDialog';
+
+/**
+ * `t` echoes the key, so a MISSING key is visible as a raw key in the output —
+ * which is exactly the defect this suite pins down.
+ */
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string) => key,
+        i18n: { language: 'de', on: vi.fn(), off: vi.fn(), changeLanguage: vi.fn() },
+    }),
+}));
+
+describe('LegalNoticeDialog', () => {
+    /**
+     * The action was wired to `btn.close`, a key that exists in no locale, so
+     * the button rendered the literal string "btn.close" to every visitor of
+     * the sign-in page. `footer.legal.close` ("Schließen" / "Close") is the key
+     * that was actually translated for this dialog.
+     */
+    it('labels the close action with a key that exists', () => {
+        render(<LegalNoticeDialog kind="privacy" onClose={vi.fn()} />);
+
+        expect(screen.getByRole('button', { name: 'footer.legal.close' })).toBeInTheDocument();
+        expect(screen.queryByText('btn.close')).toBeNull();
+    });
+
+    it('closes through that action', async () => {
+        const onClose = vi.fn();
+        render(<LegalNoticeDialog kind="imprint" onClose={onClose} />);
+
+        screen.getByRole('button', { name: 'footer.legal.close' }).click();
+
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    /**
+     * The published legal texts are pages long. The text — not the dialog — is
+     * what scrolls, so the title and the close action stay reachable.
+     */
+    it('scrolls the text instead of the sheet, and exposes it as a landmark', () => {
+        render(<LegalNoticeDialog kind="privacy" onClose={vi.fn()} />);
+
+        const body = screen.getByTestId('legal-notice-privacy');
+
+        expect(body).toHaveAttribute('role', 'region');
+        expect(body).toHaveAttribute('tabindex', '0');
+    });
+
+    /**
+     * Both notices used one generic MUI gavel — a courtroom symbol, and the only
+     * icon on the public surface sourced from outside the ORISO set. Each notice
+     * now shows the product's own icon for that document, the same one the legal
+     * editor card uses.
+     */
+    it('uses the product legal icon of the notice it shows', () => {
+        const iconMarkup = (kind: 'imprint' | 'privacy') => {
+            const { unmount } = render(<LegalNoticeDialog kind={kind} onClose={vi.fn()} />);
+            const icon = document.querySelector('.ant-modal-header .anticon svg');
+            const markup = icon?.innerHTML ?? '';
+            unmount();
+            return markup;
+        };
+
+        const imprint = iconMarkup('imprint');
+        const privacy = iconMarkup('privacy');
+
+        expect(imprint).not.toBe('');
+        expect(privacy).not.toBe('');
+        expect(imprint).not.toBe(privacy);
+    });
+});

--- a/src/components/Layout/LegalNoticeDialog.tsx
+++ b/src/components/Layout/LegalNoticeDialog.tsx
@@ -1,4 +1,5 @@
-import GavelOutlinedIcon from '@mui/icons-material/GavelOutlined';
+import type { ReactNode } from 'react';
+import { GdprIcon, ImprintIcon } from '../CustomIcons/LegalIcons';
 import { Modal } from '../Modal';
 import { useLegalNoticeContent, type LegalNoticeKind } from './legalNoticeContent';
 import styles from './legalNoticeDialog.module.scss';
@@ -7,6 +8,18 @@ export interface LegalNoticeDialogProps {
     kind: LegalNoticeKind;
     onClose: () => void;
 }
+
+/**
+ * The product's own legal icons (Icons Master File, 40px grid) — the exact ones
+ * the legal editor cards use for the same two documents. A generic MUI gavel
+ * stood here before, which is a courtroom, not an imprint or a privacy notice,
+ * and it was the only icon on the public surface that came from outside the
+ * ORISO set.
+ */
+const LEGAL_NOTICE_ICONS: Record<LegalNoticeKind, ReactNode> = {
+    imprint: <ImprintIcon />,
+    privacy: <GdprIcon />,
+};
 
 /**
  * The text box behind the footer's Imprint / Privacy entries (#594.15b).
@@ -22,17 +35,36 @@ export const LegalNoticeDialog = ({ kind, onClose }: LegalNoticeDialogProps) => 
     return (
         <Modal
             title={title}
-            icon={<GavelOutlinedIcon />}
+            icon={LEGAL_NOTICE_ICONS[kind]}
             width={640}
             showDivider={false}
-            cancelLabelKey="btn.close"
+            /* `btn.close` did not exist in any locale, so the action rendered
+               the raw key. `footer.legal.close` is the key that was actually
+               translated for this dialog. */
+            cancelLabelKey="footer.legal.close"
             onClose={onClose}
         >
-            <div className={styles.body} data-testid={`legal-notice-${kind}`}>
+            {/* The published legal texts are far longer than the placeholder
+                copy, so the text scrolls inside the sheet — title, icon and the
+                close action stay put instead of being pushed off-screen.
+
+                The tab stop is WCAG 2.1.1, not decoration: without it a
+                keyboard-only user cannot scroll the rest of a legal text at
+                all — the very content this dialog exists for. The lint rule
+                does not know the region scrolls, so it is disabled here only. */}
+            {/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}
+            <div
+                className={styles.body}
+                data-testid={`legal-notice-${kind}`}
+                role="region"
+                aria-label={title}
+                tabIndex={0}
+            >
                 {paragraphs.map((paragraph) => (
                     <p key={paragraph}>{paragraph}</p>
                 ))}
             </div>
+            {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
         </Modal>
     );
 };

--- a/src/components/Layout/SiteFooter.test.tsx
+++ b/src/components/Layout/SiteFooter.test.tsx
@@ -85,16 +85,36 @@ describe('SiteFooter', () => {
             expect(container.querySelector('.layoutFooter')).toHaveClass('stageFooter');
         });
 
-        it('carries the language selector as a third entry of the same menu', () => {
+        /**
+         * The language selector used to be a submenu ENTRY of this menu. That
+         * is what made the row wrap at 100% zoom, painted antd's red active bar
+         * under it and anchored its popup beside the trigger. It is now its own
+         * control next to the menu — the menu itself is legal texts only.
+         */
+        it('keeps the legal menu to legal texts and puts the language beside it', () => {
             render(<SiteFooter variant="stage" />);
 
-            expect(menuItems()).toEqual(['footer.label.imprint', 'footer.label.privacy', '(DE) Deutsch']);
+            expect(menuItems()).toEqual(['footer.label.imprint', 'footer.label.privacy']);
+            expect(screen.getByRole('button', { name: /language\.selectAriaLabel/ })).toBeInTheDocument();
         });
 
-        it('switches the language from that entry', async () => {
+        it('shows the language code on the trigger and the full name in its options', async () => {
             render(<SiteFooter variant="stage" />);
 
-            await userEvent.click(screen.getByText('(DE) Deutsch'));
+            const trigger = screen.getByRole('button', { name: /language\.selectAriaLabel/ });
+            expect(trigger).toHaveTextContent('DE');
+            expect(trigger).not.toHaveTextContent('Deutsch');
+
+            await userEvent.click(trigger);
+
+            expect(await screen.findByText('(DE) Deutsch')).toBeInTheDocument();
+            expect(await screen.findByText('(EN) English')).toBeInTheDocument();
+        });
+
+        it('switches the language from that control', async () => {
+            render(<SiteFooter variant="stage" />);
+
+            await userEvent.click(screen.getByRole('button', { name: /language\.selectAriaLabel/ }));
             await userEvent.click(await screen.findByText('(EN) English'));
 
             expect(changeLanguage).toHaveBeenCalledWith('en');
@@ -103,7 +123,7 @@ describe('SiteFooter', () => {
         it('keeps the language out of the in-flow footer, which has its own selector elsewhere', () => {
             render(<SiteFooter />);
 
-            expect(screen.queryByText('(DE) Deutsch')).toBeNull();
+            expect(screen.queryByRole('button', { name: /language\.selectAriaLabel/ })).toBeNull();
         });
     });
 });

--- a/src/components/Layout/SiteFooter.tsx
+++ b/src/components/Layout/SiteFooter.tsx
@@ -6,12 +6,9 @@ import { Footer } from 'antd/es/layout/layout';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { runtimeConfig } from '../../config/runtimeConfig';
-import { useLanguage } from '../../hooks/useLanguage';
-import { isSupportedLanguage } from '../../utils/language';
+import { FooterLanguageMenu } from './FooterLanguageMenu';
 import { LegalNoticeDialog } from './LegalNoticeDialog';
 import { LEGAL_NOTICE_KINDS, type LegalNoticeKind } from './legalNoticeContent';
-
-const LANGUAGE_KEY_PREFIX = 'language:';
 
 export interface SiteFooterProps {
     /**
@@ -28,8 +25,8 @@ export interface SiteFooterProps {
 }
 
 /**
- * The site footer menu — Imprint, Privacy and (on the public surface) the
- * language selector as a third entry of the same menu.
+ * The site footer — Imprint, Privacy and (on the public surface) the language
+ * control.
  *
  * Until #594.15b every entry here was dead: the antd items carried a label and
  * a placeholder key (`item-1`, `split`, `submenu`) and no handler at all, so
@@ -37,44 +34,24 @@ export interface SiteFooterProps {
  * default selection state. The keys are now meaningful, both legal entries open
  * their own dialog, and the `' | '` pseudo-item is gone: a separator is styling,
  * not a focusable entry announced to screen readers.
+ *
+ * The language control is deliberately NOT a fourth item of this menu any more
+ * (see {@link FooterLanguageMenu}). A menu of legal texts and a language
+ * selector are two different things; making the selector a submenu is what made
+ * the row wrap, painted antd's red active bar under it, and anchored its popup
+ * to the side of the trigger instead of over it.
  */
 const SiteFooter = ({ variant = 'default' }: SiteFooterProps) => {
     const { t } = useTranslation();
-    const { language, options, changeLanguage } = useLanguage();
     const [openNotice, setOpenNotice] = useState<LegalNoticeKind | null>(null);
     const isStage = variant === 'stage';
 
-    const items: MenuProps['items'] = [
-        ...LEGAL_NOTICE_KINDS.map((kind) => ({
-            label: <span>{t(`footer.label.${kind}`)}</span>,
-            key: kind,
-        })),
-        // The language selector IS an entry of this menu, not a control floating
-        // next to it (#594.15b) — as a submenu, so the options stay real menu
-        // items instead of a combobox nested inside a menuitem.
-        ...(isStage
-            ? [
-                  {
-                      label: <span>{options.find((option) => option.value === language)?.label ?? language}</span>,
-                      key: 'language',
-                      children: options.map((option) => ({
-                          label: option.label,
-                          key: `${LANGUAGE_KEY_PREFIX}${option.value}`,
-                      })),
-                  },
-              ]
-            : []),
-    ];
+    const items: MenuProps['items'] = LEGAL_NOTICE_KINDS.map((kind) => ({
+        label: <span>{t(`footer.label.${kind}`)}</span>,
+        key: kind,
+    }));
 
     const handleClick: MenuProps['onClick'] = ({ key }) => {
-        if (key.startsWith(LANGUAGE_KEY_PREFIX)) {
-            const next = key.slice(LANGUAGE_KEY_PREFIX.length);
-            if (isSupportedLanguage(next)) {
-                changeLanguage(next);
-            }
-            return;
-        }
-
         if ((LEGAL_NOTICE_KINDS as readonly string[]).includes(key)) {
             setOpenNotice(key as LegalNoticeKind);
         }
@@ -91,6 +68,7 @@ const SiteFooter = ({ variant = 'default' }: SiteFooterProps) => {
                 disabledOverflow
                 aria-label={t('footer.ariaLabel')}
             />
+            {isStage && <FooterLanguageMenu />}
             {runtimeConfig.platformVersion && <span className="platformVersion">{runtimeConfig.platformVersion}</span>}
             {openNotice && <LegalNoticeDialog kind={openNotice} onClose={() => setOpenNotice(null)} />}
         </Footer>

--- a/src/components/Layout/footerLanguageMenu.module.scss
+++ b/src/components/Layout/footerLanguageMenu.module.scss
@@ -1,0 +1,107 @@
+/* Standalone language control of the public footer (see FooterLanguageMenu.tsx).
+   Fixed, narrow footprint — globe + language code — so the footer row can never
+   be pushed onto a second line by the length of a translated language name. */
+
+.trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 32px;
+    padding: 0 8px;
+    border: 0;
+    border-radius: 100px;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    /* Typography is inherited from the footer row it sits in — the stage panel
+       makes it white/bold/uppercase like its menu entries, the in-flow footer
+       leaves it plain. Setting it here would make the control the odd one out
+       on one of the two surfaces. */
+    font: inherit;
+    letter-spacing: 0.5px;
+    line-height: 1.4;
+    transition: background-color 150ms ease;
+    white-space: nowrap;
+
+    &:hover,
+    &[aria-expanded='true'] {
+        /* Follows `currentColor`, so the same rule works on the dark stage panel
+           (white) and on the light in-flow footer (near-black). The brand red
+           would vanish on the panel — and an underline reads as an error. */
+        background: color-mix(in srgb, currentColor 12%, transparent);
+    }
+
+    &:focus-visible {
+        outline: 2px solid currentColor;
+        outline-offset: 2px;
+    }
+}
+
+.icon {
+    width: 18px;
+    height: 18px;
+    flex: none;
+}
+
+.code {
+    font-variant-numeric: tabular-nums;
+}
+
+/* Popup: centred over the trigger by antd's `top` placement. */
+
+.popup {
+    :global(.ant-dropdown-menu) {
+        min-width: 160px;
+        padding: 8px 0;
+        border-radius: 12px;
+        /* The M3 menu surface, so the sheet reads as product chrome on the dark
+           panel instead of antd's default white card. */
+        background: var(--m3-surface-container-high, #eae7e8);
+    }
+
+    :global(.ant-dropdown-menu-item) {
+        padding: 8px 16px 8px 8px;
+        color: var(--m3-on-surface, #1b1b1c);
+        font-size: 14px;
+    }
+
+    /* antd tints the selected row with the brand colour. On this surface that is
+       the same red we just removed from under the footer entry — a red row in a
+       language list reads as "something is wrong", not as "this is the current
+       one". The check mark carries that meaning; the row stays neutral. */
+
+    /* Doubled class: antd injects its own `.ant-dropdown .ant-dropdown-menu
+       .ant-dropdown-menu-item-selected` rule at runtime, so an equally specific
+       override would lose the cascade by injection order. */
+
+    &#{&} :global(.ant-dropdown-menu-item-selected) {
+        background: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 8%, transparent);
+        color: var(--m3-on-surface, #1b1b1c);
+    }
+
+    &#{&} :global(.ant-dropdown-menu-item:hover),
+    &#{&} :global(.ant-dropdown-menu-item-active) {
+        background: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 12%, transparent);
+    }
+}
+
+.option {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    white-space: nowrap;
+}
+
+/* Reserved gutter so the labels stay aligned whether or not the row is active —
+   the check mark must not shift the text when the language changes. */
+
+.optionCheck {
+    display: inline-flex;
+    width: 18px;
+    height: 18px;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    color: var(--m3-primary, #a5000a);
+    font-size: 18px;
+}

--- a/src/components/Layout/legalNoticeDialog.module.scss
+++ b/src/components/Layout/legalNoticeDialog.module.scss
@@ -4,8 +4,22 @@
    this block is what the read-only reader takes over. */
 
 .body {
-    max-height: min(60vh, 520px);
+    /*
+     * The placeholder copy is three paragraphs; the published imprint and
+     * privacy notice are pages. `min(60vh, 520px)` alone still let a short
+     * viewport (a phone in landscape) push the close action off-screen,
+     * because it does not know what the dialog chrome above and below the
+     * text costs — icon + title ≈ 140px, action row + margins ≈ 124px.
+     * Subtracting that keeps the whole sheet inside the viewport at any
+     * height, and `max(...)` stops it collapsing to nothing on a very short
+     * one. `dvh` so the mobile browser's collapsing URL bar is accounted for.
+     */
+    max-height: max(160px, min(60vh, 520px, calc(100dvh - 264px)));
+    padding-right: 4px;
     overflow-y: auto;
+
+    /* A long legal text must not chain its scroll to the page behind the mask. */
+    overscroll-behavior: contain;
 
     p {
         margin: 0 0 12px;

--- a/src/components/Modal/styles.module.scss
+++ b/src/components/Modal/styles.module.scss
@@ -65,6 +65,11 @@
     display: inline-flex;
     margin-bottom: 8px;
     color: var(--m3-secondary, #4c555f);
+    /* antd's `Icon` renders its SVG at `1em`, and the ORISO icon set clips
+       itself against a rect expressed in the same unit. Sizing by font-size —
+       not only by width/height — keeps both in step, so an icon can never come
+       out cropped to a fraction of its artboard. */
+    font-size: 32px;
 
     svg {
         width: 32px;

--- a/src/resources/img/svg/dpa.svg
+++ b/src/resources/img/svg/dpa.svg
@@ -6,7 +6,7 @@
 </g>
 <defs>
 <clipPath id="clip0_61304_2568">
-<rect width="1em" height="1em" fill="white"/>
+<rect width="40" height="40" fill="white"/>
 </clipPath>
 </defs>
 </svg>

--- a/src/resources/img/svg/gdpr.svg
+++ b/src/resources/img/svg/gdpr.svg
@@ -12,7 +12,7 @@
 </g>
 <defs>
 <clipPath id="clip0_1_34932">
-<rect width="1em" height="1em" fill="white"/>
+<rect width="40" height="40" fill="white"/>
 </clipPath>
 </defs>
 </svg>

--- a/src/resources/img/svg/imprint.svg
+++ b/src/resources/img/svg/imprint.svg
@@ -10,7 +10,7 @@
 </g>
 <defs>
 <clipPath id="clip0_1_34905">
-<rect width="1em" height="1em" fill="white"/>
+<rect width="40" height="40" fill="white"/>
 </clipPath>
 </defs>
 </svg>

--- a/src/styles/components/siteFooter.less
+++ b/src/styles/components/siteFooter.less
@@ -46,11 +46,45 @@
        under a grey page. */
     padding: @spacing-sm;
     background: transparent;
+    /* Inherited by the standalone language trigger, whose hover tint and focus
+       ring follow `currentColor`. Below @screen-xl the stage variant is an
+       ordinary in-flow footer on the light surface, so it takes the light
+       surface's ink; the desktop block below flips it to white on the panel. */
+    color: @black-80-opacity;
 
     .footerMenu {
         padding-left: 0;
         border-bottom: 0;
+        /*
+         * ONE row — the defect the 100%-zoom review found was the MENU folding
+         * ("Impressum Datenschutz" on one line, the language entry on the next).
+         * The rule sits on the menu, not on the footer: the menu is two short
+         * words that always fit, so it can be held to a line safely. Holding the
+         * whole FOOTER to a line would be unsafe — `.publicLayout` sets
+         * `overflow-x: hidden`, so anything that did not fit would be clipped
+         * away instead of wrapped, and `disabledOverflow` has already removed
+         * antd's own collapse-to-"…" fallback. The optional version stamp may
+         * therefore still drop below; a wrapped build stamp is not a broken menu.
+         */
+        flex-wrap: nowrap;
         background-color: transparent;
+    }
+}
+
+/*
+ * No red bar under a footer entry.
+ *
+ * antd's horizontal menu marks the active/open entry with a bottom border in
+ * the primary colour. On this surface the primary colour is the brand red, and
+ * a red rule under "Datenschutz" on a sign-in screen reads as a validation
+ * error, not as a hover state. The entries already answer with an underline on
+ * hover (see below), which is the affordance that works on the dark panel.
+ */
+
+.layoutFooter .footerMenu.ant-menu-horizontal {
+    > .ant-menu-item::after,
+    > .ant-menu-submenu::after {
+        border-bottom: 0;
     }
 }
 
@@ -64,8 +98,13 @@
         left: 0;
         width: 40vw;
         justify-content: flex-start;
-        padding: @spacing-m @spacing-2xl;
+        /* Same gutter as the stage panel's own padding (`@stage-gutter`), so the
+           footer stays flush under the claim. It tightens below ~1500px because
+           40vw is simply not wide enough there for a fixed 80px gutter AND a
+           one-line footer — the gutter gives way, the row does not. */
+        padding: @spacing-m @stage-gutter;
         background: transparent;
+        color: @white;
         gap: @spacing-m;
 
         .footerMenu {
@@ -87,6 +126,16 @@
                     color: @white;
                     text-decoration: underline;
                 }
+
+                /* The trailing margin of the last entry used to stack on top of
+                   the footer's own gap, so the language control sat 35px from
+                   "Datenschutz" while the two legal entries sat 20px apart.
+                   Dropping it makes the spacing uniform AND gives the row back
+                   the width it needs at the narrow end of the desktop range. */
+
+                &:last-child {
+                    margin-right: 0;
+                }
             }
 
             .ant-menu-submenu-arrow,
@@ -101,6 +150,15 @@
                     color: @white;
                 }
             }
+        }
+
+        /* Same voice as the menu entries next to it — the control is separate,
+           the typography is not. */
+
+        .footerLanguage {
+            font-size: @fontSize-m;
+            font-weight: 700;
+            text-transform: uppercase;
         }
 
         .platformVersion {

--- a/src/styles/components/stage.less
+++ b/src/styles/components/stage.less
@@ -11,7 +11,9 @@
     flex-direction: column;
     align-items: flex-start;
     justify-content: flex-start;
-    padding: @spacing-2xl;
+    /* Vertical gutter stays the drawn 80px; the horizontal one is shared with
+       the stage footer (`@stage-gutter`) so claim and footer stay flush. */
+    padding: @spacing-2xl @stage-gutter;
     /* The desktop sidebar's own token (#594.13a) — the panel and the app shell
        must provably resolve to the SAME colour, not to two values that merely
        look alike. See the block comment on `--m3-on-background` in app.css for

--- a/src/styles/variables/_spacings.less
+++ b/src/styles/variables/_spacings.less
@@ -9,3 +9,13 @@
 @spacing-2xl: 80px;
 
 @mobileNavHeight: 77px;
+
+/*
+ * Inner gutter of the public stage panel — used by the panel itself and by the
+ * footer menu pinned to its bottom left, so the claim and the footer can never
+ * drift apart. It is a clamp, not the flat 80px it used to be: the panel is
+ * 40vw, so on a 1280px screen its gutters ate 160px of a 512px panel and the
+ * footer row wrapped onto a second line. It reaches the full @spacing-2xl from
+ * ~1500px up, which is where the design was drawn.
+ */
+@stage-gutter: clamp(@spacing-l, 5.3vw, @spacing-2xl);


### PR DESCRIPTION
## Problem

A 100% zoom review of the public sign-in surface found six defects: the footer row folded onto two lines, antd painted its red active bar under the open language entry, that entry's popup anchored beside the trigger instead of over it, the legal dialog's close action rendered the raw key `btn.close`, and its hero icon was a generic MUI gavel.

## What changed

- The language selector is no longer a submenu **item** of the footer menu but its own control (`FooterLanguageMenu`): a real button with a fixed 62px footprint (was 167px) and a `top`-placed Dropdown, which is antd's centred placement.
- `@stage-gutter` replaces the flat 80px inline padding on the stage panel **and** its footer, so the two cannot drift and the row fits 40vw below ~1510px. Only the optional version stamp may wrap — `.publicLayout` hides overflow and would clip instead.
- Removed antd's `.ant-menu-item::after` border: here the primary colour is the brand red, and a red rule under "Datenschutz" on a sign-in screen reads as a validation error.
- `cancelLabelKey` → `footer.legal.close`, which exists in both locales. `btn.close` existed in neither.
- Dialog uses `ImprintIcon`/`GdprIcon`. That surfaced a Figma export artefact: dpa/gdpr/imprint.svg clipped against `<rect width="1em">`, cropping the icon to ~40% at any font-size but 40.
- Dialog body sizes against the viewport minus the dialog chrome, so published legal texts scroll inside the sheet with title and close visible.

## Verification

- `npx vitest run` — 227 files, 1388 tests pass
- `npx eslint src --max-warnings=0`, `npx prettier src --check` — clean
- Screenshots per review item via `scripts/shootPublicFooter.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated footer language selector with supported-language options, active-language indication, and accessible controls.
  - Simplified footer navigation so legal notices and language selection are clearly separated.
- **Bug Fixes**
  - Improved legal notice dialogs with appropriate icons, corrected close-button labeling, keyboard-friendly scrolling, and better behavior for long content on mobile.
- **Style**
  - Refined footer, language menu, dialog, icon sizing, spacing, focus states, and responsive layout across screen sizes.
- **Tests**
  - Added coverage for legal notices, language switching, responsive dialog content, and footer variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->