### PR TITLE
feat(nav): useNavOverflow — show only the destinations that fit

### DIFF
--- a/src/hooks/useNavOverflow.hook.ts
+++ b/src/hooks/useNavOverflow.hook.ts
@@ -1,0 +1,105 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+
+/**
+ * Narrowest a navigation segment may get before its destination has to move
+ * into the overflow menu. Figma lays the bar out at 96px per segment
+ * (288 / 3 at 412px), but the design itself tolerates less: at 412px the bar
+ * gives the navigation 276px and still packs three segments into it. 72px is
+ * the point where a 12px label stops being readable — "Statistiken" fits,
+ * "Beratungsstelle" ellipsises, anything narrower is decoration.
+ */
+export const DEFAULT_MIN_SLOT_WIDTH = 72;
+
+/** M3 caps a navigation bar at five destinations, overflow segment included. */
+export const DEFAULT_MAX_SEGMENTS = 5;
+
+export interface UseNavOverflowOptions {
+    /** How many destinations the user is allowed to see in total. */
+    itemCount: number;
+    minSlotWidth?: number;
+    maxSegments?: number;
+}
+
+export interface NavOverflow {
+    /** Attach to the element that gives the navigation its width. */
+    ref: (node: HTMLElement | null) => void;
+    /** How many destinations to render in the bar — slice `items` to this. */
+    visibleCount: number;
+    /** Whether the remaining destinations need an overflow ("Mehr") segment. */
+    hasOverflow: boolean;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+export const resolveNavOverflow = (
+    width: number,
+    { itemCount, minSlotWidth = DEFAULT_MIN_SLOT_WIDTH, maxSegments = DEFAULT_MAX_SEGMENTS }: UseNavOverflowOptions,
+): Omit<NavOverflow, 'ref'> => {
+    if (itemCount <= 0) {
+        return { visibleCount: 0, hasOverflow: false };
+    }
+
+    // Unmeasured (width 0) resolves to the narrowest layout. The hook measures
+    // in a layout effect, so this state is never painted in the browser; the
+    // conservative choice only shows up where there is no layout at all — SSR
+    // and jsdom — where claiming five segments fit would be a lie.
+    const segments = width > 0 ? clamp(Math.floor(width / minSlotWidth), 1, maxSegments) : 1;
+
+    if (itemCount <= segments) {
+        return { visibleCount: itemCount, hasOverflow: false };
+    }
+
+    // The overflow segment costs one slot, so it is the destinations that give
+    // way — never the "Mehr" button itself, which must always stay reachable.
+    return { visibleCount: Math.max(0, segments - 1), hasOverflow: true };
+};
+
+/**
+ * Decides how many navigation destinations fit into the bottom bar at the
+ * current width, and whether an overflow segment is needed for the rest.
+ *
+ * Measures the element the returned `ref` is attached to — that element is the
+ * navigation's flex slot, whose width is decided by the bar (and shrinks when
+ * the search expands), not by the segments inside it. So this reports available
+ * space, not content width, and cannot feed back into itself.
+ */
+export const useNavOverflow = (options: UseNavOverflowOptions): NavOverflow => {
+    const { itemCount, minSlotWidth, maxSegments } = options;
+    const elementRef = useRef<HTMLElement | null>(null);
+    const [width, setWidth] = useState(0);
+
+    const measure = useCallback(() => {
+        const element = elementRef.current;
+
+        if (element) {
+            setWidth(element.getBoundingClientRect().width);
+        }
+    }, []);
+
+    const ref = useCallback((node: HTMLElement | null) => {
+        elementRef.current = node;
+    }, []);
+
+    // Layout effect, not effect: measuring after paint would show one frame of
+    // the fallback layout on every mount.
+    useLayoutEffect(() => {
+        measure();
+
+        const element = elementRef.current;
+
+        if (!element || typeof ResizeObserver === 'undefined') {
+            window.addEventListener('resize', measure);
+            return () => window.removeEventListener('resize', measure);
+        }
+
+        const observer = new ResizeObserver(measure);
+
+        observer.observe(element);
+
+        return () => observer.disconnect();
+    }, [measure]);
+
+    return { ref, ...resolveNavOverflow(width, { itemCount, minSlotWidth, maxSegments }) };
+};
+
+export default useNavOverflow;

--- a/src/hooks/useNavOverflow.test.tsx
+++ b/src/hooks/useNavOverflow.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveNavOverflow, useNavOverflow, type UseNavOverflowOptions } from './useNavOverflow.hook';
+
+describe('resolveNavOverflow', () => {
+    const at = (width: number, options: Partial<UseNavOverflowOptions> = {}) =>
+        resolveNavOverflow(width, { itemCount: 7, ...options });
+
+    it('shows every destination when they all fit', () => {
+        expect(at(400, { itemCount: 3 })).toEqual({ visibleCount: 3, hasOverflow: false });
+    });
+
+    it('reproduces the Figma layout: 2 destinations plus overflow at 412px', () => {
+        // 412px bar − 32 padding − 88 search pill − 16 gap = 276px for the nav.
+        expect(at(276)).toEqual({ visibleCount: 2, hasOverflow: true });
+    });
+
+    it('keeps the overflow button and drops destinations on a 320px phone', () => {
+        // 320 − 32 − 88 − 16 = 184px, room for two segments.
+        expect(at(184)).toEqual({ visibleCount: 1, hasOverflow: true });
+    });
+
+    it('never drops the overflow segment itself, however narrow the bar gets', () => {
+        expect(at(40)).toEqual({ visibleCount: 0, hasOverflow: true });
+        expect(at(0)).toEqual({ visibleCount: 0, hasOverflow: true });
+    });
+
+    it('respects the M3 cap of five segments on a wide viewport', () => {
+        expect(at(2000)).toEqual({ visibleCount: 4, hasOverflow: true });
+    });
+
+    it('does not invent an overflow when the cap is not exceeded', () => {
+        expect(at(2000, { itemCount: 5 })).toEqual({ visibleCount: 5, hasOverflow: false });
+    });
+
+    it('handles a user with no visible destinations at all', () => {
+        expect(at(276, { itemCount: 0 })).toEqual({ visibleCount: 0, hasOverflow: false });
+    });
+});
+
+const Probe = ({ itemCount = 7 }: { itemCount?: number }) => {
+    const { ref, visibleCount, hasOverflow } = useNavOverflow({ itemCount });
+
+    return (
+        <div ref={ref} data-testid="slot">
+            {visibleCount}/{hasOverflow ? 'overflow' : 'complete'}
+        </div>
+    );
+};
+
+const stubWidth = (width: number) =>
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({ width } as DOMRect);
+
+describe('useNavOverflow', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        // @ts-expect-error — the stub below is installed per test.
+        delete globalThis.ResizeObserver;
+    });
+
+    it('measures its element before paint', () => {
+        stubWidth(276);
+        render(<Probe />);
+
+        expect(screen.getByTestId('slot')).toHaveTextContent('2/overflow');
+    });
+
+    it('recomputes when the element is resized', () => {
+        stubWidth(276);
+        let notify = () => {};
+        globalThis.ResizeObserver = class {
+            constructor(callback: () => void) {
+                notify = callback;
+            }
+
+            observe = () => {};
+
+            disconnect = () => {};
+        } as unknown as typeof ResizeObserver;
+
+        render(<Probe />);
+        expect(screen.getByTestId('slot')).toHaveTextContent('2/overflow');
+
+        stubWidth(184);
+        act(() => notify());
+
+        expect(screen.getByTestId('slot')).toHaveTextContent('1/overflow');
+    });
+
+    it('falls back to window resize where ResizeObserver is unavailable', () => {
+        stubWidth(276);
+        render(<Probe />);
+
+        stubWidth(632);
+        act(() => {
+            window.dispatchEvent(new Event('resize'));
+        });
+
+        expect(screen.getByTestId('slot')).toHaveTextContent('4/overflow');
+    });
+});


### PR DESCRIPTION
Closes #627 — part of #622.

**Stacked PR.** Base is `feat/admin-m3-nav-02-navbar`; retarget to `pre-dev` once the parent merges. Review only the top commit.

Measures the navigation slot, whose width is decided by the bar rather than by
its own content, so the calculation cannot feed back into itself. Minimum
segment width is 72px: Figma itself packs three segments into the 276px it
gives the nav at 412px, so the design's own 96px slot would not reproduce it.

When space runs out the destinations give way, never the overflow button.

**Verification:** `npm run test`, `npx eslint . --max-warnings=0`, `npx prettier . --check`, `npm run build` — all green on the full stack.

## Reviewer test plan
- [ ] At 412px the bar shows 2 destinations plus "More" (this is the Figma layout)
- [ ] At 320px it shows 1 destination plus "More", and both labels are fully readable
- [ ] At 768px it shows 4 destinations plus "More" and never more than five segments in total
- [ ] Slowly resize the browser across those widths: segments appear and disappear cleanly, with no flicker or overlap at any point
- [ ] With a role that has only two destinations, no "More" segment appears at all