### PR TITLE
fix(admin): open legal editors on the legal source language, not the UI language

### DIFF
--- a/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/index.tsx
@@ -47,7 +47,7 @@ export const AgencyLegalTextContainer = ({
     onSaveAgencyWide,
     saving,
 }: AgencyLegalTextContainerProps) => {
-    const { i18n, t } = useTranslation();
+    const { t } = useTranslation();
     const [selected, setSelected] = useState<number | typeof ALL_DEPARTMENTS>(ALL_DEPARTMENTS);
 
     const agencyId = Number(agencyData?.id);
@@ -170,7 +170,6 @@ export const AgencyLegalTextContainer = ({
             departmentName={selectedDepartment?.name}
             initialContentByLanguage={contentByLanguage}
             languages={languages}
-            defaultLanguage={i18n.language?.split('-')[0] || 'de'}
             publicationStatus={isDepartment ? departmentQuery.data?.publicationStatus : undefined}
             onSave={onSave}
             saving={saving || departmentPublish.isPending}

--- a/src/components/Tenants/LegalSettings/components/DataProcessingAgreementCard/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DataProcessingAgreementCard/index.tsx
@@ -64,7 +64,7 @@ interface DataProcessingAgreementCardProps {
     initialContentByLanguage?: Record<string, string>;
     /** The languages offered for editing (tenant's active languages + stored ones). */
     languages?: string[];
-    /** The language shown first (usually the admin's UI language). */
+    /** Explicit override of the language shown first; defaults to the legal source language. */
     defaultLanguage?: string;
     /** Previously published versions, newest first — browsable via the editor's version select. */
     versions: LegalVersion[];

--- a/src/components/Tenants/LegalSettings/components/DataProcessingAgreementCard/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DataProcessingAgreementCard/index.tsx
@@ -64,7 +64,10 @@ interface DataProcessingAgreementCardProps {
     initialContentByLanguage?: Record<string, string>;
     /** The languages offered for editing (tenant's active languages + stored ones). */
     languages?: string[];
-    /** Explicit override of the language shown first; defaults to the legal source language. */
+    /**
+     * Explicit override of the language shown first; defaults to the legal source
+     * language, or to the first offered language when the source is not offered.
+     */
     defaultLanguage?: string;
     /** Previously published versions, newest first — browsable via the editor's version select. */
     versions: LegalVersion[];

--- a/src/components/Tenants/LegalSettings/components/DataProcessingAgreementContainer/DataProcessingAgreementContainer.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DataProcessingAgreementContainer/DataProcessingAgreementContainer.test.tsx
@@ -129,7 +129,9 @@ describe('DataProcessingAgreementContainer', () => {
         });
         // active languages + stored fr, but never the metadata key
         expect(card).toHaveAttribute('data-languages', 'de,en,fr');
-        expect(card).toHaveAttribute('data-default-language', 'de');
+        // The container no longer forces the admin's UI language on the editor — the card
+        // opens on the legal source language itself (#718).
+        expect(card).not.toHaveAttribute('data-default-language');
     });
 
     it('marks the newest version as current and passes each version content through untouched', () => {

--- a/src/components/Tenants/LegalSettings/components/DataProcessingAgreementContainer/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DataProcessingAgreementContainer/index.tsx
@@ -163,7 +163,6 @@ export const DataProcessingAgreementContainer = ({ tenantId, readOnly }: DataPro
                 key={(versions as DpaVersion[])[0]?.activationDate ?? ''}
                 initialContentByLanguage={latestContentByLanguage}
                 languages={languages}
-                defaultLanguage={lang}
                 versions={mapped}
                 onPublish={publish}
                 publishing={isPending}

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.test.tsx
@@ -253,6 +253,32 @@ describe('DepartmentDataProtectionCard', () => {
         expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>EN</p>');
     });
 
+    it('keeps a language the admin edited when the offered languages change', async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(
+            <DepartmentDataProtectionCard
+                // Before the tenant settings load only the stored language is offered.
+                initialContentByLanguage={{ en: '<p>EN</p>' }}
+                languages={['en']}
+                onSave={() => undefined}
+            />,
+        );
+
+        // Editing counts as engagement just like picking a language in the menu.
+        await user.click(screen.getByRole('button', { name: 'edit' }));
+        expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>edited</p>');
+
+        rerender(
+            <DepartmentDataProtectionCard
+                initialContentByLanguage={{ de: '<p>DE</p>', en: '<p>EN</p>' }}
+                languages={['de', 'en']}
+                onSave={() => undefined}
+            />,
+        );
+
+        expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>edited</p>');
+    });
+
     it('marks languages without content in the language menu (#718)', async () => {
         const user = userEvent.setup();
         render(

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.test.tsx
@@ -168,6 +168,48 @@ describe('DepartmentDataProtectionCard', () => {
         expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>EN</p>');
     });
 
+    it('opens on the legal source language when no default is given (#718)', () => {
+        render(
+            <DepartmentDataProtectionCard
+                // 'en' first — the editor must still open on the source language 'de'
+                initialContentByLanguage={{ de: '<p>DE</p>', en: '<p>EN</p>' }}
+                languages={['en', 'de']}
+                onSave={() => undefined}
+            />,
+        );
+
+        expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>DE</p>');
+    });
+
+    it('falls back to the first offered language when the source language is not offered', () => {
+        render(
+            <DepartmentDataProtectionCard
+                initialContentByLanguage={{ en: '<p>EN</p>', fr: '<p>FR</p>' }}
+                languages={['en', 'fr']}
+                onSave={() => undefined}
+            />,
+        );
+
+        expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>EN</p>');
+    });
+
+    it('marks languages without content in the language menu (#718)', async () => {
+        const user = userEvent.setup();
+        render(
+            <DepartmentDataProtectionCard
+                initialContentByLanguage={{ de: '<p>DE</p>' }}
+                languages={['de', 'en']}
+                onSave={() => undefined}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /^languages:/ }));
+
+        expect(await screen.findByText('legal.translation.label.empty:en')).toBeInTheDocument();
+        // The source language carries content and keeps its "original" label.
+        expect(screen.getByText('legal.translation.label.original:de')).toBeInTheDocument();
+    });
+
     it('shows the published status tag', () => {
         render(<DepartmentDataProtectionCard publicationStatus="PUBLISHED" onSave={() => undefined} />);
         expect(screen.getByText('tenants.legal.departmentDataProtection.status.published')).toBeInTheDocument();

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.test.tsx
@@ -193,6 +193,66 @@ describe('DepartmentDataProtectionCard', () => {
         expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>EN</p>');
     });
 
+    it('lets an explicit defaultLanguage override the source-language default', () => {
+        render(
+            <DepartmentDataProtectionCard
+                initialContentByLanguage={{ de: '<p>DE</p>', en: '<p>EN</p>' }}
+                languages={['de', 'en']}
+                defaultLanguage="en"
+                onSave={() => undefined}
+            />,
+        );
+
+        expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>EN</p>');
+    });
+
+    it('re-runs the automatic selection when the offered languages arrive late', () => {
+        const { rerender } = render(
+            <DepartmentDataProtectionCard
+                // Before the tenant settings load only the stored language is offered.
+                initialContentByLanguage={{ en: '<p>EN</p>' }}
+                languages={['en']}
+                onSave={() => undefined}
+            />,
+        );
+        expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>EN</p>');
+
+        rerender(
+            <DepartmentDataProtectionCard
+                initialContentByLanguage={{ de: '<p>DE</p>', en: '<p>EN</p>' }}
+                languages={['de', 'en']}
+                onSave={() => undefined}
+            />,
+        );
+
+        expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>DE</p>');
+    });
+
+    it('keeps a language the admin engaged with when the offered languages change', async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(
+            <DepartmentDataProtectionCard
+                initialContentByLanguage={{ de: '<p>DE</p>', en: '<p>EN</p>' }}
+                languages={['de', 'en']}
+                onSave={() => undefined}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /^languages:/ }));
+        await user.click(await screen.findByText('en'));
+        expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>EN</p>');
+
+        rerender(
+            <DepartmentDataProtectionCard
+                initialContentByLanguage={{ de: '<p>DE</p>', en: '<p>EN</p>', fr: '<p>FR</p>' }}
+                languages={['de', 'en', 'fr']}
+                onSave={() => undefined}
+            />,
+        );
+
+        expect(screen.getByTestId('editor')).toHaveAttribute('data-value', '<p>EN</p>');
+    });
+
     it('marks languages without content in the language menu (#718)', async () => {
         const user = userEvent.setup();
         render(

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/index.tsx
@@ -17,7 +17,10 @@ interface DepartmentDataProtectionCardProps {
     initialContentByLanguage?: Record<string, string>;
     /** The languages offered for editing (tenant's active languages + stored ones). */
     languages?: string[];
-    /** Explicit override of the language shown first; defaults to the legal source language. */
+    /**
+     * Explicit override of the language shown first; defaults to the legal source
+     * language, or to the first offered language when the source is not offered.
+     */
     defaultLanguage?: string;
     /** Current publication status of the department's data privacy policy. */
     publicationStatus?: DepartmentPublicationStatus;

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/index.tsx
@@ -17,7 +17,7 @@ interface DepartmentDataProtectionCardProps {
     initialContentByLanguage?: Record<string, string>;
     /** The languages offered for editing (tenant's active languages + stored ones). */
     languages?: string[];
-    /** The language shown first (usually the admin's UI language). */
+    /** Explicit override of the language shown first; defaults to the legal source language. */
     defaultLanguage?: string;
     /** Current publication status of the department's data privacy policy. */
     publicationStatus?: DepartmentPublicationStatus;

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/DepartmentDataProtectionContainer.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/DepartmentDataProtectionContainer.test.tsx
@@ -80,7 +80,9 @@ describe('DepartmentDataProtectionContainer', () => {
         });
         // active languages + stored fr, but never the metadata key
         expect(card).toHaveAttribute('data-languages', 'de,en,fr');
-        expect(card).toHaveAttribute('data-default-language', 'de');
+        // The container no longer forces the admin's UI language on the editor — the card
+        // opens on the legal source language itself (#718).
+        expect(card).not.toHaveAttribute('data-default-language');
         expect(card).toHaveAttribute('data-status', 'PUBLISHED');
         expect(card).toHaveAttribute('data-name', 'Sucht');
     });

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/index.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDepartmentDpp } from '../../../../../hooks/useDepartmentDpp.hook';
 import { usePublishDepartmentDpp } from '../../../../../hooks/usePublishDepartmentDpp.hook';
 import { useTenantAdminData } from '../../../../../hooks/useTenantAdminData.hook';
@@ -25,9 +24,6 @@ export const DepartmentDataProtectionContainer = ({
     topicId,
     departmentName,
 }: DepartmentDataProtectionContainerProps) => {
-    const { i18n } = useTranslation();
-    const lang = i18n.language?.split('-')[0] || 'de';
-
     const { data, isLoading } = useDepartmentDpp(agencyId, topicId);
     const { mutate: publish, isPending } = usePublishDepartmentDpp(agencyId, topicId);
     const { data: tenantData } = useTenantAdminData();
@@ -50,7 +46,6 @@ export const DepartmentDataProtectionContainer = ({
             departmentName={departmentName}
             initialContentByLanguage={contentByLanguage}
             languages={languages}
-            defaultLanguage={lang}
             publicationStatus={data?.publicationStatus}
             onSave={(contentByLang, doPublish) => publish({ content: contentByLang, publish: doPublish })}
             saving={isPending}

--- a/src/components/Tenants/LegalSettings/components/DepartmentImprintContainer/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentImprintContainer/index.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDepartmentImprint } from '../../../../../hooks/useDepartmentImprint.hook';
 import { usePublishDepartmentImprint } from '../../../../../hooks/usePublishDepartmentImprint.hook';
 import { useTenantAdminData } from '../../../../../hooks/useTenantAdminData.hook';
@@ -16,7 +15,6 @@ export const DepartmentImprintContainer = ({
     topicId: number;
     departmentName?: string;
 }) => {
-    const { i18n } = useTranslation();
     const { data, isLoading } = useDepartmentImprint(agencyId, topicId);
     const { mutate: publish, isPending } = usePublishDepartmentImprint(agencyId, topicId);
     const { data: tenantData } = useTenantAdminData();
@@ -36,7 +34,6 @@ export const DepartmentImprintContainer = ({
             departmentName={departmentName}
             initialContentByLanguage={contentByLanguage}
             languages={languages}
-            defaultLanguage={i18n.language?.split('-')[0] || 'de'}
             publicationStatus={data?.publicationStatus}
             onSave={(content, doPublish) => publish({ content, publish: doPublish })}
             saving={isPending}

--- a/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/LegalContentLanguageSelect.stories.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/LegalContentLanguageSelect.stories.tsx
@@ -50,6 +50,21 @@ export const WithMachineTranslation: Story = {
     render: (args) => <StatefulLanguageSelect {...args} />,
 };
 
+/**
+ * Languages that carry no content yet are labelled "… (noch kein Inhalt)" in the menu,
+ * so an admin sees the gap before publishing into the wrong language (#718).
+ */
+export const WithEmptyLanguage: Story = {
+    args: {
+        languages: ['de', 'en', 'ru'],
+        contentMap: {
+            de: '<p>Original</p>',
+            en: '',
+        } as Record<string, string>,
+    },
+    render: (args) => <StatefulLanguageSelect {...args} />,
+};
+
 /** With only one language the component renders nothing (nothing to switch). */
 export const SingleLanguageHidden: Story = {
     args: { languages: ['de'] },

--- a/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalContentLanguageSelect/index.tsx
@@ -2,6 +2,7 @@ import Language from '@mui/icons-material/Language';
 import { useTranslation } from 'react-i18next';
 import { SplitDropdown } from '../../../../FormPluginEditor/SplitDropdown';
 import { isMachineTranslated } from '../../utils/translationMeta';
+import { isEmptyHtml } from '../../utils/legalContentLanguages';
 
 interface LegalContentLanguageSelectProps {
     /** The languages offered for editing/viewing. Hidden when there is only one. */
@@ -39,6 +40,11 @@ export const LegalContentLanguageSelect = ({
 
     const labelFor = (language: string): string => {
         const base = t(`language.${language}`, language);
+        // "no content yet" outranks the original/translated status: a language without
+        // content is exactly the gap an admin must see before publishing (#718).
+        if (contentMap && isEmptyHtml(contentMap[language])) {
+            return t('legal.translation.label.empty', { language: base });
+        }
         if (sourceLanguage && language === sourceLanguage) {
             return t('legal.translation.label.original', { language: base });
         }

--- a/src/components/Tenants/LegalSettings/hooks/useLegalContentTranslation.ts
+++ b/src/components/Tenants/LegalSettings/hooks/useLegalContentTranslation.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { TranslateRequest, TranslateResponse } from '../../../../types/translation';
 import { isEmptyHtml, mergeLegalContentMap } from '../utils/legalContentLanguages';
 import {
@@ -18,7 +18,8 @@ interface UseLegalContentTranslationArgs {
      * Explicit override of the language shown first. Without it the editor opens on the
      * legal source language ("Rechtssprache") — NOT on the admin's UI language: the legal
      * texts are authored in the source language, and an editor that opens elsewhere lets
-     * an admin publish into a language their advice seekers never read (#718).
+     * an admin publish into a language their advice seekers never read (#718). When the
+     * source language is not offered either, the first offered language is shown.
      */
     defaultLanguage?: string;
     /** Translate call (usually useTranslateLegalContent().translate). Absent = no translation UI. */
@@ -50,12 +51,14 @@ export const useLegalContentTranslation = ({
 }: UseLegalContentTranslationArgs) => {
     // v1: the platform's legal source language ("Rechtssprache") is always German.
     const sourceLanguage = languages.includes(LEGAL_SOURCE_LANGUAGE) ? LEGAL_SOURCE_LANGUAGE : languages[0];
+    const preferredLanguage = defaultLanguage && languages.includes(defaultLanguage) ? defaultLanguage : sourceLanguage;
 
     const [edits, setEdits] = useState<Record<string, string>>({});
     const [freshMeta, setFreshMeta] = useState<Record<string, string>>({});
-    const [activeLanguage, setActiveLanguage] = useState(
-        defaultLanguage && languages.includes(defaultLanguage) ? defaultLanguage : sourceLanguage,
-    );
+    const [activeLanguage, setActiveLanguage] = useState(preferredLanguage);
+    // Whether the admin engaged with the shown language (picked one or edited it) —
+    // only then may a late change of the offered languages not switch it away.
+    const [languageEngaged, setLanguageEngaged] = useState(false);
     const [modalOpen, setModalOpen] = useState(false);
     const [translating, setTranslating] = useState(false);
     const [modalErrorKey, setModalErrorKey] = useState<string | null>(null);
@@ -65,6 +68,19 @@ export const useLegalContentTranslation = ({
         () => languages.filter((language) => language !== sourceLanguage),
         [languages, sourceLanguage],
     );
+
+    // The offered languages can change after mount (tenant settings and stored content
+    // load asynchronously) while useState evaluates its initializer only once. Re-run
+    // the automatic selection then — but never switch away from a language the admin
+    // engaged with, unless it stopped being offered altogether.
+    useEffect(() => {
+        if (!languages.includes(activeLanguage)) {
+            setActiveLanguage(preferredLanguage);
+            setLanguageEngaged(false);
+        } else if (!languageEngaged && activeLanguage !== preferredLanguage) {
+            setActiveLanguage(preferredLanguage);
+        }
+    }, [languages, activeLanguage, preferredLanguage, languageEngaged]);
 
     const currentContent = edits[activeLanguage] ?? initialContentByLanguage[activeLanguage] ?? '';
     const sourceContent = edits[sourceLanguage] ?? initialContentByLanguage[sourceLanguage] ?? '';
@@ -84,7 +100,13 @@ export const useLegalContentTranslation = ({
         [initialContentByLanguage, editsWithMeta],
     );
 
+    const selectLanguage = (language: string) => {
+        setLanguageEngaged(true);
+        setActiveLanguage(language);
+    };
+
     const handleEditorChange = (html: string) => {
+        setLanguageEngaged(true);
         setEdits((prev) => ({ ...prev, [activeLanguage]: html }));
         // A manual edit replaces a translation made in this session, so its fresh
         // meta must not be published. Stored meta is untouched (backend clears it).
@@ -185,7 +207,7 @@ export const useLegalContentTranslation = ({
 
     return {
         activeLanguage,
-        setActiveLanguage,
+        setActiveLanguage: selectLanguage,
         currentContent,
         sourceLanguage,
         targetLanguages,

--- a/src/components/Tenants/LegalSettings/hooks/useLegalContentTranslation.ts
+++ b/src/components/Tenants/LegalSettings/hooks/useLegalContentTranslation.ts
@@ -14,7 +14,12 @@ interface UseLegalContentTranslationArgs {
     initialContentByLanguage: Record<string, string>;
     /** The languages offered for editing. */
     languages: string[];
-    /** The language shown first (usually the admin's UI language). */
+    /**
+     * Explicit override of the language shown first. Without it the editor opens on the
+     * legal source language ("Rechtssprache") — NOT on the admin's UI language: the legal
+     * texts are authored in the source language, and an editor that opens elsewhere lets
+     * an admin publish into a language their advice seekers never read (#718).
+     */
     defaultLanguage?: string;
     /** Translate call (usually useTranslateLegalContent().translate). Absent = no translation UI. */
     onTranslate?: (request: TranslateRequest) => Promise<TranslateResponse>;
@@ -43,19 +48,19 @@ export const useLegalContentTranslation = ({
     onTranslate,
     onPublish,
 }: UseLegalContentTranslationArgs) => {
+    // v1: the platform's legal source language ("Rechtssprache") is always German.
+    const sourceLanguage = languages.includes(LEGAL_SOURCE_LANGUAGE) ? LEGAL_SOURCE_LANGUAGE : languages[0];
+
     const [edits, setEdits] = useState<Record<string, string>>({});
     const [freshMeta, setFreshMeta] = useState<Record<string, string>>({});
     const [activeLanguage, setActiveLanguage] = useState(
-        defaultLanguage && languages.includes(defaultLanguage) ? defaultLanguage : languages[0],
+        defaultLanguage && languages.includes(defaultLanguage) ? defaultLanguage : sourceLanguage,
     );
     const [modalOpen, setModalOpen] = useState(false);
     const [translating, setTranslating] = useState(false);
     const [modalErrorKey, setModalErrorKey] = useState<string | null>(null);
     const [fieldTranslating, setFieldTranslating] = useState(false);
     const [fieldErrorKey, setFieldErrorKey] = useState<string | null>(null);
-
-    // v1: the platform's legal source language ("Rechtssprache") is always German.
-    const sourceLanguage = languages.includes(LEGAL_SOURCE_LANGUAGE) ? LEGAL_SOURCE_LANGUAGE : languages[0];
     const targetLanguages = useMemo(
         () => languages.filter((language) => language !== sourceLanguage),
         [languages, sourceLanguage],

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -949,6 +949,7 @@
     "tenants.legal.departmentDataProtection.publish": "Veröffentlichen",
     "legal.translation.label.original": "{{language}} (Original)",
     "legal.translation.label.machineTranslated": "{{language}} (maschinell übersetzt)",
+    "legal.translation.label.empty": "{{language}} (noch kein Inhalt)",
     "legal.translation.settings.title": "Automatische Übersetzung",
     "legal.translation.settings.description": "API-Schlüssel für die automatische Übersetzung der Rechtstexte. Nur Super-Admins können sie ändern — für alle anderen sind sie sichtbar, aber nicht veränderbar.",
     "legal.translation.settings.provider.openrouter": "OpenRouter",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1396,6 +1396,7 @@
     "tenants.legal.departmentDataProtection.publish": "Publish",
     "legal.translation.label.original": "{{language}} (original)",
     "legal.translation.label.machineTranslated": "{{language}} (machine translated)",
+    "legal.translation.label.empty": "{{language}} (no content yet)",
     "legal.translation.settings.title": "Automatic translation",
     "legal.translation.settings.description": "API keys for the machine translation of legal texts. Only super admins can change them — everyone else sees them read-only.",
     "legal.translation.settings.provider.openrouter": "OpenRouter",


### PR DESCRIPTION
## Problem

The legal editors (platform DPA, department imprint, department data privacy policy) opened on the admin's UI language. An admin with an EN interface authored their imprint into the `en` variant and published — while German-speaking advice seekers kept being served the untouched inherited `de` template. Found in the E2E canvas run (OpenResilienceInitiative/ORISO-E2E#57, step 16, PRIO1).

Fixes #718

## What changed

- `useLegalContentTranslation` opens on the legal source language ("Rechtssprache", `de`) instead of the first offered language; `defaultLanguage` remains as an explicit override only
- the four legal containers no longer pass the admin UI language as `defaultLanguage`
- the language menu labels languages without content ("noch kein Inhalt" / "no content yet"), so empty variants are visible before publishing
- new card tests (source-language default, non-de fallback, empty labels) and a `WithEmptyLanguage` story

## Verification

- `npm run test -- --run`: 238 files / 1468 tests green
- `npx eslint . --max-warnings=0`, `npx prettier . --check`, `npm run build`: clean
- Storybook DOM check: menu renders "Deutsch (Original)", "Englisch (noch kein Inhalt)", "Russisch (noch kein Inhalt)"; DPA card opens on DE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Legal content editors now open in the legal source language by default.
  * Language menus indicate when a language has no content.
  * Language selection remains stable as available languages load or change.

* **Tests**
  * Added coverage for language selection, fallback behavior, and empty-language labels.

* **Documentation**
  * Clarified how initial language overrides work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->