### PR TITLE
feat(nav): section carousel instead of pill tabs on mobile

### DIFF
--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -14,8 +14,11 @@ import { Spin } from 'antd';
 import classNames from 'classnames';
 import React, { cloneElement, forwardRef, Ref, useEffect, useMemo, useRef, type JSX } from 'react';
 import { useTranslation } from 'react-i18next';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 import { ReactComponent as TabStarIcon } from '../../resources/img/svg/permissions/tab_star.svg';
+import { SectionCarousel, type SectionCarouselItem } from '../SectionCarousel';
+import { getSectionArtwork } from '../../constants/sectionArtwork';
+import { useIsDesktopLayout } from '../../hooks/useIsDesktopLayout.hook';
 import styles from './styles.module.scss';
 
 interface PageProps {
@@ -72,6 +75,8 @@ export const tabIcons: Record<string, SvgIconComponent> = {
 const PageTabs = ({ tabs }: { tabs: Array<{ to: string; titleKey; iconName?: string; icon?: JSX.Element }> }) => {
     const { t } = useTranslation();
     const tabsContainerRef = useRef<HTMLDivElement>(null);
+    const isDesktopLayout = useIsDesktopLayout();
+    const { pathname } = useLocation();
 
     useEffect(() => {
         tabsContainerRef.current?.querySelector('a.active')?.scrollIntoView({
@@ -79,6 +84,41 @@ const PageTabs = ({ tabs }: { tabs: Array<{ to: string; titleKey; iconName?: str
             inline: 'nearest',
         });
     }, [tabs]);
+
+    /*
+     * Mobile shows the section carousel instead of the pill row: the pills are
+     * sized for a desktop header and become unusable on a phone. Artwork is
+     * looked up by `iconName`, which is also what the image files are named
+     * after — sections without one keep their icon on a tonal tile, so pages
+     * outside settings (logs, statistics, users) work unchanged.
+     */
+    if (!isDesktopLayout) {
+        const items: SectionCarouselItem[] = tabs
+            .filter((tab) => tab && tab.to)
+            .map(({ icon, iconName, ...tab }) => {
+                const Icon = iconName ? tabIcons[iconName] : undefined;
+                const TabIcon = Icon || TabStarIcon;
+
+                return {
+                    key: tab.to,
+                    label: String(t(tab.titleKey)),
+                    image: iconName ? getSectionArtwork(iconName) : undefined,
+                    icon: icon ?? <TabIcon data-admin-tab-icon={iconName || 'fallback'} />,
+                    to: tab.to,
+                };
+            });
+
+        const active = items.filter((item) => pathname === item.to || pathname.startsWith(`${item.to}/`));
+
+        return (
+            <SectionCarousel
+                activeKey={active.sort((a, b) => b.key.length - a.key.length)[0]?.key}
+                ariaLabel={String(t('settings.title', 'Bereiche'))}
+                dimUnselected
+                items={items}
+            />
+        );
+    }
 
     return (
         <div className={styles.tabsContainer} ref={tabsContainerRef}>


### PR DESCRIPTION
Closes #631 - part of #622.

Final PR in the mobile-nav stack. Reopened as a fresh PR (was #640) to clear stale Graphite stack-tracking that was blocking a native merge into pre-dev, following the same pattern as #647-#653 earlier in this stack.

PageTabs is the single place every page's tabs pass through, so no page file changes. Artwork is looked up by iconName, already the key the image files are named after; pages without artwork keep their icon tiles and work unchanged. Reuses SectionCarousel (merged in #652), which already renders Link (not NavLink) internally, so this integration is not exposed to the aria-current bug fixed earlier in the stack.

Reviewed locally: single-file diff, verified the "single tab" case is already guarded at the call site (finalTabs.length > 1 in Page/index.tsx), and confirmed there are no pre-existing tests for the Page component (not a regression - none existed before this PR either).

Verification: npx eslint . --max-warnings=0, npx prettier . --check, npx tsc --noEmit, npm run build - all green. npm run test (full suite, 233 files) has 3 pre-existing failing files (InviteComposer.test.tsx, DataProcessingAgreementCard.snackbar.test.tsx, LegalText.test.tsx, all failing with "window.localStorage.clear is not a function") that are unrelated to this change - confirmed by running them in isolation against a clean pre-dev checkout with none of this PR's changes, where they fail identically. None of the failing files touch PageTabs, Page/index.tsx, or SectionCarousel.

Reviewer test plan
- Settings on a phone shows illustrated section cards instead of the cut-off pill row
- Settings on desktop still shows the pill row, unchanged
- Logs, Statistics and Users on a phone show their tabs as icon cards and remain navigable
- Tapping a card navigates to that section and the card becomes the selected one
- Reload directly on a sub-section URL - the correct card is already marked as selected
- A page with only one tab does not render a pointless single-card strip