### PR TITLE
fix(permissions): honor granular functionality access

### DIFF
--- a/src/components/Tenants/AppSettings/PermissionsSettings/AgencyPermissionsSettings.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/AgencyPermissionsSettings.tsx
@@ -97,7 +97,6 @@ export const AgencyPermissionsSettings = ({ agencyId, excludeCardKeys }: AgencyP
     return (
         <PermissionsSettingsView
             tenantId={`agency-${agencyId}`}
-            disableSubTogglesWhenMasterOff
             excludeCardKeys={excludeCardKeys}
             isLoading={isLoading}
             initialValues={initialValues}

--- a/src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettings.stories.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettings.stories.tsx
@@ -73,7 +73,6 @@ type Story = StoryObj<typeof meta>;
  *  Sub-toggles disable when their card master is switched off. */
 export const TenantView: Story = {
     args: {
-        disableSubTogglesWhenMasterOff: true,
         initialValues: { settings: filledSettings },
     },
 };
@@ -82,7 +81,6 @@ export const TenantView: Story = {
  *  are locked off while the master is off — "disable, don't hide". */
 export const LiveChatMasterOff: Story = {
     args: {
-        disableSubTogglesWhenMasterOff: true,
         initialValues: {
             settings: { ...filledSettings, featureAnonymousChatEnabled: false },
         },
@@ -94,7 +92,6 @@ export const LiveChatMasterOff: Story = {
  *  by the tenant admin. */
 export const PlatformForcedVideoOff: Story = {
     args: {
-        disableSubTogglesWhenMasterOff: true,
         restrictedFields: getForcedOffFields({ videoCalls: false } as never),
         initialValues: {
             settings: {
@@ -109,12 +106,19 @@ export const PlatformForcedVideoOff: Story = {
     },
 };
 
-/** Super-admin (platform) view: sub-toggles stay editable regardless of the
- *  card master, because the platform decides which toggles tenants may see. */
+/** Super-admin (platform) view with every chat-type master enabled. */
 export const SuperAdminView: Story = {
     args: {
-        disableSubTogglesWhenMasterOff: false,
         initialValues: { settings: filledSettings },
+    },
+};
+
+/** Platform view with the 1:1 master off: children remain visible but non-interactive until the
+ *  master is enabled again, matching tenant and agency behavior. */
+export const SuperAdminMasterOff: Story = {
+    args: {
+        enforceMode: true,
+        initialValues: { settings: { ...filledSettings, featureCallsEnabled: false } },
     },
 };
 
@@ -122,7 +126,6 @@ export const SuperAdminView: Story = {
  *  feature to lock it on for every lower role, so it can no longer be hidden. */
 export const EnforceActiveStates: Story = {
     args: {
-        disableSubTogglesWhenMasterOff: false,
         enforceMode: true,
         initialValues: { settings: filledSettings },
     },

--- a/src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettingsView.test.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettingsView.test.tsx
@@ -40,7 +40,6 @@ const renderOneOnOne = (initialSettings: Record<string, boolean>, onToggleUpdate
     render(
         <PermissionsSettingsView
             tenantId="t1"
-            disableSubTogglesWhenMasterOff={false}
             excludeCardKeys={['liveChat', 'group', 'groupInternal']}
             isLoading={false}
             initialValues={{ settings: initialSettings }}
@@ -90,5 +89,17 @@ describe('PermissionsSettingsView data parity (1-on-1 card)', () => {
                 settings: expect.objectContaining({ featureVideoCallsOneOnOneChatsEnabled: true }),
             }),
         );
+    });
+
+    it('keeps child features visible but disabled until the platform card master is enabled', async () => {
+        const user = userEvent.setup();
+        renderOneOnOne({ featureCallsEnabled: false, featureVideoCallsOneOnOneChatsEnabled: true });
+
+        const videoCalls = screen.getByRole('switch', { name: 'tenants.permissions.feature.videoCalls' });
+        expect(videoCalls).toBeDisabled();
+
+        await user.click(screen.getByRole('switch', { name: 'tenants.permissions.card.activated' }));
+
+        expect(videoCalls).toBeEnabled();
     });
 });

--- a/src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettingsView.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettingsView.tsx
@@ -14,7 +14,6 @@ import styles from './styles.module.scss';
 
 export type PermissionsSettingsViewProps = {
     tenantId: string;
-    disableSubTogglesWhenMasterOff: boolean;
     excludeCardKeys?: Array<ChatTypeCardKey>;
     isLoading: boolean;
     initialValues: Record<string, unknown>;
@@ -35,7 +34,6 @@ export type PermissionsSettingsViewProps = {
 
 export const PermissionsSettingsView = ({
     tenantId,
-    disableSubTogglesWhenMasterOff,
     excludeCardKeys,
     isLoading,
     initialValues,
@@ -173,12 +171,11 @@ export const PermissionsSettingsView = ({
                                                                 label={t(toggle.labelKey)}
                                                                 disabled={
                                                                     restrictedFields.has(toggle.field[1]) ||
-                                                                    (disableSubTogglesWhenMasterOff &&
-                                                                        isSubToggleDisabled(
-                                                                            card,
-                                                                            toggle.field,
-                                                                            masterEnabled,
-                                                                        ))
+                                                                    isSubToggleDisabled(
+                                                                        card,
+                                                                        toggle.field,
+                                                                        masterEnabled,
+                                                                    )
                                                                 }
                                                                 onAfterChange={onToggleUpdate}
                                                             />

--- a/src/components/Tenants/AppSettings/PermissionsSettings/SuperAdminPermissionsSettings.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/SuperAdminPermissionsSettings.tsx
@@ -85,7 +85,6 @@ export const SuperAdminPermissionsSettings = ({ tenantId, excludeCardKeys }: Per
     return (
         <PermissionsSettingsView
             tenantId={tenantId}
-            disableSubTogglesWhenMasterOff={false}
             excludeCardKeys={excludeCardKeys}
             isLoading={isLoading}
             initialValues={initialValues}

--- a/src/components/Tenants/AppSettings/PermissionsSettings/TenantPermissionsSettings.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/TenantPermissionsSettings.tsx
@@ -78,7 +78,6 @@ export const TenantPermissionsSettings = ({ tenantId, excludeCardKeys }: Permiss
     return (
         <PermissionsSettingsView
             tenantId={tenantId}
-            disableSubTogglesWhenMasterOff
             excludeCardKeys={excludeCardKeys}
             isLoading={isLoading}
             initialValues={initialValues}

--- a/src/components/Tenants/AppSettings/PermissionsSettings/permissionsSettingsUtils.test.ts
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/permissionsSettingsUtils.test.ts
@@ -37,6 +37,18 @@ describe('permissions settings utils', () => {
         expect(singleAiScan.size).toBe(1);
     });
 
+    it('lets an explicitly enabled AI scan child override the disabled hidden family master', () => {
+        const forcedOffFields = getForcedOffFields({
+            mediaAiScan: false,
+            mediaAiScanOneOnOneChats: true,
+            mediaAiScanGroupChats: false,
+        } as any);
+
+        expect(forcedOffFields.has('featureMediaAiScanEnabled')).toBe(true);
+        expect(forcedOffFields.has('featureMediaAiScanOneOnOneChatsEnabled')).toBe(false);
+        expect(forcedOffFields.has('featureMediaAiScanGroupChatsEnabled')).toBe(true);
+    });
+
     it('defaults media upload and inline display on, AI scan off', () => {
         expect(DEFAULT_PERMISSION_SETTINGS.featureMediaUploadEnabled).toBe(true);
         expect(DEFAULT_PERMISSION_SETTINGS.featureMediaInlineDisplayEnabled).toBe(true);

--- a/src/components/Tenants/AppSettings/PermissionsSettings/permissionsSettingsUtils.ts
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/permissionsSettingsUtils.ts
@@ -153,6 +153,16 @@ export const PLATFORM_TOGGLE_FIELDS: Record<keyof PermissionToggleVisibility, st
     mediaAiScanSupervisionChats: ['featureMediaAiScanSupervisionChatsEnabled'],
 };
 
+/**
+ * Direct setting owned by each governance toggle. Family toggles list their own setting first,
+ * followed by the child settings they constrain when disabled.
+ */
+export const TOGGLE_KEY_TO_FIELD = Object.fromEntries(
+    (Object.entries(PLATFORM_TOGGLE_FIELDS) as [keyof PermissionToggleVisibility, string[]][]).map(
+        ([toggleKey, [directField]]) => [toggleKey, directField],
+    ),
+) as Record<keyof PermissionToggleVisibility, string>;
+
 const ONE_ON_ONE_CALL_TOGGLE_FIELDS = new Set([
     'featureVideoCallsOneOnOneChatsEnabled',
     'featureAudioCallsOneOnOneChatsEnabled',
@@ -161,16 +171,25 @@ const ONE_ON_ONE_CALL_TOGGLE_FIELDS = new Set([
 export const getForcedOffFields = (toggles?: PermissionToggleVisibility) => {
     if (!toggles) return new Set<string>();
 
-    return Object.entries(toggles).reduce((fields, [toggleKey, enabled]) => {
+    const fields = Object.entries(toggles).reduce((forcedOffFields, [toggleKey, enabled]) => {
         if (enabled === false) {
             const platformFields = PLATFORM_TOGGLE_FIELDS[toggleKey as keyof PermissionToggleVisibility];
             if (platformFields) {
-                platformFields.forEach((field) => fields.add(field));
-                return fields;
+                platformFields.forEach((field) => forcedOffFields.add(field));
             }
         }
-        return fields;
+        return forcedOffFields;
     }, new Set<string>());
+
+    // A granular permission is authoritative for its own field. This lets a platform admin opt a
+    // chat type into AI scanning even though the hidden family master defaults off.
+    Object.entries(toggles).forEach(([toggleKey, enabled]) => {
+        if (enabled === true) {
+            fields.delete(TOGGLE_KEY_TO_FIELD[toggleKey as keyof PermissionToggleVisibility]);
+        }
+    });
+
+    return fields;
 };
 
 export const applyForcedOffFields = (
@@ -263,55 +282,6 @@ export const applyVisibleTogglesAsValues = (visibleToggles?: PermissionToggleVis
     );
 
     return settings;
-};
-
-/**
- * 1:1 map from a platform allowed/enforced toggle key to the single settings feature flag it
- * mirrors. Encoding (settings → controls) and decoding stay inverse because each key owns exactly
- * one field — no cross-gating by a card master and no group/granular overlap. See ADR-013 P2.
- */
-export const TOGGLE_KEY_TO_FIELD: Record<keyof PermissionToggleVisibility, string> = {
-    anonymousChat: 'featureAnonymousChatEnabled',
-    groupChat: 'featureGroupChatV2Enabled',
-    calls: 'featureCallsEnabled',
-    supervision: 'featureSupervisionEnabled',
-    supervisionAnonymousChats: 'featureSupervisionAnonymousChatsEnabled',
-    supervisionOneOnOneChats: 'featureSupervisionOneOnOneChatsEnabled',
-    audioCalls: 'featureAudioCallsEnabled',
-    audioCallsAnonymousChats: 'featureAudioCallsAnonymousChatsEnabled',
-    audioCallsOneOnOneChats: 'featureAudioCallsOneOnOneChatsEnabled',
-    audioCallsGroupChats: 'featureAudioCallsGroupChatsEnabled',
-    audioCallsSupervisionChats: 'featureAudioCallsSupervisionChatsEnabled',
-    videoCalls: 'featureVideoCallsEnabled',
-    videoCallsAnonymousChats: 'featureVideoCallsAnonymousChatsEnabled',
-    videoCallsOneOnOneChats: 'featureVideoCallsOneOnOneChatsEnabled',
-    videoCallsGroupChats: 'featureVideoCallsGroupChatsEnabled',
-    videoCallsSupervisionChats: 'featureVideoCallsSupervisionChatsEnabled',
-    threads: 'featureThreadsEnabled',
-    threadsAnonymousChats: 'featureThreadsAnonymousChatsEnabled',
-    threadsOneOnOneChats: 'featureThreadsOneOnOneEnabled',
-    threadsGroupChats: 'featureThreadsGroupChatsEnabled',
-    threadsSupervisionChats: 'featureThreadsSupervisionChatsEnabled',
-    voiceMessages: 'featureVoiceMessagesEnabled',
-    voiceMessagesAnonymousChats: 'featureVoiceMessagesAnonymousChatsEnabled',
-    voiceMessagesOneOnOneChats: 'featureVoiceMessagesOneOnOneChatsEnabled',
-    voiceMessagesGroupChats: 'featureVoiceMessagesGroupChatsEnabled',
-    voiceMessagesSupervisionChats: 'featureVoiceMessagesSupervisionChatsEnabled',
-    mediaUpload: 'featureMediaUploadEnabled',
-    mediaUploadAnonymousChats: 'featureMediaUploadAnonymousChatsEnabled',
-    mediaUploadOneOnOneChats: 'featureMediaUploadOneOnOneChatsEnabled',
-    mediaUploadGroupChats: 'featureMediaUploadGroupChatsEnabled',
-    mediaUploadSupervisionChats: 'featureMediaUploadSupervisionChatsEnabled',
-    mediaInlineDisplay: 'featureMediaInlineDisplayEnabled',
-    mediaInlineDisplayAnonymousChats: 'featureMediaInlineDisplayAnonymousChatsEnabled',
-    mediaInlineDisplayOneOnOneChats: 'featureMediaInlineDisplayOneOnOneChatsEnabled',
-    mediaInlineDisplayGroupChats: 'featureMediaInlineDisplayGroupChatsEnabled',
-    mediaInlineDisplaySupervisionChats: 'featureMediaInlineDisplaySupervisionChatsEnabled',
-    mediaAiScan: 'featureMediaAiScanEnabled',
-    mediaAiScanAnonymousChats: 'featureMediaAiScanAnonymousChatsEnabled',
-    mediaAiScanOneOnOneChats: 'featureMediaAiScanOneOnOneChatsEnabled',
-    mediaAiScanGroupChats: 'featureMediaAiScanGroupChatsEnabled',
-    mediaAiScanSupervisionChats: 'featureMediaAiScanSupervisionChatsEnabled',
 };
 
 export const syncMasterTogglesToTenantAdminControls = (formData: { settings?: Record<string, unknown> }) => {


### PR DESCRIPTION
## Problem

Functionality Access had two conflicting permission behaviors:

- a hidden disabled AI Media Check family master forced every tenant child off, even when the platform explicitly allowed one chat type;
- platform-level child toggles stayed interactive while their chat-type master was off, unlike tenant and agency views.

Closes #656. Parent delivery issue: #655.

## Solution

- Expand disabled family constraints first, then let an explicitly enabled granular permission own its direct field.
- Enforce the master-off child lock in the shared permissions view for platform, tenant, and agency usage.
- Derive the direct toggle-field map from the existing platform field registry instead of maintaining a duplicate literal map.
- Add the platform master-off Storybook state and regression tests for both behaviors.

The case-handover save failure tracked in the parent issue is fixed independently in `ORISO-UserService#962`; neither diff has to merge first, but both are required to close the parent delivery slice.

## Validation

- `npm test`: 236 files / 1,475 tests passed.
- `npm run build`: passed.
- `npm run build-storybook`: passed.
- `npm run lint:js`: passed.
- Touched permissions directory: Prettier and `git diff --check` passed.
- Focused PreDev real-browser gate passed on the candidate bundle at 1440x900 and 390x844:
  - master off left children visible and disabled, then test state was restored;
  - platform `mediaAiScan=false` plus 1:1 granular allow made Bart Simpson's tenant 1:1 AI toggle editable and persistent, while Group stayed locked;
  - all platform and tenant test settings were restored.

Repository-wide Stylelint currently reports 881 pre-existing errors in unrelated SCSS files. This PR changes no styles.

## Reviewer checklist

- [ ] Confirm an explicitly true granular permission overrides only its own field, not sibling constraints.
- [ ] Confirm explicitly false granular permissions remain forced off.
- [ ] Confirm platform, tenant, and agency children are disabled while their chat-type master is off.
- [ ] Inspect the Storybook `SuperAdminMasterOff` state and responsive screenshots.
- [ ] Confirm no generated or unrelated files are included.

## Risk

The constraint change is intentionally narrow: it removes a field from the forced-off set only when that same granular toggle is explicitly `true`. Browser proof used disposable images; regular PreDev images were restored after the run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permission sub-toggles now consistently appear disabled when their master setting is off.
  * Explicitly enabled granular permissions remain available where supported, while other restricted settings stay disabled.
  * Permission behavior is now consistent across tenant, agency, and administrator settings.

* **Tests**
  * Added coverage for master-toggle behavior and granular permission overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->