### PR TITLE
feat(nav): AppBottomBar shelf and the bottom-bar search variant

### DIFF
--- a/src/components/AppBottomBar/AppBottomBar.stories.tsx
+++ b/src/components/AppBottomBar/AppBottomBar.stories.tsx
@@ -1,0 +1,214 @@
+import {
+    Assessment,
+    AssessmentOutlined,
+    HolidayVillage,
+    HolidayVillageOutlined,
+    History,
+    HistoryOutlined,
+    Link as LinkIcon,
+    LinkOutlined,
+    ListAlt,
+    ListAltOutlined,
+    MoreVert,
+    People,
+    PeopleOutlined,
+    RealEstateAgent,
+    RealEstateAgentOutlined,
+    Settings,
+    SettingsOutlined,
+} from '@mui/icons-material';
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { GlobalSearchBar } from '../GlobalSearch';
+import { M3NavigationBar, type M3NavigationBarItem } from '../M3NavigationBar';
+import { useNavOverflow } from '../../hooks/useNavOverflow.hook';
+import { AppBottomBar } from './AppBottomBar';
+
+const destinations: M3NavigationBarItem[] = [
+    { key: 'settings', label: 'Einstellungen', icon: <SettingsOutlined />, activeIcon: <Settings /> },
+    { key: 'tenants', label: 'Träger', icon: <HolidayVillageOutlined />, activeIcon: <HolidayVillage /> },
+];
+
+/** The full set a super admin sees today — the seven that break the old bar. */
+const superAdminDestinations: M3NavigationBarItem[] = [
+    ...destinations,
+    { key: 'agency', label: 'Beratungsstelle', icon: <RealEstateAgentOutlined />, activeIcon: <RealEstateAgent /> },
+    { key: 'users', label: 'Nutzer*innen', icon: <PeopleOutlined />, activeIcon: <People /> },
+    { key: 'statistics', label: 'Statistiken', icon: <AssessmentOutlined />, activeIcon: <Assessment /> },
+    { key: 'links', label: 'Links', icon: <LinkOutlined />, activeIcon: <LinkIcon /> },
+    { key: 'logs', label: 'Logs', icon: <ListAltOutlined />, activeIcon: <ListAlt /> },
+    { key: 'activity-logs', label: 'Aktivitäts-Logs', icon: <HistoryOutlined />, activeIcon: <History /> },
+];
+
+const nav = (
+    <M3NavigationBar
+        ariaLabel="Hauptnavigation"
+        items={destinations}
+        activeKey="settings"
+        lang="de"
+        more={{ label: 'Mehr', icon: <MoreVert />, onClick: () => {} }}
+    />
+);
+
+const search = <GlobalSearchBar variant="pill" searchPlaceholder="Suchen" />;
+
+const meta = {
+    title: 'Organisms/AppBottomBar',
+    component: AppBottomBar,
+    parameters: {
+        layout: 'fullscreen',
+        design: {
+            type: 'figma',
+            url: 'https://www.figma.com/design/RTUi1rcrEWECXz8rNFmj7Q/Design-System-M3_ORISO?node-id=56576-34607',
+        },
+    },
+    args: {
+        search,
+        children: nav,
+    },
+    decorators: [
+        // Phone-width frame on the workspace background, so the bar's top
+        // corners and its contrast against the page are both visible.
+        (Story, context) => (
+            <div
+                style={{
+                    width: (context.parameters.deviceWidth as number | undefined) ?? 412,
+                    paddingTop: 24,
+                    background: 'var(--admin-workspace-background, #e4e2e2)',
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
+} satisfies Meta<typeof AppBottomBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Figma parity at 412px: search pill, two destinations and the overflow slot. */
+export const Default: Story = {};
+
+/** Screens where searching has no meaning: the navigation takes the full width. */
+export const WithoutSearch: Story = {
+    args: { search: undefined },
+};
+
+/**
+ * The rule Frank set: however far the search expands, it may never displace the
+ * overflow button. The search takes the free width, the navigation shrinks to a
+ * single 48×48 "Mehr" icon — and tapping that icon opens the full destination
+ * list *without* closing the search, so the two destinations the search
+ * swallowed are still one tap away.
+ *
+ * Interactive: expand the search, then open the overflow. The real list arrives
+ * with `MoreMenuSheet`; this story only proves the layout contract.
+ */
+export const SearchExpandedKeepsOverflow: Story = {
+    render: function SearchExpandedKeepsOverflowStory() {
+        const [expanded, setExpanded] = useState(true);
+        const [menuOpen, setMenuOpen] = useState(false);
+
+        return (
+            <>
+                <AppBottomBar
+                    searchExpanded={expanded}
+                    search={
+                        <GlobalSearchBar
+                            variant="pill"
+                            searchPlaceholder="Suchen"
+                            defaultExpanded
+                            onExpandedChange={setExpanded}
+                        />
+                    }
+                >
+                    <M3NavigationBar
+                        ariaLabel="Hauptnavigation"
+                        items={destinations}
+                        activeKey="settings"
+                        lang="de"
+                        collapsed={expanded}
+                        more={{
+                            label: 'Mehr',
+                            icon: <MoreVert />,
+                            expanded: menuOpen,
+                            // Deliberately does NOT touch the search state.
+                            onClick: () => setMenuOpen((open) => !open),
+                        }}
+                    />
+                </AppBottomBar>
+                {menuOpen && (
+                    <ul style={{ margin: 0, padding: '8px 16px', listStyle: 'none', fontSize: 14 }}>
+                        {destinations.map((item) => (
+                            <li key={item.key} style={{ padding: '8px 0' }}>
+                                {item.label}
+                            </li>
+                        ))}
+                        <li style={{ padding: '8px 0' }}>Statistiken</li>
+                        <li style={{ padding: '8px 0' }}>Links</li>
+                    </ul>
+                )}
+            </>
+        );
+    },
+};
+
+/** Smallest supported phone, fixed two destinations — the pre-overflow layout. */
+export const NarrowPhone: Story = {
+    parameters: { deviceWidth: 320 },
+    args: {
+        children: (
+            <M3NavigationBar
+                ariaLabel="Hauptnavigation"
+                items={[
+                    {
+                        key: 'agency',
+                        label: 'Beratungsstelle',
+                        icon: <RealEstateAgentOutlined />,
+                        activeIcon: <RealEstateAgent />,
+                    },
+                    { key: 'users', label: 'Nutzer*innen', icon: <PeopleOutlined />, activeIcon: <People /> },
+                ]}
+                activeKey="agency"
+                lang="de"
+                more={{ label: 'Mehr', icon: <MoreVert />, onClick: () => {} }}
+            />
+        ),
+    },
+};
+
+/**
+ * The seven destinations a super admin has, run through `useNavOverflow`. This
+ * is the case that breaks today's bar: it renders all seven regardless of width
+ * and lets the labels collide. Here the bar keeps as many as genuinely fit and
+ * pushes the rest behind "Mehr" — 1 at 320px, 2 at 412px, 4 from ~500px up.
+ */
+const ResponsiveBar = () => {
+    const { ref, visibleCount, hasOverflow } = useNavOverflow({ itemCount: superAdminDestinations.length });
+
+    return (
+        <AppBottomBar navSlotRef={ref} search={search}>
+            <M3NavigationBar
+                ariaLabel="Hauptnavigation"
+                items={superAdminDestinations.slice(0, visibleCount)}
+                activeKey="settings"
+                lang="de"
+                more={hasOverflow ? { label: 'Mehr', icon: <MoreVert />, onClick: () => {} } : undefined}
+            />
+        </AppBottomBar>
+    );
+};
+
+export const ResponsiveOverflow: Story = {
+    render: () => <ResponsiveBar />,
+};
+
+export const ResponsiveOverflowNarrowPhone: Story = {
+    parameters: { deviceWidth: 320 },
+    render: () => <ResponsiveBar />,
+};
+
+export const ResponsiveOverflowTablet: Story = {
+    parameters: { deviceWidth: 768 },
+    render: () => <ResponsiveBar />,
+};

--- a/src/components/AppBottomBar/AppBottomBar.test.tsx
+++ b/src/components/AppBottomBar/AppBottomBar.test.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { GlobalSearchBar } from '../GlobalSearch';
+import { M3NavigationBar, type M3NavigationBarItem } from '../M3NavigationBar';
+import { AppBottomBar } from './AppBottomBar';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key }),
+}));
+
+const destinations: M3NavigationBarItem[] = [
+    { key: 'settings', label: 'Einstellungen', icon: <svg /> },
+    { key: 'tenants', label: 'Träger', icon: <svg /> },
+];
+
+/** Mirrors how the layout wrapper will wire the two components together. */
+const Harness = () => {
+    const [expanded, setExpanded] = useState(false);
+    const [menuOpen, setMenuOpen] = useState(false);
+
+    return (
+        <MemoryRouter>
+            <AppBottomBar
+                searchExpanded={expanded}
+                search={<GlobalSearchBar variant="pill" searchPlaceholder="Suchen" onExpandedChange={setExpanded} />}
+            >
+                <M3NavigationBar
+                    ariaLabel="Hauptnavigation"
+                    items={destinations}
+                    activeKey="settings"
+                    collapsed={expanded}
+                    more={{
+                        label: 'Mehr',
+                        icon: <svg />,
+                        expanded: menuOpen,
+                        onClick: () => setMenuOpen((open) => !open),
+                    }}
+                />
+            </AppBottomBar>
+        </MemoryRouter>
+    );
+};
+
+const expandSearch = async () => userEvent.click(screen.getByRole('button', { name: 'Suche ausklappen' }));
+
+describe('AppBottomBar + M3NavigationBar', () => {
+    it('keeps the overflow button reachable while the search is expanded', async () => {
+        render(<Harness />);
+
+        await expandSearch();
+
+        expect(screen.getByRole('textbox', { name: 'Suchen' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Mehr' })).toBeInTheDocument();
+    });
+
+    it('drops the other destinations from the bar while the search is expanded', async () => {
+        render(<Harness />);
+
+        expect(screen.getByText('Träger')).toBeInTheDocument();
+
+        await expandSearch();
+
+        expect(screen.queryByText('Träger')).not.toBeInTheDocument();
+    });
+
+    it('does not close the search when the overflow menu is opened', async () => {
+        render(<Harness />);
+
+        await expandSearch();
+        await userEvent.click(screen.getByRole('button', { name: 'Mehr' }));
+
+        expect(screen.getByRole('button', { name: 'Mehr' })).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByRole('textbox', { name: 'Suchen' })).toBeInTheDocument();
+    });
+
+    it('never sets a fixed pixel width on the expanded pill', async () => {
+        const { container } = render(<Harness />);
+
+        await expandSearch();
+
+        // A pixel width would be exactly how the search could outgrow the bar
+        // and push the overflow button off the edge on a narrower phone.
+        const pill = container.querySelector('[class*="pillSearch"]') as HTMLElement;
+
+        expect(pill.style.width).toBe('');
+    });
+});

--- a/src/components/AppBottomBar/AppBottomBar.tsx
+++ b/src/components/AppBottomBar/AppBottomBar.tsx
@@ -1,0 +1,60 @@
+import type { Ref, ReactNode } from 'react';
+import classNames from 'classnames';
+import styles from './appBottomBar.module.scss';
+
+export interface AppBottomBarProps {
+    /**
+     * Search control for this screen — rendered bottom-left. Leave it out on
+     * screens where searching has no meaning; the bar then gives its full width
+     * to the navigation instead of showing a dead control.
+     */
+    search?: ReactNode;
+    /**
+     * Set while the search control is expanded. It hands the free width to the
+     * search and lets the navigation shrink — pass `collapsed` to the
+     * {@link M3NavigationBar} at the same time so what is left is the single
+     * 48×48 overflow button. The search never displaces that button, and
+     * opening the overflow menu never closes the search.
+     */
+    searchExpanded?: boolean;
+    /** Navigation for this screen, usually an {@link M3NavigationBar}. */
+    children: ReactNode;
+    /**
+     * Attached to the navigation slot, whose width is what decides how many
+     * destinations fit — pass `useNavOverflow`'s ref here. Measuring the slot
+     * rather than the segments inside it is what keeps that decision free of
+     * feedback: the slot is sized by the bar, not by its own content.
+     */
+    navSlotRef?: Ref<HTMLDivElement>;
+    className?: string;
+}
+
+/**
+ * Mobile bottom bar (Figma 56576:34607): a 96px M3 surface-container shelf with
+ * the search pill on the left and the navigation on the right.
+ *
+ * Layout only — it does **not** position itself. Fixing it to the viewport is
+ * the layout wrapper's job, the same way {@link AdminSidebar} leaves its
+ * `position: sticky` to `protectedLayout.less`. That keeps the bar renderable
+ * inline in Storybook and keeps one owner for the content offset it needs.
+ */
+export const AppBottomBar = ({
+    children,
+    className,
+    navSlotRef,
+    search,
+    searchExpanded = false,
+}: AppBottomBarProps) => (
+    <div className={classNames(styles.bar, className)}>
+        {search && (
+            <div className={classNames(styles.searchSlot, { [styles.searchSlotExpanded]: searchExpanded })}>
+                {search}
+            </div>
+        )}
+        <div className={classNames(styles.navSlot, { [styles.navSlotCollapsed]: searchExpanded })} ref={navSlotRef}>
+            {children}
+        </div>
+    </div>
+);
+
+export default AppBottomBar;

--- a/src/components/AppBottomBar/appBottomBar.module.scss
+++ b/src/components/AppBottomBar/appBottomBar.module.scss
@@ -1,0 +1,44 @@
+/* Mobile bottom bar (Figma 56576:34607): 96px shelf, 16px padding, 16px gap,
+   rounded only at the top because it is flush with the bottom of the viewport. */
+
+.bar {
+    display: flex;
+    width: 100%;
+    height: 96px;
+    box-sizing: border-box;
+    align-items: center;
+    padding: 16px;
+    background: var(--m3-surface-container, #f0edee);
+    border-radius: 12px 12px 0 0;
+    gap: 16px;
+}
+
+.searchSlot {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+}
+
+/* The navigation takes whatever the search pill leaves; its own segments then
+   share that space equally. `min-width: 0` keeps long labels from pushing the
+   search pill off the left edge. */
+.navSlot {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+/*
+ * Expanded search. The two slots swap roles: the search grows into the free
+ * width, the navigation stops growing and shrinks to its single overflow
+ * button. Because the nav slot is `flex: 0 0 auto` here, the search can never
+ * take the last 48px away from it — the guarantee is in the flex model, not in
+ * a magic pixel width that a wider phone would break.
+ */
+.searchSlotExpanded {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.navSlotCollapsed {
+    flex: 0 0 auto;
+}

--- a/src/components/AppBottomBar/index.ts
+++ b/src/components/AppBottomBar/index.ts
@@ -1,0 +1,1 @@
+export { AppBottomBar, type AppBottomBarProps } from './AppBottomBar';

--- a/src/components/GlobalSearch/GlobalSearchBar.tsx
+++ b/src/components/GlobalSearch/GlobalSearchBar.tsx
@@ -3,6 +3,7 @@ import { SearchOutlined } from '@ant-design/icons';
 import { Input, type InputRef } from 'antd';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
+import { ReactComponent as ArrowMenuOpenIcon } from '../../resources/img/svg/oriso/arrow_menu_open_24px.svg';
 import styles from './globalSearchBar.module.scss';
 
 export interface GlobalSearchBarProps {
@@ -30,19 +31,14 @@ export interface GlobalSearchBarProps {
     searchPlaceholder?: string;
     /** Controlled query value; leave undefined for internal state. */
     value?: string;
+    /**
+     * `row` (default) is the page-toolbar layout: the search control plus its
+     * sibling controls in a horizontally scrollable row. `pill` is the
+     * bottom-bar layout (Figma 56576:34610) — the control on its own, 88px
+     * collapsed, raised off the bar surface with M3's inner shadow.
+     */
+    variant?: 'row' | 'pill';
 }
-
-/**
- * Placeholder for the M3 "open search panel" caret (Figma marks it "change
- * icon", so the final glyph is still owned by design). Flips horizontally via
- * CSS when the search control is expanded.
- */
-const ExpandCaretIcon = () => (
-    <svg aria-hidden fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-        <path d="M8 7v10l6-5-6-5z" fill="currentColor" />
-        <path d="M16 6h2v12h-2z" fill="currentColor" />
-    </svg>
-);
 
 /**
  * Global search row (Figma 1165:17005, "Search Bar Admin Panel"). The search
@@ -67,6 +63,7 @@ export const GlobalSearchBar = ({
     onSearchChange,
     searchPlaceholder,
     value,
+    variant = 'row',
 }: GlobalSearchBarProps) => {
     const { t } = useTranslation();
     const [expanded, setExpanded] = useState(defaultExpanded);
@@ -125,29 +122,63 @@ export const GlobalSearchBar = ({
         toggleExpanded();
     };
 
+    const caretButton = (
+        <button
+            aria-expanded={expanded}
+            aria-label={
+                expanded ? t('globalSearch.collapse', 'Suche einklappen') : t('globalSearch.expand', 'Suche ausklappen')
+            }
+            className={styles.iconButton}
+            key="caret"
+            onClick={toggleExpanded}
+            type="button"
+        >
+            <span className={classNames(styles.caret, { [styles.caretFlipped]: expanded })}>
+                <ArrowMenuOpenIcon aria-hidden />
+            </span>
+        </button>
+    );
+
+    const magnifierButton = (
+        <button
+            aria-label={
+                expanded && searchValue.length > 0
+                    ? t('globalSearch.submit', 'Suche ausführen')
+                    : t('globalSearch.toggle', 'Suche öffnen oder schließen')
+            }
+            className={styles.iconButton}
+            key="magnifier"
+            onClick={handleMagnifierClick}
+            type="button"
+        >
+            <SearchOutlined className={styles.magnifier} />
+        </button>
+    );
+
+    // The bottom bar follows M3's search-bar anatomy — magnifier as the leading
+    // icon, the panel caret trailing (Figma 56576:34610). The page-toolbar row
+    // keeps its established caret-first order so existing screens don't shift.
+    const [leadingButton, trailingButton] =
+        variant === 'pill' ? [magnifierButton, caretButton] : [caretButton, magnifierButton];
+
+    const isPill = variant === 'pill';
+
     return (
-        <div className={classNames(styles.scroller, className)}>
-            <div className={styles.row}>
+        <div className={classNames(styles.scroller, { [styles.pillScroller]: isPill }, className)}>
+            <div className={classNames(styles.row, { [styles.pillRow]: isPill })}>
                 {leading}
                 <div
-                    className={classNames(styles.search, { [styles.searchExpanded]: expanded })}
-                    style={{ width: expanded ? expandedWidth : undefined }}
+                    className={classNames(styles.search, {
+                        [styles.searchExpanded]: expanded,
+                        [styles.pillSearch]: isPill,
+                        [styles.pillSearchExpanded]: isPill && expanded,
+                    })}
+                    // The pill grows by filling its flex slot, never to a fixed
+                    // pixel width: the bottom bar keeps a 48px slot for the
+                    // overflow button, so the search can never push it away.
+                    style={{ width: expanded && !isPill ? expandedWidth : undefined }}
                 >
-                    <button
-                        aria-expanded={expanded}
-                        aria-label={
-                            expanded
-                                ? t('globalSearch.collapse', 'Suche einklappen')
-                                : t('globalSearch.expand', 'Suche ausklappen')
-                        }
-                        className={styles.iconButton}
-                        onClick={toggleExpanded}
-                        type="button"
-                    >
-                        <span className={classNames(styles.caret, { [styles.caretFlipped]: expanded })}>
-                            <ExpandCaretIcon />
-                        </span>
-                    </button>
+                    {leadingButton}
                     {expanded && (
                         <Input
                             aria-label={ariaLabel ?? searchPlaceholder ?? t('globalSearch.placeholder', 'Suchen')}
@@ -164,18 +195,7 @@ export const GlobalSearchBar = ({
                             variant="borderless"
                         />
                     )}
-                    <button
-                        aria-label={
-                            expanded && searchValue.length > 0
-                                ? t('globalSearch.submit', 'Suche ausführen')
-                                : t('globalSearch.toggle', 'Suche öffnen oder schließen')
-                        }
-                        className={styles.iconButton}
-                        onClick={handleMagnifierClick}
-                        type="button"
-                    >
-                        <SearchOutlined className={styles.magnifier} />
-                    </button>
+                    {trailingButton}
                 </div>
                 {children}
             </div>

--- a/src/components/GlobalSearch/globalSearchBar.module.scss
+++ b/src/components/GlobalSearch/globalSearchBar.module.scss
@@ -55,6 +55,48 @@
     transition: width 240ms cubic-bezier(0.2, 0, 0, 1);
 }
 
+/*
+ * Bottom-bar variant (Figma 56576:34610). Same control, but it sits alone on
+ * the M3 surface-container of AppBottomBar instead of in a page toolbar: 88px
+ * collapsed (4px padding + two 40px icon slots), a lowest-tier surface so it
+ * reads as raised against the bar, and M3's pressed-in inner shadow.
+ */
+.pillScroller {
+    width: 100%;
+    min-width: 0;
+    overflow: visible;
+}
+
+.pillRow {
+    width: 100%;
+    min-width: 0;
+    padding: 0;
+}
+
+.pillSearch {
+    width: 88px;
+    background: var(--m3-surface-container-lowest, #ffffff);
+    box-shadow: inset 4px 4px 8px rgb(0 0 0 / 12%);
+
+    .iconButton {
+        width: 40px;
+        height: 40px;
+        flex-basis: 40px;
+    }
+}
+
+/*
+ * Expanded, the pill fills whatever the bottom bar gives it — it never grows to
+ * a fixed pixel width. That is the whole guarantee: the bar always keeps a 48px
+ * slot for the overflow ("Mehr") button, so however long the search gets, that
+ * one icon stays reachable and the search does not have to close to get to it.
+ */
+.pillSearchExpanded {
+    width: 100%;
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
 .iconButton {
     display: inline-flex;
     width: 48px;

--- a/src/resources/img/svg/oriso/arrow_menu_open_24px.svg
+++ b/src/resources/img/svg/oriso/arrow_menu_open_24px.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M9 21V3H11V21H9ZM13 17V7L18 12L13 17Z" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
Closes #626 — part of #622.

**Stacked PR.** Base is `feat/admin-m3-nav-03-overflow`; retarget to `pre-dev` once the parent merges. Review only the top commit.

The shelf is layout only — fixing it to the viewport belongs to the layout that
uses it, which keeps it renderable inline in Storybook.

GlobalSearchBar gains an additive variant="pill": 88px collapsed, magnifier
leading and the panel caret trailing per Figma. The six existing call sites are
untouched.

The expanded search can never push the overflow icon off the bar. That guarantee
sits in the flex model, not in a pixel width that a narrower phone would break.

**Verification:** `npm run test`, `npx eslint . --max-warnings=0`, `npx prettier . --check`, `npm run build` — all green on the full stack.

## Reviewer test plan
- [ ] In Storybook, `Organisms/AppBottomBar` at 412px matches the Figma bar (light shelf, rounded top corners, search bottom-left)
- [ ] Expand the search: it grows to fill the row and the ⋮ "More" icon is **still visible and tappable**
- [ ] Repeat at 320px — the "More" icon survives there too
- [ ] Opening "More" does **not** close the search
- [ ] The story without a search shows the navigation using the full width, with no empty gap on the left
- [ ] Open an existing page that uses the search (Agencies, Tenants, Users) on desktop → its toolbar search looks and works exactly as before