### PR TITLE
fix(storybook): resolve the MSW worker relative to the Storybook base

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -17,7 +17,14 @@ import '../src/i18n';
 
 // Start the MSW request-mocking worker. Stories opt in with `parameters.msw.handlers`;
 // everything else passes through untouched (`onUnhandledRequest: 'bypass'`).
-initialize({ onUnhandledRequest: 'bypass' });
+// The worker URL must be resolved relative to the preview iframe: MSW's default is the
+// absolute '/mockServiceWorker.js', which on a sub-path deployment (Pre-Dev serves this
+// build under /storybook-admin/) hits the app's SPA fallback and returns text/html —
+// registration then fails and *every* story renders as an error page instead.
+initialize({
+    onUnhandledRequest: 'bypass',
+    serviceWorker: { url: new URL('mockServiceWorker.js', window.location.href).href },
+});
 
 const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },


### PR DESCRIPTION
## Problem

Every story in the Pre-Dev Storybook (`/storybook-admin/`) rendered Storybook's "component failed to render" page. MSW registered its service worker at the absolute `/mockServiceWorker.js`, which on a sub-path deployment hits the app's SPA fallback (`text/html`) and fails registration — so `mswLoader` rejected for every story.

## What changed

- `.storybook/preview.tsx`: resolve the worker URL against the preview iframe (`new URL('mockServiceWorker.js', window.location.href)`) instead of the domain root.
- Comment explains why the default is wrong here, so it doesn't get "simplified" back.

Root-served local dev is unaffected — the resolved URL is identical to the old default.

## Verification

- Built the Storybook and served it under `/storybook-admin/`: EditButton "Custom Label" renders; console logs `[MSW] Mocking enabled`, worker URL `/storybook-admin/mockServiceWorker.js`.
- MSW-backed story `Organisms/Pages/Logs/CaseHandoverLogs — Filled` still renders mocked rows, so mocking works, not just registration.
- Served the same build at the domain root: worker URL `/mockServiceWorker.js`, no regression.
- `npx prettier --check`, `npx tsc --noEmit` (clean), `npx eslint .` (334 errors — unchanged baseline), `npm run build-storybook`.

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)