### PR TITLE
ci: reject fixable HIGH/CRITICAL vulnerabilities in published images

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -68,3 +68,13 @@ jobs:
                     echo "::error::${ref} ships '${shipped}' but this run built '${built}' — stale bundle in image (issue #424)."
                     exit 1
                   fi
+
+            - name: Reject fixable high or critical image vulnerabilities
+              uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+              with:
+                  image-ref: ${{ env.REGISTRY }}/${{ env.ORG }}/oriso-admin@${{ steps.publish.outputs.digest }}
+                  format: table
+                  exit-code: '1'
+                  ignore-unfixed: true
+                  vuln-type: os,library
+                  severity: CRITICAL,HIGH

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -71,6 +71,7 @@ jobs:
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Build and push admin image
+              id: app_image
               uses: docker/build-push-action@v7
               with:
                   context: .
@@ -84,7 +85,18 @@ jobs:
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
 
+            - name: Reject fixable admin image vulnerabilities
+              uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+              with:
+                  image-ref: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.APP_IMAGE_NAME }}@${{ steps.app_image.outputs.digest }}
+                  format: table
+                  exit-code: '1'
+                  ignore-unfixed: true
+                  vuln-type: os,library
+                  severity: CRITICAL,HIGH
+
             - name: Build and push admin Storybook image
+              id: storybook_image
               uses: docker/build-push-action@v7
               with:
                   context: .
@@ -97,6 +109,16 @@ jobs:
                       org.opencontainers.image.version=${{ env.VERSION }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
+
+            - name: Reject fixable Storybook image vulnerabilities
+              uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+              with:
+                  image-ref: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ env.STORYBOOK_IMAGE_NAME }}@${{ steps.storybook_image.outputs.digest }}
+                  format: table
+                  exit-code: '1'
+                  ignore-unfixed: true
+                  vuln-type: os,library
+                  severity: CRITICAL,HIGH
 
             - name: Create and push release tag
               shell: bash


### PR DESCRIPTION
Mirror the container-scanning gate that AgencyService, UserService and Frontend
already run, so every repo that publishes an image has one.

What the gate is:
  aquasecurity/trivy-action (pinned to the same SHA the other repos use),
  exit-code 1, ignore-unfixed, vuln-type os,library, severity CRITICAL,HIGH,
  referencing the image by immutable digest rather than a mutable tag.

Added to:
- ci-main.yml (push to main/dev/pre-dev), after the existing stale-bundle check
- release-image.yml, for both the admin image and the Storybook image

HONEST WARNING - this gate will be RED on its first run, and unlike the Java
services it will not be fixed by a dependency bump.

I scanned ghcr.io/openresilienceinitiative/oriso-admin:pre-dev locally with the
same settings first. It reports 21 fixable HIGH/CRITICAL findings, all of them
OS packages, and the root cause is the base image:

  FROM ghcr.io/onlineberatung/onlineberatung-nginx:dockerimage.v.005-main

That is Alpine 3.18.4, which Trivy flags as EOSL - end of service life, no
security updates published anymore. Findings include CVE-2024-45491 and
CVE-2024-45492 (libexpat, CRITICAL), CVE-2024-6119 (libcrypto3) and
CVE-2024-6197 (curl/libcurl).

It is also an image from the old onlineberatung org that we do not control and
that has not been rebuilt in a long time. The Dockerfile only uses nginx itself
from it - our own nginx.conf, entrypoint and bundle are copied in on top, and
Node.js is installed at build time - so moving to an actively maintained base
looks feasible. That migration is deliberately NOT in this PR: it needs its own
change and a container smoke test.

Order of operations: either land the base-image migration first, or accept a red
ci-main on pre-dev until it lands. Flagging rather than quietly weakening the
gate, since a gate tuned to pass is not a gate.

Local scan settings used, for reproduction:
  trivy image --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed \
    --pkg-types os,library ghcr.io/openresilienceinitiative/oriso-admin:pre-dev

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)