### PR TITLE
Show platform version for tenant admins

### DIFF
--- a/src/components/Layout/ProtectedPageLayoutWrapper.tsx
+++ b/src/components/Layout/ProtectedPageLayoutWrapper.tsx
@@ -137,7 +137,7 @@ const ProtectedPageLayoutWrapper = ({ children }: any) => {
                 <Layout className={classNames(styles.mainContent)}>
                     <Content className={styles.content}>
                         {children}
-                        {!hasRole(UserRole.TenantAdmin) && <SiteFooter />}
+                        <SiteFooter />
                     </Content>
                 </Layout>
             </Layout>


### PR DESCRIPTION
## Summary
- Always render the Admin `SiteFooter` in protected layouts, including tenant-admin sessions.
- Keeps the Helm-provided platform version visible for tenant admins.

## Root cause
Tenant-admin users skipped `SiteFooter`, so the version injected by Helm was present in runtime config but never mounted in the UI.

## Validation
- `npm ci`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The site footer now appears consistently across all protected pages, including pages accessed by tenant administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->