### PR TITLE
feat(admin): lay out Agency General Information fields with FieldGrid

### DIFF
--- a/src/pages/Agency/Edit/components/GeneralInformation/index.tsx
+++ b/src/pages/Agency/Edit/components/GeneralInformation/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
-import { Col, Row } from 'antd';
 import { MuiFormField, MuiMultilineFormField } from '../../../../../components/mui/MuiFormField';
 import { Card } from '../../../../../components/Card';
+import { FieldGrid } from '../../../../../components/FieldGrid';
 
 interface AgencyGeneralInformationProps {
     asFields?: boolean;
@@ -12,100 +12,86 @@ export const AgencyGeneralInformation = ({ asFields }: AgencyGeneralInformationP
     const requiredRule = { required: true, message: t('form.errors.required') };
 
     const fields = (
-        <>
+        <FieldGrid>
+            {/* Name + description span the full row; the address fields flow into
+                as many columns as the card width allows (FieldGrid decides — the
+                per-field antd Col spans are gone). Field data binding is unchanged:
+                every Form.Item name/rule/inputProps is identical to before. */}
+            <FieldGrid.Wide>
+                <MuiFormField
+                    name="name"
+                    label={t('agency.edit.general.general_information.name')}
+                    placeholder={t('agency.edit.general.general_information.name')}
+                    required
+                    rules={[requiredRule]}
+                />
+            </FieldGrid.Wide>
+
             <MuiFormField
-                name="name"
-                label={t('agency.edit.general.general_information.name')}
-                placeholder={t('agency.edit.general.general_information.name')}
+                name="postcode"
+                label={t('agency.edit.general.address.postcode')}
+                placeholder={t('agency.edit.general.address.postcode')}
+                required
+                inputProps={{ maxLength: 5 }}
+                rules={[requiredRule, { min: 5, required: true, message: t('agency.postcode.minimum') }]}
+            />
+            <MuiFormField
+                name="city"
+                label={t('agency.edit.general.address.city')}
+                placeholder={t('agency.edit.general.address.city')}
                 required
                 rules={[requiredRule]}
             />
-
-            <Row gutter={[20, 10]}>
-                <Col xs={12} sm={4}>
-                    <MuiFormField
-                        name="postcode"
-                        label={t('agency.edit.general.address.postcode')}
-                        placeholder={t('agency.edit.general.address.postcode')}
-                        required
-                        inputProps={{ maxLength: 5 }}
-                        rules={[requiredRule, { min: 5, required: true, message: t('agency.postcode.minimum') }]}
-                    />
-                </Col>
-                <Col xs={12} sm={8}>
-                    <MuiFormField
-                        name="city"
-                        label={t('agency.edit.general.address.city')}
-                        placeholder={t('agency.edit.general.address.city')}
-                        required
-                        rules={[requiredRule]}
-                    />
-                </Col>
-                <Col xs={16} sm={8}>
-                    <MuiFormField
-                        name="street"
-                        label={t('agency.edit.general.address.street')}
-                        placeholder={t('agency.edit.general.address.street')}
-                        inputProps={{ maxLength: 255 }}
-                    />
-                </Col>
-                <Col xs={8} sm={4}>
-                    <MuiFormField
-                        name="houseNumber"
-                        label={t('agency.edit.general.address.house_number')}
-                        placeholder={t('agency.edit.general.address.house_number')}
-                        inputProps={{ maxLength: 20 }}
-                    />
-                </Col>
-                <Col xs={12} sm={8}>
-                    <MuiFormField
-                        name="floorBuilding"
-                        label={t('agency.edit.general.address.floor_building')}
-                        placeholder={t('agency.edit.general.address.floor_building')}
-                        inputProps={{ maxLength: 100 }}
-                    />
-                </Col>
-                <Col xs={12} sm={8}>
-                    <MuiFormField
-                        name="country"
-                        label={t('agency.edit.general.address.country')}
-                        placeholder={t('agency.edit.general.address.country')}
-                        inputProps={{ maxLength: 100 }}
-                    />
-                </Col>
-                <Col xs={12} sm={8}>
-                    <MuiFormField
-                        name="phone"
-                        label={t('agency.edit.general.address.phone')}
-                        placeholder={t('agency.edit.general.address.phone')}
-                        inputProps={{ maxLength: 30 }}
-                    />
-                </Col>
-                <Col xs={12} sm={8}>
-                    <MuiFormField
-                        name="phoneSecondary"
-                        label={t('agency.edit.general.address.phone_secondary')}
-                        placeholder={t('agency.edit.general.address.phone_secondary')}
-                        inputProps={{ maxLength: 30 }}
-                    />
-                </Col>
-                <Col xs={24} sm={8}>
-                    <MuiFormField
-                        name="email"
-                        label={t('agency.edit.general.address.email')}
-                        placeholder={t('agency.edit.general.address.email')}
-                        inputProps={{ maxLength: 255 }}
-                    />
-                </Col>
-                <Col xs={24}>
-                    <MuiMultilineFormField
-                        name="description"
-                        label={t('agency.edit.general.general_information.description')}
-                        placeholder={t('agency.edit.general.general_information.description')}
-                    />
-                </Col>
-            </Row>
-        </>
+            <MuiFormField
+                name="street"
+                label={t('agency.edit.general.address.street')}
+                placeholder={t('agency.edit.general.address.street')}
+                inputProps={{ maxLength: 255 }}
+            />
+            <MuiFormField
+                name="houseNumber"
+                label={t('agency.edit.general.address.house_number')}
+                placeholder={t('agency.edit.general.address.house_number')}
+                inputProps={{ maxLength: 20 }}
+            />
+            <MuiFormField
+                name="floorBuilding"
+                label={t('agency.edit.general.address.floor_building')}
+                placeholder={t('agency.edit.general.address.floor_building')}
+                inputProps={{ maxLength: 100 }}
+            />
+            <MuiFormField
+                name="country"
+                label={t('agency.edit.general.address.country')}
+                placeholder={t('agency.edit.general.address.country')}
+                inputProps={{ maxLength: 100 }}
+            />
+            <MuiFormField
+                name="phone"
+                label={t('agency.edit.general.address.phone')}
+                placeholder={t('agency.edit.general.address.phone')}
+                inputProps={{ maxLength: 30 }}
+            />
+            <MuiFormField
+                name="phoneSecondary"
+                label={t('agency.edit.general.address.phone_secondary')}
+                placeholder={t('agency.edit.general.address.phone_secondary')}
+                inputProps={{ maxLength: 30 }}
+            />
+            <MuiFormField
+                name="email"
+                label={t('agency.edit.general.address.email')}
+                placeholder={t('agency.edit.general.address.email')}
+                inputProps={{ maxLength: 255 }}
+            />
+            <FieldGrid.Wide>
+                <MuiMultilineFormField
+                    name="description"
+                    label={t('agency.edit.general.general_information.description')}
+                    placeholder={t('agency.edit.general.general_information.description')}
+                />
+            </FieldGrid.Wide>
+        </FieldGrid>
     );
 
     if (asFields) {


### PR DESCRIPTION
Closes OpenResilienceInitiative/ORISO-Admin#696

## What
Applies the `FieldGrid` responsive column layout (introduced in #434 for tenant create) to the Agency **General Information** section. Layout-only change: 77+/91−, one file, no logic or validation touched.

## Why
Finished local commit found without a PR during the 2026-08-12 leftover-work sweep — shipping it instead of letting it drift.

## How should I test this?
- [ ] Open Agency → create: the General Information fields align in the same responsive grid as the tenant create form.
- [ ] Resize to 320px and 412px: fields stack cleanly, labels readable, nothing overlaps.
- [ ] Create/edit an agency with every field filled → values save and read back unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
