### PR TITLE
fix(branding): decode tenant logo and favicon so they actually render

### DIFF
--- a/src/api/tenant/getPublicTenantData.ts
+++ b/src/api/tenant/getPublicTenantData.ts
@@ -1,7 +1,33 @@
 import { fetchData, FETCH_METHODS, FETCH_ERRORS } from '../fetchData';
 import { baseTenantPublicEndpoint } from '../../appConfig';
 import getLocationVariables from '../../utils/getLocationVariables';
+import { decodeTenantAsset } from '../../utils/decodeTenantAsset';
 import { AppConfigInterface } from '../../types/AppConfigInterface';
+
+const BRANDING_ASSETS = ['logo', 'favicon', 'associationLogo'] as const;
+
+/**
+ * TenantService HTML-encodes every stored string, so a base64 branding asset
+ * comes back with `+`/`=` as `&#43;`/`&#61;` and is not a decodable data URL
+ * (see {@link decodeTenantAsset}). Decoding here — at the ONE seam every public
+ * consumer reads through — is what makes the tenant logo appear on the sign-in
+ * stage and the tenant favicon in the browser tab. Doing it per consumer is how
+ * it got missed: the admin's upload preview decoded, the public surfaces did not.
+ */
+const decodeBrandingAssets = (result: any) => {
+    if (!result?.theming) {
+        return result;
+    }
+
+    const theming = { ...result.theming };
+    BRANDING_ASSETS.forEach((asset) => {
+        if (typeof theming[asset] === 'string') {
+            theming[asset] = decodeTenantAsset(theming[asset]);
+        }
+    });
+
+    return { ...result, theming };
+};
 
 /**
  * retrieve all needed public tenant data
@@ -36,7 +62,7 @@ const getPublicTenantData = (settings: AppConfigInterface) => {
         })
             .then((result) => {
                 // console.log('🔍 getPublicTenantData: SUCCESS - Result:', result);
-                return result;
+                return decodeBrandingAssets(result);
             })
             .catch((error) => {
                 // console.error('🔍 getPublicTenantData: ERROR:', error);

--- a/src/styles/components/stage.less
+++ b/src/styles/components/stage.less
@@ -23,8 +23,16 @@
        only artwork on the panel; the hardcoded Lottie fallback is gone. */
 
     .logo {
-        width: 200px;
-        height: 80px;
+        /*
+         * A box, not a strip. The old 200x80 assumed a wide wordmark; the
+         * uploaded platform logos are square (512x512 on dev), and `contain`
+         * inside an 80px-high strip shrank them to an 80px thumbnail lost in a
+         * 40vw panel. Height leads and width follows so a wide wordmark and a
+         * square mark both fill the same optical area.
+         */
+        width: auto;
+        max-width: 260px;
+        height: 140px;
 
         img {
             max-width: 100%;

--- a/src/utils/decodeTenantAsset.test.ts
+++ b/src/utils/decodeTenantAsset.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { decodeTenantAsset } from './decodeTenantAsset';
+
+/**
+ * Live evidence (dev, tenant `caritas-berlin`, 2026-07-31): the stored
+ * `theming.logo` carried 3,284 × `&#43;`, the favicon 249 × `&#43;` plus one
+ * `&#61;`. Every one of the three branding assets failed to decode in the
+ * browser (`ERR_INVALID_URL`), which is why the sign-in stage showed no logo
+ * and the tab kept the built-in favicon.
+ */
+describe('decodeTenantAsset', () => {
+    it('turns a TenantService-encoded data URL back into a decodable one', () => {
+        const stored = 'data:image/png;base64,iVBORw0KGgo&#43;abc&#43;def&#61;';
+
+        expect(decodeTenantAsset(stored)).toBe('data:image/png;base64,iVBORw0KGgo+abc+def=');
+    });
+
+    it('leaves an already-clean value untouched', () => {
+        const clean = 'data:image/png;base64,iVBORw0KGgo+abc/def=';
+
+        expect(decodeTenantAsset(clean)).toBe(clean);
+    });
+
+    it('handles hex entities and plain http urls', () => {
+        expect(decodeTenantAsset('data:image/png;base64,a&#x2B;b')).toBe('data:image/png;base64,a+b');
+        expect(decodeTenantAsset('https://assets.example.test/logo.png?a=1&amp;b=2')).toBe(
+            'https://assets.example.test/logo.png?a=1&b=2',
+        );
+    });
+
+    it('is empty-safe so a tenant without branding stays without branding', () => {
+        expect(decodeTenantAsset(undefined)).toBeUndefined();
+        expect(decodeTenantAsset(null)).toBeUndefined();
+        expect(decodeTenantAsset('')).toBeUndefined();
+    });
+
+    /** The decode must not route the value through markup parsing. */
+    it('does not turn markup in the value into anything but text', () => {
+        expect(decodeTenantAsset('data:image/png;base64,<img onerror=x>')).toBe(
+            'data:image/png;base64,<img onerror=x>',
+        );
+    });
+});

--- a/src/utils/decodeTenantAsset.ts
+++ b/src/utils/decodeTenantAsset.ts
@@ -1,0 +1,36 @@
+const NUMERIC_ENTITY = /&#(x[0-9a-f]+|\d+);/gi;
+
+/**
+ * Undo the HTML encoding TenantService applies to every stored string, for
+ * values that are URLs rather than markup — the branding assets (`theming.logo`,
+ * `theming.favicon`, `theming.associationLogo`).
+ *
+ * TenantService stores `+` as `&#43;` and `=` as `&#61;` (see {@link decodeHTML}
+ * for the same quirk on tenant names). Base64 payloads are full of both, so a
+ * stored logo comes back as
+ *
+ *   data:image/png;base64,iVBORw0KGgo…&#43;…&#43;…&#61;
+ *
+ * which is not a decodable data URL: the browser answers `ERR_INVALID_URL`, the
+ * `<img>` fires `onError`, and the stage panel simply drops the logo — the
+ * branding looks unimplemented rather than broken. The admin's own upload
+ * preview never showed this because it already decodes (`FormFileUploaderField`).
+ *
+ * Deliberately NOT implemented via `innerHTML` like {@link decodeHTML}: these
+ * values are pasted straight into `img[src]` / `link[rel=icon]`, so they must
+ * never take a detour through markup parsing. A plain numeric-entity decode is
+ * both safer and testable outside a DOM.
+ */
+export const decodeTenantAsset = (value?: string | null): string | undefined => {
+    if (!value) return undefined;
+
+    return value
+        .replace(NUMERIC_ENTITY, (_match, code: string) =>
+            String.fromCharCode(
+                code[0].toLowerCase() === 'x' ? Number.parseInt(code.slice(1), 16) : Number.parseInt(code, 10),
+            ),
+        )
+        .replace(/&amp;/g, '&');
+};
+
+export default decodeTenantAsset;

--- a/src/utils/getSafeFaviconUrl.ts
+++ b/src/utils/getSafeFaviconUrl.ts
@@ -1,12 +1,24 @@
 const VALID_DATA_IMAGE_URL = /^data:image\/[a-z0-9.+-]+(?:;[^,]*)?,/i;
 
+/**
+ * An HTML entity left in the payload means the value never got decoded on its
+ * way out of TenantService (`+` is stored as `&#43;`, see `decodeTenantAsset`).
+ * The prefix check alone waves such a string through — it looks like a data
+ * image URL — and the browser then silently fails to decode it, leaving the tab
+ * with a `<link rel=icon>` pointing at nothing. Better to keep the default
+ * favicon than to replace it with a broken one.
+ */
+const HTML_ENTITY = /&(?:#x?[0-9a-f]+|amp|lt|gt|quot);/i;
+
 export const getSafeFaviconUrl = (favicon?: string): string | undefined => {
     if (!favicon) return undefined;
 
     try {
         const url = new URL(favicon, window.location.origin);
         if (url.protocol === 'http:' || url.protocol === 'https:') return favicon;
-        if (url.protocol === 'data:' && VALID_DATA_IMAGE_URL.test(favicon)) return favicon;
+        if (url.protocol === 'data:' && VALID_DATA_IMAGE_URL.test(favicon) && !HTML_ENTITY.test(favicon)) {
+            return favicon;
+        }
     } catch {
         return undefined;
     }


### PR DESCRIPTION
## Problem

The tenant logo never appeared on the sign-in stage and the browser tab kept the built-in favicon, which read as "not implemented yet". The wiring was there all along — `Login` and `PasswordResetPageLayout` pass `theming.logo` to the Stage, `App.tsx` sets the favicon. The stored values were unusable.

TenantService HTML-encodes every string it stores. In a base64 payload that turns `+` into `&#43;` and `=` into `&#61;`. Measured on dev for tenant `caritas-berlin`: 3,284 such entities in `theming.logo`, 250 in the favicon, 480 in the association logo. All three answered `ERR_INVALID_URL`; the Stage's `onError` handler then removed the logo silently. The admin never saw it because its upload preview already decodes (`FormFileUploaderField`).

## What changed

- Decode the three branding assets in `getPublicTenantData` — the single seam every public consumer reads through. Decoding per consumer is how this got missed.
- `decodeTenantAsset` decodes numeric entities directly rather than via `innerHTML` like `decodeHTML`: these values go straight into `img[src]` and `link[rel=icon]` and must not take a detour through markup parsing.
- `getSafeFaviconUrl` rejects a still-encoded data URL instead of pointing the tab at a broken icon.
- Stage logo box is 140px tall with width following, instead of a 200x80 strip — the uploaded logos are square (512x512) and `contain` shrank them to a thumbnail in a 40vw panel.

## Verification

Against live dev data: logo/favicon/associationLogo went from `ERROR` to `ok 512x512 / ok 48x48 / ok 512x512`. 412 tests pass; eslint `--max-warnings=0` and prettier `--check` clean.

Backend counterpart (stops new saves from being corrupted): OpenResilienceInitiative/ORISO-TenantService#158

🤖 Generated with [Claude Code](https://claude.com/claude-code)