### PR TITLE
show card titles in permissions settings

### DIFF
--- a/src/components/Tenants/AppSettings/PermissionsSettings/styles.module.scss
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/styles.module.scss
@@ -25,7 +25,7 @@
         display: none !important;
     }
 
-    h5 {
+    > .cardEditable > h5 {
         display: none !important;
     }
 }


### PR DESCRIPTION
## Why
Card titles (Fallübergabe, 1:1, Gruppenberatungen, etc.) were hidden in
Functionality Access settings because `.transparentCardWrapper h5 { display: none }`
targeted all h5 elements, including card titles that use Ant Design Title level 5.

## What
Scoped the rule to `.transparentCardWrapper > .cardEditable > h5` so only
the outer CardEditable header is hidden, not nested card titles.

## Screenshots
<img width="1883" height="931" alt="image" src="https://github.com/user-attachments/assets/20b69eca-8f1e-45b1-9116-8ac3e66053d6" />
<img width="1887" height="927" alt="image" src="https://github.com/user-attachments/assets/7dd3f3e7-19c7-407c-a886-50ffbe4fbb74" />
<img width="1903" height="937" alt="image" src="https://github.com/user-attachments/assets/9609b03c-c0d1-453b-bf1d-401e62341506" />


## Test
- [ ] /admin/theme-settings/permissions — card titles visible
- [ ] /admin/agency/:id/functionalities — card titles visible

Closes #669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended hiding of heading elements within permission settings cards, ensuring only the intended card title is hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->