### PR TITLE
refactor(settings): single source for the branding read-only lock (#579)

### DIFF
--- a/src/components/Tenants/GeneralSettings/components/LogoAndFavicon/index.tsx
+++ b/src/components/Tenants/GeneralSettings/components/LogoAndFavicon/index.tsx
@@ -7,10 +7,8 @@ import { FormFileUploaderField } from '../../../../FormFileUploaderField';
 import { usePublicTenantData } from '../../../../../hooks/usePublicTenantData.hook';
 import { useTenantAppearanceFormData } from '../../../../../hooks/useTenantAppearanceFormData';
 import { useAppConfigContext } from '../../../../../context/useAppConfig';
+import { isReadOnlySetting } from '../../../../../utils/serverSettingsMeta';
 import styles from './styles.module.scss';
-
-const isReadOnlySetting = (meta: Record<string, { readOnly?: boolean }> | undefined, keys: string[]) =>
-    keys.some((key) => meta?.[key]?.readOnly);
 
 export const LogoAndFavicon = ({ tenantId, readOnly = false }: { tenantId: string; readOnly?: boolean }) => {
     const { t } = useTranslation();

--- a/src/components/Tenants/GeneralSettings/components/TenantColor/index.tsx
+++ b/src/components/Tenants/GeneralSettings/components/TenantColor/index.tsx
@@ -5,9 +5,7 @@ import { useAppConfigContext } from '../../../../../context/useAppConfig';
 import { usePublicTenantData } from '../../../../../hooks/usePublicTenantData.hook';
 import { useSingleTenantData } from '../../../../../hooks/useSingleTenantData';
 import { useTenantAdminDataMutation } from '../../../../../hooks/useTenantAdminDataMutation.hook';
-
-const isReadOnlySetting = (meta: Record<string, { readOnly?: boolean }> | undefined, keys: string[]) =>
-    keys.some((key) => meta?.[key]?.readOnly);
+import { isReadOnlySetting } from '../../../../../utils/serverSettingsMeta';
 
 export const TenantColor = ({ tenantId, readOnly = false }: { tenantId: string; readOnly?: boolean }) => {
     const { t } = useTranslation();


### PR DESCRIPTION
## Problem

`LogoAndFavicon` and `TenantColor` each carried a private copy of
`isReadOnlySetting`, identical to the one exported from `utils/serverSettingsMeta`
that `ThemeBuilder` already imports — three implementations of the branding
inheritance-lock check, two of them untested.

## What changed

- Both components now import the shared helper; the two local copies are gone.
- No behaviour change. It matters because this check is the extension point for
  #81's missing half, and three copies is how they drift apart.

## Verification

- `npx vitest run` — 1472 pass, 1 fail (`src/pages/lazyNamed.test.ts`, Safari
  private mode); that one fails identically on a clean `origin/pre-dev`, verified.
- Targeted CardDeck / settingsTabs / serverSettingsMeta / GeneralSettings: 24 pass.
- `npx tsc --noEmit`, `npx eslint --max-warnings=0`, `npx prettier --check`: clean.

Epic state (#57 closed, #58 and #568 already built, #81 blocked on #665) is
reported on #579 rather than repeated here.

Refs #579, #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized read-only setting handling across tenant branding settings for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->