### PR TITLE
feat(theme): seed-derived tokens for the mobile nav active indicator

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -193,6 +193,12 @@
     --admin-field-surface-hover: #f6f3f3;
     --admin-field-selected-surface: #ffe2de;
     --admin-field-selected-text: #930008;
+    /* Mobile bottom-navigation active indicator (Figma 56576:34607). The deep
+       brand red pill behind the selected destination's icon; the icon on top is
+       the readable foreground. Seed-derived at runtime by computeOrisoPalette —
+       these static values must match what it writes for the default seed. */
+    --admin-nav-indicator-surface: #410001;
+    --admin-nav-indicator-icon: #ffffff;
     --admin-status-success: var(--tag-success, #0a882f);
     --admin-status-success-container: color-mix(
         in srgb,

--- a/src/utils/applyAdminTheme.test.ts
+++ b/src/utils/applyAdminTheme.test.ts
@@ -238,4 +238,20 @@ describe('applyAdminInvertedTheme', () => {
             `${onRole} (${tokens[onRole]}) on ${surface} (${tokens[surface]}) = ${ratio.toFixed(2)}:1`,
         ).toBeGreaterThanOrEqual(4.5);
     });
+
+    it('keeps the inverted nav indicator icon readable on a saturated custom accent (#00cc00)', () => {
+        // Regression for readableOn() using a raw-sRGB luminance shortcut: a
+        // saturated green reads as "light" under that shortcut even though its
+        // true WCAG luminance is low, so white text was picked and only cleared
+        // ~2.18:1 against the pill instead of the required 4.5:1.
+        const { tokens } = computeOrisoPalette({ accentDark: BENCHMARK_SEED, accentLight: '#00cc00' }, 'inverted');
+        const onRole = '--admin-nav-indicator-icon';
+        const surface = '--admin-nav-indicator-surface';
+        const ratio = wcagRatio(tokens[onRole], tokens[surface]);
+
+        expect(
+            ratio,
+            `${onRole} (${tokens[onRole]}) on ${surface} (${tokens[surface]}) = ${ratio.toFixed(2)}:1`,
+        ).toBeGreaterThanOrEqual(4.5);
+    });
 });

--- a/src/utils/applyAdminTheme.test.ts
+++ b/src/utils/applyAdminTheme.test.ts
@@ -228,6 +228,7 @@ describe('applyAdminInvertedTheme', () => {
         ['--m3-on-secondary-container', '--m3-secondary-container'],
         ['--m3-on-error', '--m3-error'],
         ['--m3-on-error-container', '--m3-error-container'],
+        ['--admin-nav-indicator-icon', '--admin-nav-indicator-surface'],
     ])('%s on %s meets WCAG-AA body contrast', (onRole, surface) => {
         const { tokens } = computeOrisoPalette({ accentDark: BENCHMARK_SEED }, 'inverted');
         const ratio = wcagRatio(tokens[onRole], tokens[surface]);

--- a/src/utils/theme/orisoScheme.ts
+++ b/src/utils/theme/orisoScheme.ts
@@ -68,6 +68,12 @@ const DEFAULT_ACCENT_LIGHT = '#ffe2de';
 const DEFAULT_ACCENT_DIM = '#ffb4aa';
 const DEFAULT_ACCENT_ACTION = '#cc1e1c';
 /**
+ * Active-indicator tone of the mobile bottom navigation for the default seed
+ * #A5000A, taken 1:1 from Figma 56576:34607 ("Figma hat Vorrang"). Numerically
+ * identical to SYSTEM_ALERT below, but a different role — do not merge them.
+ */
+const DEFAULT_NAV_INDICATOR = '#410001';
+/**
  * The dark stage surface: the desktop sidebar AND the public sign-in stage
  * panel (#594.13a). Figma calls the style `M3/sys/light/on-background`, so the
  * token keeps that name although this palette then uses an M3 *system* name in
@@ -127,6 +133,7 @@ const defaultAccentTokens = (accentDark: string, explicitAccentLight?: string) =
             accentDim: DEFAULT_ACCENT_DIM,
             accentAction: DEFAULT_ACCENT_ACTION,
             onAccentLightVariant: '#930008',
+            navIndicator: DEFAULT_NAV_INDICATOR,
         };
     }
 
@@ -137,10 +144,27 @@ const defaultAccentTokens = (accentDark: string, explicitAccentLight?: string) =
         accentDim: mix(accentLight, accentDark, 0.16),
         accentAction: accentDark,
         onAccentLightVariant: mix(accentDark, '#000000', 0.12),
+        // 0.6 towards black lands #a5000a on #420004 — i.e. the same tone the
+        // default seed pins to DEFAULT_NAV_INDICATOR, so custom seeds stay in
+        // the same depth register as Figma.
+        navIndicator: mix(accentDark, '#000000', 0.6),
     };
 };
 
 const readableOn = (background: string) => (luminance(background) > 0.62 ? DARK_TEXT : '#ffffff');
+
+/**
+ * Mobile bottom-navigation active indicator (Figma 56576:34607): the deep brand
+ * red 56×32 pill behind the selected destination's icon. It is a SURFACE, so
+ * the icon on top is {@link readableOn} of it — never the other way round. Kept
+ * as its own `--admin-*` pair instead of borrowing an M3 `on-*` role name,
+ * because the M3 nav bar normally uses `secondary-container` here and ORISO
+ * deliberately deviates. Static fallbacks live in src/app.css.
+ */
+const adminNavTokens = (navIndicator: string) => ({
+    '--admin-nav-indicator-surface': navIndicator,
+    '--admin-nav-indicator-icon': readableOn(navIndicator),
+});
 
 const invertedTokens = (accentDark: string, accentLight: string, accentDim: string, onAccentLightVariant: string) => {
     const primary = accentLight;
@@ -150,6 +174,9 @@ const invertedTokens = (accentDark: string, accentLight: string, accentDim: stri
     return {
         ...ADMIN_TABLE_TOKENS,
         ...adminFieldTokens(accentLight, onAccentLightVariant),
+        // Inverted scheme flips the indicator to the LIGHT accent: the deep red
+        // pill of the light scheme would vanish against the dark surface.
+        ...adminNavTokens(accentLight),
         '--m3-primary': primary,
         '--m3-on-primary': readableOn(primary),
         '--m3-primary-container': primaryContainer,
@@ -196,7 +223,7 @@ const invertedTokens = (accentDark: string, accentLight: string, accentDim: stri
 export const computeOrisoPalette = (seeds: TenantSeeds, scheme: OrisoSchemeName = 'light'): OrisoPaletteResult => {
     const accentDark = normalizeHex(getAccentDark(seeds)) ?? DEFAULT_ACCENT_DARK;
     const explicitAccentLight = normalizeHex(getAccentLight(seeds));
-    const { accentLight, accentDim, accentAction, onAccentLightVariant } = defaultAccentTokens(
+    const { accentLight, accentDim, accentAction, onAccentLightVariant, navIndicator } = defaultAccentTokens(
         accentDark,
         explicitAccentLight,
     );
@@ -217,6 +244,7 @@ export const computeOrisoPalette = (seeds: TenantSeeds, scheme: OrisoSchemeName 
         tokens: {
             ...ADMIN_TABLE_TOKENS,
             ...adminFieldTokens(accentLight, onAccentLightVariant),
+            ...adminNavTokens(navIndicator),
             '--m3-primary': accentDark,
             '--m3-on-primary': onAccentDark,
             '--m3-primary-container': accentLight,

--- a/src/utils/theme/orisoScheme.ts
+++ b/src/utils/theme/orisoScheme.ts
@@ -43,9 +43,23 @@ const mix = (a: string, b: string, amount: number) => {
     );
 };
 
-const luminance = (hex: string) => {
+const srgbChannelToLinear = (channel: number) => {
+    const c = channel / 255;
+    return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+};
+
+// WCAG relative luminance (not the raw-sRGB shortcut): channels are gamma-decoded
+// before weighting, or saturated colors like #00cc00 come out lighter than they
+// actually render and readableOn() below picks a foreground that fails contrast.
+const relativeLuminance = (hex: string) => {
     const { r, g, b } = hexToRgb(hex);
-    return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+    return 0.2126 * srgbChannelToLinear(r) + 0.7152 * srgbChannelToLinear(g) + 0.0722 * srgbChannelToLinear(b);
+};
+
+const contrastRatio = (hexA: string, hexB: string) => {
+    const a = relativeLuminance(hexA);
+    const b = relativeLuminance(hexB);
+    return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
 };
 
 const saturation = (hex: string) => {
@@ -151,7 +165,8 @@ const defaultAccentTokens = (accentDark: string, explicitAccentLight?: string) =
     };
 };
 
-const readableOn = (background: string) => (luminance(background) > 0.62 ? DARK_TEXT : '#ffffff');
+const readableOn = (background: string) =>
+    contrastRatio(DARK_TEXT, background) >= contrastRatio('#ffffff', background) ? DARK_TEXT : '#ffffff';
 
 /**
  * Mobile bottom-navigation active indicator (Figma 56576:34607): the deep brand
@@ -227,9 +242,9 @@ export const computeOrisoPalette = (seeds: TenantSeeds, scheme: OrisoSchemeName 
         accentDark,
         explicitAccentLight,
     );
-    const onAccentDark = luminance(accentDark) > 0.62 ? '#141c25' : '#ffffff';
-    const onAccentLight = luminance(accentLight) > 0.62 ? '#141c25' : '#ffffff';
-    const onAccentAction = luminance(accentAction) > 0.62 ? '#141c25' : '#ffffff';
+    const onAccentDark = readableOn(accentDark);
+    const onAccentLight = readableOn(accentLight);
+    const onAccentAction = readableOn(accentAction);
     const tooPale = saturation(accentDark) < 0.12;
 
     if (scheme === 'inverted') {


### PR DESCRIPTION
Closes #624 — part of #622.

**Stacked PR.** Base is `pre-dev`; retarget to `pre-dev` once the parent merges. Review only the top commit.

The M3 navigation bar marks the selected destination with a filled pill behind
its icon. Hard-coding Figma's #410001 would break tenant theming, so the tone is
derived from the tenant seed and its foreground computed with readableOn().

**Verification:** `npm run test`, `npx eslint . --max-warnings=0`, `npx prettier . --check`, `npm run build` — all green on the full stack.

## Reviewer test plan
- [ ] `npm run test -- src/utils/applyAdminTheme.test.ts` passes, including the new indicator contrast pair
- [ ] With the default tenant seed, the selected destination's pill is the deep brand red and its icon is white
- [ ] Configure a tenant with a different primary colour → the pill follows that colour and the icon stays readable on it
- [ ] Nothing else in Admin changes colour (spot-check a form and a table on desktop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added mobile bottom-navigation indicator colors for light, custom, and inverted themes.
  * Improved visual consistency and icon readability for the active navigation state.
  * Ensured indicator colors adapt appropriately across supported theme variations.

* **Tests**
  * Added accessibility coverage to verify sufficient contrast between the navigation indicator and its icon.
  * Confirmed the active navigation state remains readable in inverted themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->