### PR TITLE
fix(nav): stop MobileNavProvider from freezing the admin panel after one navigation

### DIFF
--- a/src/components/AdminMobileNav/MobileNavContext.test.tsx
+++ b/src/components/AdminMobileNav/MobileNavContext.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import { useRef } from 'react';
+import { describe, expect, it } from 'vitest';
+import { MobileNavProvider, useMobileNav, useRegisterMobileNav } from './MobileNavContext';
+
+/**
+ * Regression guard for ORISO-Admin#702 / ORISO-E2E#57.
+ *
+ * `MobileNavProvider` used to rebuild its `register` callback whenever the merged
+ * registration changed, while `useRegisterMobileNav` listed `register` in its effect
+ * dependencies. Registering therefore invalidated the very function that had just been
+ * used to register, re-running the effect forever: React aborted the render pass with
+ * "Maximum update depth exceeded" (minified error #185).
+ *
+ * Because that abort happens inside a `startTransition` (react-router wraps every
+ * navigation in one), it never surfaced as a crash — the admin panel simply stopped
+ * re-rendering: the URL advanced and the page kept showing the previous screen.
+ */
+
+/** Counts its own renders so a non-converging update loop is visible as a number. */
+const RegisteringPage = ({ label }: { label: string }) => {
+    const renders = useRef(0);
+    renders.current += 1;
+
+    useRegisterMobileNav('page', {
+        subsections: [{ key: '/a', label: 'A', to: '/a' }],
+        activeSubsectionKey: '/a',
+        backPath: '/back',
+        backLabel: label,
+    });
+
+    return <div data-testid="renders">{renders.current}</div>;
+};
+
+const Consumer = () => {
+    const registration = useMobileNav();
+    return <div data-testid="back-label">{registration?.backLabel ?? 'none'}</div>;
+};
+
+describe('MobileNavProvider', () => {
+    it('settles after a page registers instead of looping forever', () => {
+        render(
+            <MobileNavProvider>
+                <RegisteringPage label="Zurück" />
+                <Consumer />
+            </MobileNavProvider>,
+        );
+
+        // The registration must reach the bar...
+        expect(screen.getByTestId('back-label')).toHaveTextContent('Zurück');
+        // ...and registering must not feed itself a new `register` identity forever.
+        expect(Number(screen.getByTestId('renders').textContent)).toBeLessThan(10);
+    });
+
+    it('keeps the register callback referentially stable across registrations', () => {
+        const seen = new Set<unknown>();
+
+        const Probe = () => {
+            useRegisterMobileNav('probe', { backLabel: 'x' });
+            const registration = useMobileNav();
+            return <span>{registration?.backLabel ?? '-'}</span>;
+        };
+
+        const Spy = () => {
+            const registration = useMobileNav();
+            seen.add(registration);
+            return null;
+        };
+
+        render(
+            <MobileNavProvider>
+                <Probe />
+                <Spy />
+            </MobileNavProvider>,
+        );
+
+        // null + the single merged registration — not one object per loop iteration.
+        expect(seen.size).toBeLessThanOrEqual(3);
+    });
+});

--- a/src/components/AdminMobileNav/MobileNavContext.tsx
+++ b/src/components/AdminMobileNav/MobileNavContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import type { M3ConnectedButtonGroupItem } from '../M3ConnectedButtonGroup';
 
 export interface MobileNavRegistration {
@@ -50,28 +50,30 @@ export const MobileNavProvider = ({ children }: { children: ReactNode }) => {
         }, {});
     }, [entries]);
 
-    const value = useMemo<MobileNavContextValue>(
-        () => ({
-            registration,
-            register: (id, entry) =>
-                setEntries((current) => {
-                    if (!entry) {
-                        if (!(id in current)) {
-                            return current;
-                        }
+    // `register` must never change identity: `useRegisterMobileNav` lists it in its
+    // effect dependencies, so rebuilding it here (it used to be recreated whenever
+    // `registration` changed) made every registration invalidate the callback that had
+    // just performed it — an endless register → re-render → register loop that React
+    // aborts with "Maximum update depth exceeded" (ORISO-Admin#702).
+    const register = useCallback<MobileNavContextValue['register']>((id, entry) => {
+        setEntries((current) => {
+            if (!entry) {
+                if (!(id in current)) {
+                    return current;
+                }
 
-                        const rest = { ...current };
+                const rest = { ...current };
 
-                        delete rest[id];
+                delete rest[id];
 
-                        return rest;
-                    }
+                return rest;
+            }
 
-                    return { ...current, [id]: entry };
-                }),
-        }),
-        [registration],
-    );
+            return { ...current, [id]: entry };
+        });
+    }, []);
+
+    const value = useMemo<MobileNavContextValue>(() => ({ registration, register }), [registration, register]);
 
     return <MobileNavContext.Provider value={value}>{children}</MobileNavContext.Provider>;
 };


### PR DESCRIPTION
Fixes #706. Blocks canvas step 1 of `OpenResilienceInitiative/ORISO-E2E#57`.

## Problem

Clicking any sidebar entry or settings section advanced the URL but never changed the rendered page — the admin panel was unusable after the first navigation, with no console errors and no failed requests.

`MobileNavProvider` rebuilt its `register` callback in a `useMemo` keyed on the merged `registration`, while `useRegisterMobileNav` lists `register` in its effect dependencies. Registering invalidated the callback that had just registered, re-running the effect forever; React aborted the render pass with "Maximum update depth exceeded" (minified #185). Since react-router wraps navigation in `startTransition`, the abort silently kept the previous tree on screen while `history.pushState` had already moved the URL.

## What changed

- `register` is now a `useCallback` with no dependencies, so its identity is stable for the provider's lifetime (same shape as `CardDeckNavProvider`).
- New `MobileNavContext.test.tsx`: registration converges instead of looping, and the context value stays stable.

## Verification

- `npx vitest run` — 238 files / 1461 tests pass. Before the fix the new provider test exhausted the worker heap (the loop is that aggressive).
- `npx eslint src/components/AdminMobileNav --max-warnings=0`, `npx prettier --check` — clean.
- `npm run build` — clean.
- Real browser against Pre-Dev, brokered platform-admin session, identical journey run twice — once with the deployed bundle, once with this build served through the same origin:

| step | deployed (before) | this branch (after) |
| --- | --- | --- |
| click Agencies | still Tenants | Agency list |
| click Statistics | still Tenants | Statistics |
| click Settings | still Tenants | Settings sections |
| click Legal tab | n/a | Legal panel at `/theme-settings/legal` |

## Reviewer test plan

- [ ] Sign in to the admin panel as a platform admin.
- [ ] Click each sidebar entry in turn (Tenants, Agencies, Accounts, Statistics, Links, Logs, Settings) — the page content must change every time, and the sidebar's active item must follow.
- [ ] In Settings, click each section (Global Configs, Master Data, Appearance, Legal, Email Server, Functionality Access) — the panel must swap each time.
- [ ] Use browser back/forward across several of those navigations — content stays in sync with the URL.
- [ ] Repeat the whole journey on a mobile viewport (<= 768px): the bottom bar must still show the current page's subsections, back target, search and create actions.
- [ ] Confirm no "Maximum update depth exceeded" or other React errors in the console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile navigation registration to prevent unnecessary re-renders and potential infinite render loops.
  * Preserved registered navigation labels and registration updates while keeping rendering bounded.

* **Tests**
  * Added regression coverage for registration, replacement, removal, merged updates, and render-count behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->