### PR TITLE
feat(nav): M3NavigationBar with vertical segments

### DIFF
--- a/src/components/M3NavigationBar/M3NavigationBar.stories.tsx
+++ b/src/components/M3NavigationBar/M3NavigationBar.stories.tsx
@@ -1,0 +1,139 @@
+import {
+    Assessment,
+    AssessmentOutlined,
+    HolidayVillage,
+    HolidayVillageOutlined,
+    Link as LinkIcon,
+    LinkOutlined,
+    MoreVert,
+    People,
+    PeopleOutlined,
+    RealEstateAgent,
+    RealEstateAgentOutlined,
+    Settings,
+    SettingsOutlined,
+} from '@mui/icons-material';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { M3NavigationBar, type M3NavigationBarItem } from './M3NavigationBar';
+
+const settings: M3NavigationBarItem = {
+    key: 'settings',
+    label: 'Einstellungen',
+    icon: <SettingsOutlined />,
+    activeIcon: <Settings />,
+};
+const tenants: M3NavigationBarItem = {
+    key: 'tenants',
+    label: 'Träger',
+    icon: <HolidayVillageOutlined />,
+    activeIcon: <HolidayVillage />,
+};
+const agency: M3NavigationBarItem = {
+    key: 'agency',
+    label: 'Beratungsstelle',
+    icon: <RealEstateAgentOutlined />,
+    activeIcon: <RealEstateAgent />,
+};
+const users: M3NavigationBarItem = {
+    key: 'users',
+    label: 'Nutzer*innen',
+    icon: <PeopleOutlined />,
+    activeIcon: <People />,
+};
+const statistics: M3NavigationBarItem = {
+    key: 'statistics',
+    label: 'Statistiken',
+    icon: <AssessmentOutlined />,
+    activeIcon: <Assessment />,
+};
+const links: M3NavigationBarItem = {
+    key: 'links',
+    label: 'Links',
+    icon: <LinkOutlined />,
+    activeIcon: <LinkIcon />,
+};
+
+const more = {
+    label: 'Mehr',
+    icon: <MoreVert />,
+    onClick: () => {},
+};
+
+const meta = {
+    title: 'Molecules/M3NavigationBar',
+    component: M3NavigationBar,
+    parameters: {
+        layout: 'centered',
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/design/RTUi1rcrEWECXz8rNFmj7Q/Design-System-M3_ORISO?node-id=56576-34607',
+        },
+    },
+    args: {
+        ariaLabel: 'Hauptnavigation',
+        activeKey: 'settings',
+        lang: 'de',
+        items: [settings, tenants],
+        more,
+    },
+    decorators: [
+        // The bar always sits on the M3 surface-container of AppBottomBar —
+        // rendering it on Storybook's white canvas would hide contrast problems.
+        // Width comes from the story so each segment count gets its real slot
+        // width (Figma: 96px per segment).
+        (Story, context) => (
+            <div
+                style={{
+                    width: (context.parameters.barWidth as number | undefined) ?? 288,
+                    padding: 16,
+                    background: 'var(--m3-surface-container, #f0edee)',
+                    borderRadius: '12px 12px 0 0',
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
+} satisfies Meta<typeof M3NavigationBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Figma parity: two destinations plus the overflow slot, "Einstellungen" selected. */
+export const ThreeSegments: Story = {};
+
+export const FourSegments: Story = {
+    args: { items: [settings, tenants, agency], activeKey: 'tenants' },
+    parameters: { barWidth: 384 },
+};
+
+/** M3 caps the bar at five destinations — this is the widest legal layout. */
+export const FiveSegments: Story = {
+    args: { items: [settings, tenants, agency, users], activeKey: 'users' },
+    parameters: { barWidth: 480 },
+};
+
+/** Without overflow: every destination fits, so no "Mehr" segment is rendered. */
+export const WithoutOverflow: Story = {
+    args: { items: [settings, tenants, agency], more: undefined, activeKey: 'agency' },
+};
+
+/**
+ * The labels that break today's bottom bar. They must wrap inside their segment
+ * instead of pushing the neighbours around ("Nutzer* innen" in the old bar).
+ */
+export const LongLabels: Story = {
+    args: {
+        items: [
+            { ...agency, label: 'Beratungsstelle' },
+            { ...users, label: 'Nutzer*innen' },
+        ],
+        activeKey: 'agency',
+    },
+};
+
+/** Narrowest supported viewport: 320px minus the search pill and the bar padding. */
+export const NarrowViewport: Story = {
+    args: { items: [statistics, links], activeKey: 'statistics' },
+    parameters: { barWidth: 200 },
+};

--- a/src/components/M3NavigationBar/M3NavigationBar.test.tsx
+++ b/src/components/M3NavigationBar/M3NavigationBar.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { M3NavigationBar, type M3NavigationBarItem } from './M3NavigationBar';
+
+const items: M3NavigationBarItem[] = [
+    { key: 'settings', label: 'Einstellungen', icon: <svg />, activeIcon: <svg data-testid="settings-filled" /> },
+    { key: 'tenants', label: 'Träger', icon: <svg /> },
+];
+
+const renderBar = (props: Partial<React.ComponentProps<typeof M3NavigationBar>> = {}) =>
+    render(
+        <MemoryRouter>
+            <M3NavigationBar ariaLabel="Hauptnavigation" items={items} activeKey="settings" {...props} />
+        </MemoryRouter>,
+    );
+
+describe('M3NavigationBar', () => {
+    it('marks only the active destination with aria-current', () => {
+        renderBar();
+
+        expect(screen.getByText('Einstellungen').closest('[aria-current]')).not.toBeNull();
+        expect(screen.getByText('Träger').closest('[aria-current]')).toBeNull();
+    });
+
+    it('renders the filled icon variant for the active destination only', () => {
+        renderBar();
+
+        expect(screen.getByTestId('settings-filled')).toBeInTheDocument();
+    });
+
+    it('reports the selected key', async () => {
+        const onSelect = vi.fn();
+        renderBar({ onSelect });
+
+        await userEvent.click(screen.getByText('Träger'));
+
+        expect(onSelect).toHaveBeenCalledWith('tenants');
+    });
+
+    it('renders destinations with a route as links', () => {
+        renderBar({ items: [{ ...items[0], to: '/admin/settings' }] });
+
+        expect(screen.getByRole('link', { name: /Einstellungen/ })).toHaveAttribute('href', '/admin/settings');
+    });
+
+    it('exposes the overflow slot as a collapsed menu button', async () => {
+        const onClick = vi.fn();
+        renderBar({ more: { label: 'Mehr', icon: <svg />, onClick } });
+
+        const moreButton = screen.getByRole('button', { name: /Mehr/ });
+
+        expect(moreButton).toHaveAttribute('aria-haspopup', 'menu');
+        expect(moreButton).toHaveAttribute('aria-expanded', 'false');
+
+        await userEvent.click(moreButton);
+
+        expect(onClick).toHaveBeenCalled();
+    });
+
+    it('omits the overflow slot when every destination fits', () => {
+        renderBar();
+
+        expect(screen.queryByRole('button', { name: /Mehr/ })).not.toBeInTheDocument();
+    });
+});

--- a/src/components/M3NavigationBar/M3NavigationBar.tsx
+++ b/src/components/M3NavigationBar/M3NavigationBar.tsx
@@ -1,0 +1,160 @@
+import type { ReactNode } from 'react';
+import classNames from 'classnames';
+import { Link } from 'react-router-dom';
+import styles from './m3NavigationBar.module.scss';
+
+export interface M3NavigationBarItem {
+    /** Stable key for the list item and for `onSelect`. */
+    key: string;
+    /** Visible + accessible label. */
+    label: string;
+    /** 24px glyph shown while the item is not selected. */
+    icon: ReactNode;
+    /**
+     * Filled 24px glyph shown while the item is selected. M3 pairs the active
+     * indicator with the filled icon variant; falls back to `icon` when the
+     * icon set has no filled twin.
+     */
+    activeIcon?: ReactNode;
+    /** Route to navigate to. Without it the item renders as a plain button. */
+    to?: string;
+}
+
+export interface M3NavigationBarProps {
+    /** Accessible name of the navigation landmark. */
+    ariaLabel: string;
+    /**
+     * Destinations to render. M3 caps a navigation bar at 3–5 destinations —
+     * anything beyond that belongs behind `more`. The component does not slice
+     * the list itself; the caller decides what fits (see `useNavOverflow`).
+     */
+    items: M3NavigationBarItem[];
+    /** Key of the selected destination. */
+    activeKey?: string;
+    /** Fired with the item key on activation (also for `to` items). */
+    onSelect?: (key: string) => void;
+    /** Trailing overflow slot ("Mehr"). Rendered as the last segment. */
+    more?: {
+        label: string;
+        icon: ReactNode;
+        onClick: () => void;
+        /** Reflected as `aria-expanded` — set while the overflow sheet is open. */
+        expanded?: boolean;
+    };
+    /**
+     * Collapses the bar down to the `more` segment alone, rendered as a bare
+     * 48×48 icon button. Used while the search occupies the row: the search may
+     * take every pixel it wants, but this one button always survives, so the
+     * user can open the full destination list without closing the search first.
+     */
+    collapsed?: boolean;
+    /** BCP-47 language tag applied to the labels. */
+    lang?: string;
+    className?: string;
+}
+
+const ItemContent = ({ item, isActive, lang }: { item: M3NavigationBarItem; isActive: boolean; lang?: string }) => (
+    <>
+        <span className={classNames(styles.indicator, { [styles.indicatorActive]: isActive })}>
+            <span className={styles.glyph} aria-hidden>
+                {isActive ? item.activeIcon ?? item.icon : item.icon}
+            </span>
+        </span>
+        <span className={classNames(styles.label, { [styles.labelActive]: isActive })} lang={lang}>
+            {item.label}
+        </span>
+    </>
+);
+
+/**
+ * Material-3 navigation bar with vertical (icon-over-label) items, per Figma
+ * 56576:34607. Presentational only: it holds no permission, routing or
+ * overflow logic, so it renders deterministically in Storybook — the same split
+ * as {@link AdminSidebar} (#283). The caller resolves which destinations a user
+ * may see and how many of them fit.
+ *
+ * The selected item gets the M3 active indicator: a 56×32 pill in the deep
+ * brand red (`--admin-nav-indicator-surface`) behind the filled icon.
+ */
+export const M3NavigationBar = ({
+    activeKey,
+    ariaLabel,
+    className,
+    collapsed = false,
+    items,
+    lang,
+    more,
+    onSelect,
+}: M3NavigationBarProps) => {
+    const overflowButton = more && (
+        <button
+            type="button"
+            className={classNames(styles.item, { [styles.itemIconOnly]: collapsed })}
+            aria-haspopup="menu"
+            aria-expanded={more.expanded ?? false}
+            aria-label={collapsed ? more.label : undefined}
+            onClick={more.onClick}
+        >
+            {collapsed ? (
+                <span className={styles.glyph} aria-hidden>
+                    {more.icon}
+                </span>
+            ) : (
+                <ItemContent item={{ key: 'more', label: more.label, icon: more.icon }} isActive={false} lang={lang} />
+            )}
+        </button>
+    );
+
+    if (collapsed) {
+        return (
+            <nav className={classNames(styles.bar, styles.barCollapsed, className)} aria-label={ariaLabel}>
+                {overflowButton}
+            </nav>
+        );
+    }
+
+    return (
+        <nav className={classNames(styles.bar, className)} aria-label={ariaLabel}>
+            {items.map((item) => {
+                const isActive = item.key === activeKey;
+
+                if (item.to) {
+                    return (
+                        // `Link`, not `NavLink`: NavLink overwrites any
+                        // `aria-current` it is given with the result of its own
+                        // route match, which would silently drop the marking on
+                        // every destination whose active state is decided some
+                        // other way (the sidebar's `activeMatch` routes, or a
+                        // caller that pins the current section). `activeKey` is
+                        // this component's single source of truth.
+                        <Link
+                            key={item.key}
+                            to={item.to}
+                            className={styles.item}
+                            aria-current={isActive ? 'page' : undefined}
+                            onClick={() => onSelect?.(item.key)}
+                        >
+                            <ItemContent item={item} isActive={isActive} lang={lang} />
+                        </Link>
+                    );
+                }
+
+                return (
+                    <button
+                        key={item.key}
+                        type="button"
+                        className={styles.item}
+                        aria-current={isActive ? 'page' : undefined}
+                        onClick={() => onSelect?.(item.key)}
+                    >
+                        <ItemContent item={item} isActive={isActive} lang={lang} />
+                    </button>
+                );
+            })}
+
+            {overflowButton}
+        </nav>
+    );
+};
+
+export default M3NavigationBar;

--- a/src/components/M3NavigationBar/index.ts
+++ b/src/components/M3NavigationBar/index.ts
@@ -1,0 +1,1 @@
+export { M3NavigationBar, type M3NavigationBarItem, type M3NavigationBarProps } from './M3NavigationBar';

--- a/src/components/M3NavigationBar/m3NavigationBar.module.scss
+++ b/src/components/M3NavigationBar/m3NavigationBar.module.scss
@@ -1,0 +1,124 @@
+/* Material-3 navigation bar, vertical items (Figma 56576:34607).
+   Geometry is taken 1:1 from the design: 64px tall, every segment an equal
+   fraction of the row, a 56×32 active-indicator pill and a 12/16/0.5
+   label-medium caption underneath. */
+
+.bar {
+    display: flex;
+    height: 64px;
+    align-items: center;
+    justify-content: center;
+    overflow: clip;
+}
+
+/* Search-expanded state: only the overflow button is left, so the bar must not
+   claim any width beyond that one 48px touch target. */
+.barCollapsed {
+    flex: 0 0 auto;
+}
+
+.itemIconOnly {
+    width: 48px;
+    min-width: 48px;
+    flex: 0 0 48px;
+    justify-content: center;
+    padding: 0;
+}
+
+.item {
+    display: flex;
+    height: 100%;
+    min-width: 0;
+    flex: 1 0 0;
+    flex-direction: column;
+    align-items: center;
+    /* 4px inline padding keeps neighbouring labels from touching once the
+       segments get narrow; Figma's 96px slot has the same optical gap. */
+    padding: 6px 4px;
+    border: 0;
+    background: none;
+    color: inherit;
+    cursor: pointer;
+    font-family: inherit;
+    gap: 4px;
+    text-decoration: none;
+
+    &:focus-visible {
+        border-radius: 12px;
+        outline: 2px solid var(--m3-secondary, #4c555f);
+        outline-offset: 2px;
+    }
+}
+
+.indicator {
+    display: flex;
+    width: 56px;
+    height: 32px;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border-radius: 16px;
+    overflow: clip;
+    transition: background 140ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.item:hover .indicator:not(.indicatorActive) {
+    /* M3 hover state layer: 8% of the on-surface role over the bar surface. */
+    background: color-mix(in srgb, var(--m3-on-surface-variant, #444748) 8%, transparent);
+}
+
+.indicatorActive {
+    background: var(--admin-nav-indicator-surface, #410001);
+
+    .glyph {
+        color: var(--admin-nav-indicator-icon, #ffffff);
+    }
+}
+
+.glyph {
+    display: inline-flex;
+    width: 24px;
+    height: 24px;
+    align-items: center;
+    justify-content: center;
+    color: var(--m3-on-surface-variant, #444748);
+
+    > svg {
+        display: block;
+        width: 24px;
+        height: 24px;
+    }
+
+    :global {
+        .anticon {
+            font-size: 24px;
+            line-height: 1;
+        }
+    }
+}
+
+/* Single line, then ellipsis — the 64px bar has room for exactly one 16px line
+   below the 32px indicator, so wrapping would either clip the second line or
+   push the whole shelf taller. A truncated label means the segment is too
+   narrow for its destination; the answer is to move a destination into "Mehr",
+   which is the caller's call (see useNavOverflow), not this component's. */
+.label {
+    overflow: hidden;
+    /* `width`, not `min-width`: a min-width lets the box grow past the segment
+       when the text is wider, and then there is nothing left for the ellipsis
+       to clip — the label just spills over its neighbour. */
+    width: 100%;
+    min-width: 0;
+    color: var(--m3-on-surface-variant, #444748);
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.5px;
+    line-height: 16px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.labelActive {
+    color: var(--m3-secondary, #4c555f);
+}


### PR DESCRIPTION
Closes #625 — part of #622.

**Stacked PR.** Base is `feat/admin-m3-nav-01-tokens`; retarget to `pre-dev` once the parent merges. Review only the top commit.

Presentational only — no permissions, routing or overflow logic, so it renders
deterministically in Storybook. Labels are single-line with ellipsis because the
64px bar fits exactly one 16px line below the 32px indicator.

Uses Link rather than NavLink: NavLink overwrites any aria-current it is given
with its own route match, which would drop the marking on destinations whose
active state is decided by the caller.

**Verification:** `npm run test`, `npx eslint . --max-warnings=0`, `npx prettier . --check`, `npm run build` — all green on the full stack.

## Reviewer test plan
- [ ] In Storybook, `Molecules/M3NavigationBar` renders at 412px matching the Figma frame (compare side by side)
- [ ] The selected segment shows the filled icon on the coloured pill; the others show outlined icons
- [ ] With a long label ("Beratungsstelle") in a narrow bar, the text ellipsises — it never wraps into a second line or overlaps its neighbour
- [ ] Tab through the segments: each one takes focus with a visible focus ring
- [ ] With a screen reader, the current destination is announced as the current page
- [ ] The Storybook a11y panel reports no violations on every story of this component