### PR TITLE
fix(i18n): use an existing translation key for the tenant admin controls success toast

### DIFF
--- a/src/hooks/useTenantAdminControlsMutation.hook.test.tsx
+++ b/src/hooks/useTenantAdminControlsMutation.hook.test.tsx
@@ -1,10 +1,13 @@
 import { ReactNode } from 'react';
+import { notification } from 'antd';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { useTenantAdminControlsMutation } from './useTenantAdminControlsMutation.hook';
 import { TENANT_ADMIN_CONTROLS_KEY } from './useTenantAdminControls.hook';
 import { updateTenantAdminControls } from '../api/tenant/updateTenantAdminControls';
+import translationDe from '../locales/de/translation.json';
+import translationEn from '../locales/en/translation.json';
 
 vi.mock('../api/tenant/updateTenantAdminControls', () => ({
     updateTenantAdminControls: vi.fn(),
@@ -12,6 +15,10 @@ vi.mock('../api/tenant/updateTenantAdminControls', () => ({
 
 vi.mock('react-i18next', () => ({
     useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('antd', () => ({
+    notification: { success: vi.fn() },
 }));
 
 describe('useTenantAdminControlsMutation', () => {
@@ -40,5 +47,29 @@ describe('useTenantAdminControlsMutation', () => {
         await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
         expect(queryClient.getQueryData([TENANT_ADMIN_CONTROLS_KEY])).toEqual(serverResponse);
+    });
+
+    it('defaults to a success message key that exists in every locale', async () => {
+        // i18n runs with keySeparator: false and returnEmptyString: false, so a key
+        // missing from a locale file is echoed verbatim in the notification.
+        vi.mocked(updateTenantAdminControls).mockResolvedValue({} as never);
+
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        const wrapper = ({ children }: { children: ReactNode }) => (
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        );
+
+        const { result } = renderHook(() => useTenantAdminControlsMutation(), { wrapper });
+
+        result.current.mutate({} as never);
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(notification.success).toHaveBeenCalledTimes(1);
+        // The test's t() mock is the identity function, so message === the i18n key.
+        const { message } = vi.mocked(notification.success).mock.calls[0][0];
+        expect(typeof message).toBe('string');
+        expect(translationDe).toHaveProperty([message as string]);
+        expect(translationEn).toHaveProperty([message as string]);
     });
 });

--- a/src/hooks/useTenantAdminControlsMutation.hook.test.tsx
+++ b/src/hooks/useTenantAdminControlsMutation.hook.test.tsx
@@ -71,5 +71,13 @@ describe('useTenantAdminControlsMutation', () => {
         expect(typeof message).toBe('string');
         expect(translationDe).toHaveProperty([message as string]);
         expect(translationEn).toHaveProperty([message as string]);
+        // Key presence alone would still pass for an empty or key-echoed translation, so
+        // also assert both locales resolve to a non-empty, actually-localized value.
+        const deValue = (translationDe as Record<string, string>)[message as string];
+        const enValue = (translationEn as Record<string, string>)[message as string];
+        expect(deValue).toBeTruthy();
+        expect(enValue).toBeTruthy();
+        expect(deValue).not.toBe(message);
+        expect(enValue).not.toBe(message);
     });
 });

--- a/src/hooks/useTenantAdminControlsMutation.hook.ts
+++ b/src/hooks/useTenantAdminControlsMutation.hook.ts
@@ -11,7 +11,7 @@ interface TenantAdminControlsMutationOptions
 }
 
 export const useTenantAdminControlsMutation = ({
-    successMessageKey = 'tenants.message.setting.update',
+    successMessageKey = 'tenants.message.settingsUpdate',
     ...options
 }: TenantAdminControlsMutationOptions = {}) => {
     const { t } = useTranslation();


### PR DESCRIPTION
**Problem** — Saving tenant admin controls showed the literal string `tenants.message.setting.update` in the success notification: the hook's default `successMessageKey` exists in no locale file, and i18next runs with `keySeparator: false` / `returnEmptyString: false`, so the raw key is echoed.

**Changes**
- Default `useTenantAdminControlsMutation`'s `successMessageKey` to the existing, already-translated `tenants.message.settingsUpdate` (same string family `useTenantAdminDataMutation` callers use).
- Add a regression test asserting the hook's default key exists in both DE and EN locale files (fails against the old key — verified by mutation).
- No other call site affected: all explicit `successMessageKey` values reference existing keys or `false` (grep-checked).

**Verification**
- `npm run test` — 238 files / 1477 tests pass
- `npx eslint <changed files> --max-warnings=0`, `npx prettier --check` — clean
- `npm run build` — succeeds

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default success notification for tenant settings changes to use the correct translation key.
  * Ensured successful updates display a translated, user-friendly notification in German and English.

* **Tests**
  * Added coverage verifying the success notification appears exactly once with a valid message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->