### PR TITLE
fix(agency): stop narrow card patches from taking the agency offline

### DIFF
--- a/src/api/agency/updateAgencyData.test.ts
+++ b/src/api/agency/updateAgencyData.test.ts
@@ -35,6 +35,25 @@ describe('updateAgencyData — ADR-014 multi-topic departments', () => {
         expect(sentBody().topicIds).toEqual(['3', '9', '12']);
     });
 
+    it('leaves visibility alone when the patch carries no online field', async () => {
+        // ORISO-Admin#715: publishing a department's legal document sends a narrow
+        // card patch with no `online` field. `offline: !formInput.online` read that
+        // absence as false and took the agency out of registration — an agency admin
+        // publishing their imprint made their own counselling centre disappear.
+        await updateAgencyData(agencyModel, { ...agencyModel } as any);
+        expect(sentBody()).not.toHaveProperty('offline');
+    });
+
+    it('still hides an agency that is explicitly switched offline', async () => {
+        await updateAgencyData(agencyModel, { ...agencyModel, online: false } as any);
+        expect(sentBody().offline).toBe(true);
+    });
+
+    it('still publishes an agency that is explicitly switched online', async () => {
+        await updateAgencyData(agencyModel, { ...agencyModel, online: true } as any);
+        expect(sentBody().offline).toBe(false);
+    });
+
     it('still accepts a lone Option from the former single-select shape', async () => {
         await updateAgencyData(agencyModel, {
             ...agencyModel,

--- a/src/api/agency/updateAgencyData.test.ts
+++ b/src/api/agency/updateAgencyData.test.ts
@@ -40,7 +40,13 @@ describe('updateAgencyData — ADR-014 multi-topic departments', () => {
         // card patch with no `online` field. `offline: !formInput.online` read that
         // absence as false and took the agency out of registration — an agency admin
         // publishing their imprint made their own counselling centre disappear.
-        await updateAgencyData(agencyModel, { ...agencyModel } as any);
+        // Delete rather than simply omit: spreading the fixture would silently stop
+        // exercising the undefined branch the day `online` is added to it, and the
+        // test would keep passing while proving nothing.
+        const patch: Record<string, unknown> = { ...agencyModel };
+        delete patch.online;
+
+        await updateAgencyData(agencyModel, patch as any);
         expect(sentBody()).not.toHaveProperty('offline');
     });
 

--- a/src/api/agency/updateAgencyData.ts
+++ b/src/api/agency/updateAgencyData.ts
@@ -50,7 +50,11 @@ export const updateAgencyData = async (agencyModel: AgencyData, formInput: Agenc
         email: formInput.email,
         consultingType: consultingTypeId,
         teamAgency: formInput.teamAgency,
-        offline: !formInput.online, // Convert from 'online' form field to 'offline' API field
+        // Same absent-vs-empty trap as `topicIds` above: a narrow card patch (publishing a
+        // department's legal document, for one) carries no `online` field, and `!undefined`
+        // is `true` — which asserted `offline: true` and quietly pulled the agency out of
+        // registration. Omitting the key leaves the stored visibility alone (ORISO-Admin#715).
+        ...(formInput.online !== undefined ? { offline: !formInput.online } : {}),
         external: false,
         demographics: formInput.demographics,
         counsellingRelations: formInput.counsellingRelations,


### PR DESCRIPTION
Closes #715. Unblocks canvas step 16 in OpenResilienceInitiative/ORISO-E2E#57.

## Problem

Publishing a department's legal notice or data privacy policy **silently takes the agency out of registration**.

Reproduced end to end on Pre-Dev:

1. Agency id 2 created, consultant assigned, *Make agency visible in registration* switched on. Verified publicly — `GET /service/agencies?postcode=55116&topicId=3&consultingType=1` returned it with `offline: false`.
2. Published the department legal notice and data privacy policy on that agency.
3. Agency now reads `Offline` in the admin list and is gone from the public query.

Nothing about visibility was touched in step 2. No error, no visible state change on the page the admin was on.

## Cause

`src/api/agency/updateAgencyData.ts`

```js
offline: !formInput.online,
```

A narrow card patch carries no `online` field, so `formInput.online` is `undefined` and `!undefined === true` — the payload asserts `offline: true`.

This is the **same absent-vs-empty trap the comment immediately above already documents** for topics ("Absent is NOT the same as empty … narrow card patches carry no topic data at all"). That one was fixed with `hasTopicField`; `online` kept the coercion.

## Fix

Omit the key when the patch does not carry `online`, so the stored visibility is left alone — exactly how an absent `topicIds` leaves the departments alone.

## Tests

Three cases added to `updateAgencyData.test.ts`, written before the fix; the first failed red with `expected { … } to not have property "offline"`.

- absent `online` → no `offline` key in the payload
- `online: false` → `offline: true` (explicit hide still works)
- `online: true` → `offline: false` (explicit publish still works)

Full suite: 238 files / 1465 tests pass. `tsc --noEmit` and `eslint --max-warnings=0` clean.

## Reviewer test plan

- [ ] Create an agency, assign a consultant, switch on *Make agency visible in registration*, save.
- [ ] Confirm it appears in registration for its topic + postcode.
- [ ] Open **Legal** on that agency and publish the department legal notice.
- [ ] Confirm the agency is **still Online** and still appears in registration.
- [ ] Switch visibility off explicitly and confirm it disappears — the switch itself must still work in both directions.
- [ ] Repeat the publish step at 390px width (mobile).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agency updates so changes that don’t include an online/offline status no longer overwrite the existing visibility state.
  * Explicit online and offline values continue to be saved correctly.

* **Tests**
  * Added coverage for updates with missing, online, and offline status values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->