### PR TITLE
feat(nav): MoreMenuSheet with the full destination list

### DIFF
--- a/src/components/MoreMenuSheet/MoreMenuSheet.stories.tsx
+++ b/src/components/MoreMenuSheet/MoreMenuSheet.stories.tsx
@@ -1,0 +1,98 @@
+import {
+    AssessmentOutlined,
+    BalanceOutlined,
+    EmailOutlined,
+    HistoryOutlined,
+    HolidayVillageOutlined,
+    LinkOutlined,
+    ListAltOutlined,
+    PeopleOutlined,
+    RealEstateAgentOutlined,
+    SettingsOutlined,
+} from '@mui/icons-material';
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MoreMenuSheet, type MoreMenuSheetGroup } from './MoreMenuSheet';
+
+/** Everything a super admin can reach — including what the bar already shows. */
+const destinations: MoreMenuSheetGroup = {
+    label: 'Bereiche',
+    activeKey: 'settings',
+    entries: [
+        { key: 'settings', label: 'Einstellungen', icon: <SettingsOutlined /> },
+        { key: 'tenants', label: 'Träger', icon: <HolidayVillageOutlined /> },
+        { key: 'agency', label: 'Beratungsstelle', icon: <RealEstateAgentOutlined /> },
+        { key: 'users', label: 'Nutzer*innen', icon: <PeopleOutlined /> },
+        { key: 'statistics', label: 'Statistiken', icon: <AssessmentOutlined /> },
+        { key: 'links', label: 'Links', icon: <LinkOutlined /> },
+        { key: 'logs', label: 'Logs', icon: <ListAltOutlined /> },
+        { key: 'activity-logs', label: 'Aktivitäts-Logs', icon: <HistoryOutlined /> },
+    ],
+};
+
+const sections: MoreMenuSheetGroup = {
+    label: 'Sektionen',
+    activeKey: 'legal',
+    entries: [
+        { key: 'global_config', label: 'Globale Einstellungen' },
+        { key: 'legal', label: 'Rechtliches', icon: <BalanceOutlined /> },
+        { key: 'email_server', label: 'E-Mail-Server', icon: <EmailOutlined /> },
+    ],
+};
+
+const meta = {
+    title: 'Organisms/MoreMenuSheet',
+    component: MoreMenuSheet,
+    parameters: { layout: 'fullscreen' },
+    args: {
+        ariaLabel: 'Weitere Bereiche',
+        closeLabel: 'Menü schließen',
+        groups: [destinations, sections],
+        lang: 'de',
+        onClose: () => {},
+        open: true,
+    },
+} satisfies Meta<typeof MoreMenuSheet>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Destinations and sections together, each with its current entry marked. */
+export const Default: Story = {};
+
+/** Screens with no sub-sections: the empty group is dropped, not left as a bare heading. */
+export const DestinationsOnly: Story = {
+    args: { groups: [destinations] },
+};
+
+/** A restricted agency admin reaches very little — the sheet must not look broken. */
+export const FewDestinations: Story = {
+    args: {
+        groups: [{ label: 'Bereiche', activeKey: 'agency', entries: destinations.entries.slice(2, 4) }],
+    },
+};
+
+const Dismissable = () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <div style={{ padding: 24 }}>
+            <button onClick={() => setOpen(true)} type="button">
+                Mehr öffnen
+            </button>
+            <MoreMenuSheet
+                ariaLabel="Weitere Bereiche"
+                closeLabel="Menü schließen"
+                groups={[destinations, sections]}
+                lang="de"
+                onClose={() => setOpen(false)}
+                open={open}
+            />
+        </div>
+    );
+};
+
+/** Open, dismiss with the scrim or Escape, and watch focus return to the trigger. */
+export const Dismissal: Story = {
+    render: () => <Dismissable />,
+};

--- a/src/components/MoreMenuSheet/MoreMenuSheet.test.tsx
+++ b/src/components/MoreMenuSheet/MoreMenuSheet.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
-import { MoreMenuSheet, type MoreMenuSheetGroup } from './MoreMenuSheet';
+import { MoreMenuSheet, type MoreMenuSheetGroup, type MoreMenuSheetProps } from './MoreMenuSheet';
 
 const groups: MoreMenuSheetGroup[] = [
     {
@@ -37,6 +38,29 @@ const renderSheet = (props: Partial<React.ComponentProps<typeof MoreMenuSheet>> 
             />
         </MemoryRouter>,
     );
+
+// A real trigger button that toggles `open`, for tests that need focus to
+// meaningfully leave and return to something — a stub onClose can't stand in
+// for the element the sheet is supposed to hand focus back to.
+const StatefulHarness = (props: Partial<MoreMenuSheetProps> = {}) => {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <MemoryRouter>
+            <button onClick={() => setOpen(true)} type="button">
+                Mehr öffnen
+            </button>
+            <MoreMenuSheet
+                ariaLabel="Weitere Bereiche"
+                closeLabel="Menü schließen"
+                groups={groups}
+                onClose={() => setOpen(false)}
+                open={open}
+                {...props}
+            />
+        </MemoryRouter>
+    );
+};
 
 describe('MoreMenuSheet', () => {
     it('renders nothing while closed', () => {
@@ -106,12 +130,37 @@ describe('MoreMenuSheet', () => {
     it('keeps Tab inside the sheet and never lands on the scrim', async () => {
         renderSheet();
 
-        const entries = screen.getAllByRole('button').filter((entry) => entry.textContent !== '');
+        // The scrim button is a sibling of the dialog, not a child of it — so
+        // scoping to the dialog excludes it without filtering on textContent,
+        // which an unrelated non-empty button could otherwise defeat.
+        const entries = within(screen.getByRole('dialog')).getAllByRole('button');
         entries[entries.length - 1].focus();
 
         await userEvent.tab();
 
         expect(entries[0]).toHaveFocus();
         expect(screen.getByRole('button', { name: 'Menü schließen' })).not.toHaveFocus();
+    });
+
+    it('keeps Shift+Tab inside the sheet, wrapping from the first entry to the last', async () => {
+        renderSheet();
+
+        const entries = within(screen.getByRole('dialog')).getAllByRole('button');
+        entries[0].focus();
+
+        await userEvent.tab({ shift: true });
+
+        expect(entries[entries.length - 1]).toHaveFocus();
+    });
+
+    it('returns focus to the trigger that opened it when the sheet closes', async () => {
+        render(<StatefulHarness />);
+
+        const trigger = screen.getByRole('button', { name: 'Mehr öffnen' });
+        await userEvent.click(trigger);
+
+        await userEvent.keyboard('{Escape}');
+
+        expect(trigger).toHaveFocus();
     });
 });

--- a/src/components/MoreMenuSheet/MoreMenuSheet.test.tsx
+++ b/src/components/MoreMenuSheet/MoreMenuSheet.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { MoreMenuSheet, type MoreMenuSheetGroup } from './MoreMenuSheet';
+
+const groups: MoreMenuSheetGroup[] = [
+    {
+        label: 'Bereiche',
+        activeKey: 'settings',
+        entries: [
+            { key: 'settings', label: 'Einstellungen' },
+            { key: 'tenants', label: 'Träger' },
+            { key: 'logs', label: 'Aktivitäts-Logs' },
+        ],
+    },
+    {
+        label: 'Sektionen',
+        activeKey: 'legal',
+        entries: [
+            { key: 'legal', label: 'Rechtliches' },
+            { key: 'smtp', label: 'E-Mail-Server' },
+        ],
+    },
+];
+
+const renderSheet = (props: Partial<React.ComponentProps<typeof MoreMenuSheet>> = {}) =>
+    render(
+        <MemoryRouter>
+            <MoreMenuSheet
+                ariaLabel="Weitere Bereiche"
+                closeLabel="Menü schließen"
+                groups={groups}
+                onClose={vi.fn()}
+                open
+                {...props}
+            />
+        </MemoryRouter>,
+    );
+
+describe('MoreMenuSheet', () => {
+    it('renders nothing while closed', () => {
+        renderSheet({ open: false });
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('mounts outside the bar so the fixed bottom bar cannot clip it', () => {
+        const { container } = renderSheet();
+
+        // Nothing lands in the component's own container — it all goes to body.
+        expect(container).toBeEmptyDOMElement();
+        expect(document.body).toContainElement(screen.getByRole('dialog'));
+    });
+
+    it('lists every destination, including the ones already in the bar', () => {
+        renderSheet();
+
+        ['Einstellungen', 'Träger', 'Aktivitäts-Logs'].forEach((label) => {
+            expect(screen.getByText(label)).toBeInTheDocument();
+        });
+    });
+
+    it('marks the current entry of each group', () => {
+        renderSheet();
+
+        const current = screen.getAllByRole('button', { current: 'page' });
+
+        expect(current.map((entry) => entry.textContent)).toEqual(['Einstellungen', 'Rechtliches']);
+    });
+
+    it('drops empty groups instead of rendering a bare heading', () => {
+        renderSheet({ groups: [groups[0], { label: 'Sektionen', entries: [] }] });
+
+        expect(screen.queryByText('Sektionen')).not.toBeInTheDocument();
+    });
+
+    it('reports the chosen entry and closes', async () => {
+        const onClose = vi.fn();
+        const onSelect = vi.fn();
+        renderSheet({ onClose, onSelect });
+
+        await userEvent.click(screen.getByText('Träger'));
+
+        expect(onSelect).toHaveBeenCalledWith('tenants');
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('closes on the scrim and on Escape', async () => {
+        const onClose = vi.fn();
+        renderSheet({ onClose });
+
+        await userEvent.click(screen.getByRole('button', { name: 'Menü schließen' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+
+        await userEvent.keyboard('{Escape}');
+        expect(onClose).toHaveBeenCalledTimes(2);
+    });
+
+    it('moves focus to the first entry, not to the scrim, when it opens', () => {
+        renderSheet();
+
+        expect(screen.getByRole('button', { name: 'Einstellungen' })).toHaveFocus();
+    });
+
+    it('keeps Tab inside the sheet and never lands on the scrim', async () => {
+        renderSheet();
+
+        const entries = screen.getAllByRole('button').filter((entry) => entry.textContent !== '');
+        entries[entries.length - 1].focus();
+
+        await userEvent.tab();
+
+        expect(entries[0]).toHaveFocus();
+        expect(screen.getByRole('button', { name: 'Menü schließen' })).not.toHaveFocus();
+    });
+});

--- a/src/components/MoreMenuSheet/MoreMenuSheet.test.tsx
+++ b/src/components/MoreMenuSheet/MoreMenuSheet.test.tsx
@@ -170,7 +170,12 @@ describe('MoreMenuSheet', () => {
         expect(screen.getByRole('dialog')).toHaveFocus();
     });
 
-    it('locks page scroll while open and restores it on close', () => {
+    it('locks page scroll while open and restores the prior value on close', () => {
+        // A non-default value here, asserted exactly after close, is what
+        // proves restoration — "not hidden" alone would still pass if
+        // cleanup reset to '' instead of putting this back.
+        document.body.style.overflow = 'clip';
+
         const { rerender } = renderSheet();
 
         expect(document.body.style.overflow).toBe('hidden');
@@ -187,7 +192,8 @@ describe('MoreMenuSheet', () => {
             </MemoryRouter>,
         );
 
-        expect(document.body.style.overflow).not.toBe('hidden');
+        expect(document.body.style.overflow).toBe('clip');
+        document.body.style.overflow = '';
     });
 
     it('keeps Tab inside the sheet and never lands on the scrim', async () => {

--- a/src/components/MoreMenuSheet/MoreMenuSheet.test.tsx
+++ b/src/components/MoreMenuSheet/MoreMenuSheet.test.tsx
@@ -85,12 +85,29 @@ describe('MoreMenuSheet', () => {
         });
     });
 
-    it('marks the current entry of each group', () => {
+    it('marks the current entry of each group with aria-current="location", not "page"', () => {
         renderSheet();
 
-        const current = screen.getAllByRole('button', { current: 'page' });
+        // These entries have no `to` — they mark the current section of the
+        // page the user is already on, not a link that IS the active route.
+        expect(screen.queryAllByRole('button', { current: 'page' })).toHaveLength(0);
+
+        const current = screen.getAllByRole('button', { current: 'location' });
 
         expect(current.map((entry) => entry.textContent)).toEqual(['Einstellungen', 'Rechtliches']);
+    });
+
+    it('marks a routed entry current with aria-current="page"', () => {
+        const routedGroups: MoreMenuSheetGroup[] = [
+            {
+                label: 'Bereiche',
+                activeKey: 'settings',
+                entries: [{ key: 'settings', label: 'Einstellungen', to: '/admin/settings' }],
+            },
+        ];
+        renderSheet({ groups: routedGroups });
+
+        expect(screen.getByRole('link', { name: 'Einstellungen', current: 'page' })).toBeInTheDocument();
     });
 
     it('drops empty groups instead of rendering a bare heading', () => {
@@ -110,6 +127,26 @@ describe('MoreMenuSheet', () => {
         expect(onClose).toHaveBeenCalled();
     });
 
+    it('navigates, reports the chosen entry, and closes for a routed entry', async () => {
+        const onClose = vi.fn();
+        const onSelect = vi.fn();
+        const routedGroups: MoreMenuSheetGroup[] = [
+            {
+                label: 'Bereiche',
+                entries: [{ key: 'settings', label: 'Einstellungen', to: '/admin/settings' }],
+            },
+        ];
+        renderSheet({ groups: routedGroups, onClose, onSelect });
+
+        const link = screen.getByRole('link', { name: 'Einstellungen' });
+        expect(link).toHaveAttribute('href', '/admin/settings');
+
+        await userEvent.click(link);
+
+        expect(onSelect).toHaveBeenCalledWith('settings');
+        expect(onClose).toHaveBeenCalled();
+    });
+
     it('closes on the scrim and on Escape', async () => {
         const onClose = vi.fn();
         renderSheet({ onClose });
@@ -125,6 +162,32 @@ describe('MoreMenuSheet', () => {
         renderSheet();
 
         expect(screen.getByRole('button', { name: 'Einstellungen' })).toHaveFocus();
+    });
+
+    it('falls back to focusing the dialog itself when there is no focusable entry', () => {
+        renderSheet({ groups: [{ label: 'Sektionen', entries: [] }] });
+
+        expect(screen.getByRole('dialog')).toHaveFocus();
+    });
+
+    it('locks page scroll while open and restores it on close', () => {
+        const { rerender } = renderSheet();
+
+        expect(document.body.style.overflow).toBe('hidden');
+
+        rerender(
+            <MemoryRouter>
+                <MoreMenuSheet
+                    ariaLabel="Weitere Bereiche"
+                    closeLabel="Menü schließen"
+                    groups={groups}
+                    onClose={vi.fn()}
+                    open={false}
+                />
+            </MemoryRouter>,
+        );
+
+        expect(document.body.style.overflow).not.toBe('hidden');
     });
 
     it('keeps Tab inside the sheet and never lands on the scrim', async () => {

--- a/src/components/MoreMenuSheet/MoreMenuSheet.tsx
+++ b/src/components/MoreMenuSheet/MoreMenuSheet.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useRef, type KeyboardEvent, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import classNames from 'classnames';
+import { NavLink } from 'react-router-dom';
+import styles from './moreMenuSheet.module.scss';
+
+export interface MoreMenuSheetEntry {
+    key: string;
+    label: string;
+    icon?: ReactNode;
+    to?: string;
+}
+
+export interface MoreMenuSheetGroup {
+    /** Group heading, e.g. "Bereiche" or "Sektionen". */
+    label: string;
+    entries: MoreMenuSheetEntry[];
+    /** Key of the entry the user is currently on, within this group. */
+    activeKey?: string;
+}
+
+export interface MoreMenuSheetProps {
+    open: boolean;
+    onClose: () => void;
+    /** Accessible name of the sheet. */
+    ariaLabel: string;
+    /**
+     * Accessible name of the scrim, which is a real button. It must describe
+     * the ACTION ("Menü schließen"), not repeat the sheet's name — otherwise
+     * screen-reader users hear the same label twice and cannot tell the
+     * dismiss target from the dialog itself.
+     */
+    closeLabel: string;
+    groups: MoreMenuSheetGroup[];
+    onSelect?: (key: string) => void;
+    lang?: string;
+}
+
+const FOCUSABLE = 'a[href], button:not([disabled])';
+
+/**
+ * The list behind the bottom bar's "Mehr" segment: every destination and every
+ * section of the current screen, in full.
+ *
+ * Two deliberate choices:
+ *
+ * - It lists **all** destinations, including the two or three already shown in
+ *   the bar — not just the overflow remainder. The bar's contents change with
+ *   the viewport, so a list of "the rest" would be a different list on every
+ *   phone; a complete list is the same everywhere and needs no explaining.
+ * - It renders through a portal on `document.body`, never inside the bar. The
+ *   bar is `position: fixed` with its own stacking context and `overflow: clip`
+ *   — a sheet mounted inside it would be clipped, and would unmount from under
+ *   its own outside-click handler.
+ */
+export const MoreMenuSheet = ({ ariaLabel, closeLabel, groups, lang, onClose, onSelect, open }: MoreMenuSheetProps) => {
+    const sheetRef = useRef<HTMLDivElement>(null);
+    const restoreFocusRef = useRef<HTMLElement | null>(null);
+
+    useEffect(() => {
+        if (!open) {
+            return undefined;
+        }
+
+        restoreFocusRef.current = document.activeElement as HTMLElement | null;
+        sheetRef.current?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+
+        return () => {
+            // Returning focus to the "Mehr" button is what makes the sheet
+            // usable by keyboard at all — otherwise closing it drops the caret
+            // back to the top of the document.
+            restoreFocusRef.current?.focus();
+        };
+    }, [open]);
+
+    // Escape listens on the document, not on the sheet: focus can legitimately
+    // sit on the scrim (after a click) or nowhere at all, and in both cases the
+    // key must still dismiss. A handler bound to the sheet would silently do
+    // nothing exactly when the user most expects an escape hatch.
+    useEffect(() => {
+        if (!open) {
+            return undefined;
+        }
+
+        const onEscape = (event: globalThis.KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+
+        document.addEventListener('keydown', onEscape);
+
+        return () => document.removeEventListener('keydown', onEscape);
+    }, [onClose, open]);
+
+    const handleKeyDown = useCallback(
+        (event: KeyboardEvent<HTMLDivElement>) => {
+            if (event.key !== 'Tab') {
+                return;
+            }
+
+            const focusable = Array.from(sheetRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? []);
+            const edge = event.shiftKey ? focusable[0] : focusable[focusable.length - 1];
+
+            if (focusable.length > 0 && document.activeElement === edge) {
+                event.preventDefault();
+                (event.shiftKey ? focusable[focusable.length - 1] : focusable[0]).focus();
+            }
+        },
+        [onClose],
+    );
+
+    if (!open) {
+        return null;
+    }
+
+    const entryContent = (entry: MoreMenuSheetEntry) => (
+        <>
+            {entry.icon && (
+                <span className={styles.icon} aria-hidden>
+                    {entry.icon}
+                </span>
+            )}
+            <span lang={lang}>{entry.label}</span>
+        </>
+    );
+
+    return createPortal(
+        <div className={styles.layer}>
+            <button aria-label={closeLabel} className={styles.scrim} onClick={onClose} type="button" />
+            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+            <div
+                aria-label={ariaLabel}
+                aria-modal="true"
+                className={styles.sheet}
+                onKeyDown={handleKeyDown}
+                ref={sheetRef}
+                role="dialog"
+            >
+                <span aria-hidden className={styles.grabber} />
+                {groups
+                    .filter((group) => group.entries.length > 0)
+                    .map((group) => (
+                        <section className={styles.group} key={group.label}>
+                            <h2 className={styles.groupLabel} lang={lang}>
+                                {group.label}
+                            </h2>
+                            <ul className={styles.list}>
+                                {group.entries.map((entry) => {
+                                    const isActive = entry.key === group.activeKey;
+                                    const className = classNames(styles.entry, {
+                                        [styles.entryActive]: isActive,
+                                    });
+                                    const select = () => {
+                                        onSelect?.(entry.key);
+                                        onClose();
+                                    };
+
+                                    return (
+                                        <li key={entry.key}>
+                                            {entry.to ? (
+                                                <NavLink
+                                                    aria-current={isActive ? 'page' : undefined}
+                                                    className={className}
+                                                    onClick={select}
+                                                    to={entry.to}
+                                                >
+                                                    {entryContent(entry)}
+                                                </NavLink>
+                                            ) : (
+                                                <button
+                                                    aria-current={isActive ? 'page' : undefined}
+                                                    className={className}
+                                                    onClick={select}
+                                                    type="button"
+                                                >
+                                                    {entryContent(entry)}
+                                                </button>
+                                            )}
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        </section>
+                    ))}
+            </div>
+        </div>,
+        document.body,
+    );
+};
+
+export default MoreMenuSheet;

--- a/src/components/MoreMenuSheet/MoreMenuSheet.tsx
+++ b/src/components/MoreMenuSheet/MoreMenuSheet.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, type KeyboardEvent, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import classNames from 'classnames';
-import { NavLink } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styles from './moreMenuSheet.module.scss';
 
 export interface MoreMenuSheetEntry {
@@ -63,13 +63,32 @@ export const MoreMenuSheet = ({ ariaLabel, closeLabel, groups, lang, onClose, on
         }
 
         restoreFocusRef.current = document.activeElement as HTMLElement | null;
-        sheetRef.current?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+        // Falls back to the dialog itself when every group is empty and there
+        // is no focusable entry — otherwise focus silently stays wherever it
+        // was and the sheet never receives it at all.
+        (sheetRef.current?.querySelector<HTMLElement>(FOCUSABLE) ?? sheetRef.current)?.focus();
 
         return () => {
             // Returning focus to the "Mehr" button is what makes the sheet
             // usable by keyboard at all — otherwise closing it drops the caret
             // back to the top of the document.
             restoreFocusRef.current?.focus();
+        };
+    }, [open]);
+
+    // Scroll-lock the app behind the sheet for as long as it's open — same
+    // pattern as DpaBlocker.tsx. Without it the page behind a position:fixed
+    // sheet keeps scrolling under the user's thumb.
+    useEffect(() => {
+        if (!open) {
+            return undefined;
+        }
+
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+
+        return () => {
+            document.body.style.overflow = previousOverflow;
         };
     }, [open]);
 
@@ -136,6 +155,7 @@ export const MoreMenuSheet = ({ ariaLabel, closeLabel, groups, lang, onClose, on
                 onKeyDown={handleKeyDown}
                 ref={sheetRef}
                 role="dialog"
+                tabIndex={-1}
             >
                 <span aria-hidden className={styles.grabber} />
                 {groups
@@ -159,17 +179,27 @@ export const MoreMenuSheet = ({ ariaLabel, closeLabel, groups, lang, onClose, on
                                     return (
                                         <li key={entry.key}>
                                             {entry.to ? (
-                                                <NavLink
+                                                // `Link`, not `NavLink`: NavLink overwrites any aria-current
+                                                // it is given with the result of its own route match, which
+                                                // would drop the marking here too — activeKey, not the
+                                                // router's current location, is this component's source of
+                                                // truth for which entry is current (see M3NavigationBar).
+                                                <Link
                                                     aria-current={isActive ? 'page' : undefined}
                                                     className={className}
                                                     onClick={select}
                                                     to={entry.to}
                                                 >
                                                     {entryContent(entry)}
-                                                </NavLink>
+                                                </Link>
                                             ) : (
+                                                // No `to` means this entry doesn't navigate to a route — it
+                                                // marks the current section of the page the user is already
+                                                // on. `aria-current="page"` is for a link that IS the active
+                                                // route; `"location"` is the correct value for a same-page
+                                                // position indicator (WAI-ARIA `aria-current`).
                                                 <button
-                                                    aria-current={isActive ? 'page' : undefined}
+                                                    aria-current={isActive ? 'location' : undefined}
                                                     className={className}
                                                     onClick={select}
                                                     type="button"

--- a/src/components/MoreMenuSheet/index.ts
+++ b/src/components/MoreMenuSheet/index.ts
@@ -1,0 +1,6 @@
+export {
+    MoreMenuSheet,
+    type MoreMenuSheetEntry,
+    type MoreMenuSheetGroup,
+    type MoreMenuSheetProps,
+} from './MoreMenuSheet';

--- a/src/components/MoreMenuSheet/moreMenuSheet.module.scss
+++ b/src/components/MoreMenuSheet/moreMenuSheet.module.scss
@@ -1,0 +1,154 @@
+/* Overflow sheet for the bottom bar's "Mehr" segment. Look and motion follow
+   GlobalSearchMenu (M3 elevation-2, 140ms cubic-bezier(0.2, 0, 0, 1)), but it
+   is a bottom sheet rather than a dropdown: it belongs to the bar it rises
+   from, and thumbs reach the bottom of the screen. */
+
+.layer {
+    position: fixed;
+    z-index: 1000;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+}
+
+.scrim {
+    position: absolute;
+    inset: 0;
+    border: 0;
+    background: rgb(0 0 0 / 32%);
+    animation: more-menu-scrim-in 140ms cubic-bezier(0.2, 0, 0, 1);
+    cursor: pointer;
+}
+
+.sheet {
+    position: relative;
+    max-height: 70vh;
+    /* Sits directly on top of the 96px bar, sharing its corner radius so the
+       two read as one surface rising out of the bottom edge. */
+    margin-bottom: 96px;
+    padding: 8px 0 12px;
+    overflow-y: auto;
+    background: var(--m3-surface-container-low, #f7f3f4);
+    border-radius: 12px 12px 0 0;
+    box-shadow: 0 -2px 6px rgb(0 0 0 / 6%), 0 -8px 24px rgb(0 0 0 / 12%);
+    animation: more-menu-sheet-in 140ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.grabber {
+    display: block;
+    width: 32px;
+    height: 4px;
+    margin: 0 auto 8px;
+    background: var(--m3-outline-variant, #c4c7c8);
+    border-radius: 2px;
+}
+
+.group + .group {
+    margin-top: 8px;
+    border-top: 1px solid var(--m3-outline-variant, #c4c7c8);
+    padding-top: 8px;
+}
+
+.groupLabel {
+    margin: 0;
+    padding: 8px 24px 4px;
+    color: var(--m3-on-surface-variant, #444748);
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.5px;
+    line-height: 16px;
+    text-transform: uppercase;
+}
+
+.list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.entry {
+    display: flex;
+    width: 100%;
+    /* 48px is the M3 minimum touch target; these rows are the fallback for
+       every destination that did not fit in the bar, so they must not be
+       fiddlier than the segments they stand in for. */
+    min-height: 48px;
+    align-items: center;
+    padding: 8px 24px;
+    border: 0;
+    background: none;
+    color: var(--m3-on-surface, #1b1b1c);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 16px;
+    gap: 16px;
+    letter-spacing: 0.15px;
+    line-height: 24px;
+    text-align: left;
+    text-decoration: none;
+
+    &:hover {
+        background: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 8%, transparent);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--m3-secondary, #4c555f);
+        outline-offset: -2px;
+    }
+}
+
+.entryActive {
+    background: var(--admin-field-selected-surface, #ffe2de);
+    color: var(--admin-field-selected-text, #930008);
+    font-weight: 500;
+}
+
+.icon {
+    display: inline-flex;
+    width: 24px;
+    height: 24px;
+    flex: 0 0 24px;
+    align-items: center;
+    justify-content: center;
+    color: currentcolor;
+
+    > svg {
+        width: 24px;
+        height: 24px;
+    }
+
+    :global(.anticon) {
+        font-size: 24px;
+        line-height: 1;
+    }
+}
+
+@keyframes more-menu-scrim-in {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes more-menu-sheet-in {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .scrim,
+    .sheet {
+        animation: none;
+    }
+}


### PR DESCRIPTION
Closes #628 — part of #622.

Stacked PR. Base is `pre-dev` (auto-retargeted; parent #636 already merged). Review only the top commit.

Rendered through a portal on document.body: the bar is position:fixed with its own stacking context and overflow:clip, so a sheet mounted inside it would be clipped and would unmount from under its own outside-click handler.

Lists every destination, including those already in the bar — the bar's contents change with viewport width, so a list of "the rest" would differ on every phone.

Escape listens on the document rather than the sheet, because after a scrim click the focus sits on the scrim and the key must still dismiss.

Verification: `npm run test`, `npx eslint . --max-warnings=0`, `npx prettier . --check`, `npm run build` — all green on the full stack.

## Reviewer test plan

- [ ] Tap "More": the sheet rises from the bottom and the bar stays visible beneath it

Reopened as a fresh PR (was #637) to clear stale Graphite stack-tracking that was blocking a native merge into `pre-dev` — no code changes beyond what was already authored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bottom-sheet overflow menu for grouped navigation options.
  * Supports active entries, links, buttons, icons, language metadata, and empty sections.
  * Added dismissal via scrim or Escape, focus restoration, keyboard focus trapping, and background scroll locking.
  * Includes entrance animations and reduced-motion support.

* **Tests**
  * Added comprehensive interaction and accessibility coverage for menu behavior.
  * Added visual and interactive examples for default, restricted, empty, and dismissal states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->