### PR TITLE
fix: resolve Form disabled state via public ConfigProvider.useConfig

### DIFF
--- a/src/components/CardEditable/CardEditable.test.tsx
+++ b/src/components/CardEditable/CardEditable.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { CardEditable } from './index';
+import { MuiFormField } from '../mui/MuiFormField';
+import { MuiSwitchField } from '../mui/MuiSwitchField';
+
+/**
+ * Read-only guarantee (#689/#735): a CardEditable that is not in edit mode
+ * disables its whole antd `<Form>`; MUI-backed fields must pick that up via
+ * `ConfigProvider.useConfig().componentDisabled`. They used to read the
+ * antd-internal `antd/es/config-provider/DisabledContext`, which resolves to a
+ * second module instance under Vitest — the context value never arrived and
+ * this exact assertion failed while the app looked fine in the browser.
+ */
+describe('CardEditable', () => {
+    const renderCard = () =>
+        render(
+            <CardEditable titleKey="card.title" onSave={vi.fn()} initialValues={{ name: 'ACME', enabled: true }}>
+                <MuiFormField name="name" label="Name" />
+                <MuiSwitchField name="enabled" label="Enabled" />
+            </CardEditable>,
+        );
+
+    it('renders MUI-backed fields disabled while not editing', () => {
+        renderCard();
+
+        expect(screen.getByLabelText('Name')).toBeDisabled();
+        expect(screen.getByRole('switch', { name: 'Enabled' })).toBeDisabled();
+    });
+
+    it('re-enables the fields once editing starts', async () => {
+        const user = userEvent.setup();
+        renderCard();
+
+        await user.click(screen.getByRole('button', { name: 'edit' }));
+
+        expect(screen.getByLabelText('Name')).toBeEnabled();
+        expect(screen.getByRole('switch', { name: 'Enabled' })).toBeEnabled();
+    });
+});

--- a/src/components/FormSwitchField/index.tsx
+++ b/src/components/FormSwitchField/index.tsx
@@ -1,8 +1,6 @@
-import { Form, Switch } from 'antd';
+import { ConfigProvider, Form, Switch } from 'antd';
 import Paragraph from 'antd/lib/typography/Paragraph';
 import classNames from 'classnames';
-import DisabledContext from 'antd/es/config-provider/DisabledContext';
-import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { M3Switch } from '../M3Switch';
 import styles from './styles.module.scss';
@@ -54,8 +52,8 @@ const FormSwitchFieldLocal = ({
     switchVariant,
 }: FormSwitchFieldLocalProps) => {
     const { t } = useTranslation();
-    const contextDisabled = useContext(DisabledContext);
-    const isDisabled = contextDisabled || disabled;
+    const { componentDisabled } = ConfigProvider.useConfig();
+    const isDisabled = componentDisabled || disabled;
     const fieldChecked = inverseValue ? !checked : checked;
     const onSwitchChange = (value: boolean) => onChange?.(inverseValue ? !value : value);
 

--- a/src/components/mui/MuiColorField/index.tsx
+++ b/src/components/mui/MuiColorField/index.tsx
@@ -1,7 +1,5 @@
-import { useContext } from 'react';
-import { Form } from 'antd';
+import { ConfigProvider, Form } from 'antd';
 import type { Rule } from 'antd/lib/form';
-import DisabledContext from 'antd/es/config-provider/DisabledContext';
 import FormHelperText from '@mui/material/FormHelperText';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
@@ -21,8 +19,8 @@ interface MuiColorControlProps {
 }
 
 const MuiColorControl = ({ value, onChange, fieldName, label, helpText, disabled }: MuiColorControlProps) => {
-    const contextDisabled = useContext(DisabledContext);
-    const isDisabled = contextDisabled || disabled;
+    const { componentDisabled } = ConfigProvider.useConfig();
+    const isDisabled = componentDisabled || disabled;
     const { status } = Form.Item.useStatus();
     const form = Form.useFormInstance();
     const isError = status === 'error';

--- a/src/components/mui/MuiFormField/MuiFormField.test.tsx
+++ b/src/components/mui/MuiFormField/MuiFormField.test.tsx
@@ -162,6 +162,16 @@ describe('MuiFormField', () => {
         expect(screen.getByLabelText('Address')).toHaveAttribute('id', 'onboarding_address');
     });
 
+    it('honors antd Form disabled context (CardEditable view mode)', () => {
+        render(
+            <Form disabled>
+                <MuiFormField name="name" label="Name" />
+            </Form>,
+        );
+
+        expect(screen.getByLabelText('Name')).toBeDisabled();
+    });
+
     it('keeps an explicitly passed id', () => {
         render(
             <Form name="onboarding">

--- a/src/components/mui/MuiFormField/index.tsx
+++ b/src/components/mui/MuiFormField/index.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { useContext } from 'react';
-import { Form } from 'antd';
+import { ConfigProvider, Form } from 'antd';
 import type { Rule } from 'antd/lib/form';
-import DisabledContext from 'antd/es/config-provider/DisabledContext';
 import TextField from '@mui/material/TextField';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -68,8 +66,8 @@ const MuiControl = ({
     variant = 'outlined',
     className,
 }: MuiControlProps) => {
-    const contextDisabled = useContext(DisabledContext);
-    const isDisabled = contextDisabled || disabled;
+    const { componentDisabled } = ConfigProvider.useConfig();
+    const isDisabled = componentDisabled || disabled;
     const { status } = Form.Item.useStatus();
     const form = Form.useFormInstance();
     const isError = status === 'error';

--- a/src/components/mui/MuiRadioGroupField/index.tsx
+++ b/src/components/mui/MuiRadioGroupField/index.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { useContext } from 'react';
-import { Form } from 'antd';
+import { ConfigProvider, Form } from 'antd';
 import type { Rule } from 'antd/lib/form';
-import DisabledContext from 'antd/es/config-provider/DisabledContext';
 import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormHelperText from '@mui/material/FormHelperText';
@@ -63,8 +61,8 @@ const MuiRadioControl = ({
     vertical,
     options,
 }: MuiRadioControlProps) => {
-    const contextDisabled = useContext(DisabledContext);
-    const isDisabled = contextDisabled || disabled;
+    const { componentDisabled } = ConfigProvider.useConfig();
+    const isDisabled = componentDisabled || disabled;
     const { status } = Form.Item.useStatus();
     const form = Form.useFormInstance();
     const isError = status === 'error';

--- a/src/components/mui/MuiSelectField/index.tsx
+++ b/src/components/mui/MuiSelectField/index.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { useContext, useMemo } from 'react';
-import { Form } from 'antd';
+import { useMemo } from 'react';
+import { ConfigProvider, Form } from 'antd';
 import type { Rule } from 'antd/lib/form';
 import type { ValidateStatus } from 'antd/es/form/FormItem';
-import DisabledContext from 'antd/es/config-provider/DisabledContext';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -105,8 +104,8 @@ const MuiSelectControl = ({
     validateStatus,
     className,
 }: MuiSelectControlProps) => {
-    const contextDisabled = useContext(DisabledContext);
-    const isDisabled = contextDisabled || disabled;
+    const { componentDisabled } = ConfigProvider.useConfig();
+    const isDisabled = componentDisabled || disabled;
     const { status } = Form.Item.useStatus();
     const form = Form.useFormInstance();
     const isError = (validateStatus ?? status) === 'error';

--- a/src/components/mui/MuiSliderField/index.tsx
+++ b/src/components/mui/MuiSliderField/index.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { useContext } from 'react';
-import { Form } from 'antd';
-import DisabledContext from 'antd/es/config-provider/DisabledContext';
+import { ConfigProvider, Form } from 'antd';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 import FormHelperText from '@mui/material/FormHelperText';
@@ -39,8 +37,8 @@ const MuiSliderControl = ({
     max,
     disabled,
 }: MuiSliderControlProps) => {
-    const contextDisabled = useContext(DisabledContext);
-    const isDisabled = contextDisabled || disabled;
+    const { componentDisabled } = ConfigProvider.useConfig();
+    const isDisabled = componentDisabled || disabled;
     const { status } = Form.Item.useStatus();
     const form = Form.useFormInstance();
     const isError = status === 'error';

--- a/src/components/mui/MuiSwitchField/MuiSwitchField.test.tsx
+++ b/src/components/mui/MuiSwitchField/MuiSwitchField.test.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import Form from 'antd/es/form';
+// Root antd import on purpose: the deep path `antd/es/form` resolves to a
+// second antd instance under Vitest and would bypass the ConfigProvider the
+// components actually read (#689/#735).
+import { Form } from 'antd';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';

--- a/src/components/mui/MuiSwitchField/index.tsx
+++ b/src/components/mui/MuiSwitchField/index.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { useContext } from 'react';
-import { Form } from 'antd';
+import { ConfigProvider, Form } from 'antd';
 import type { Rule } from 'antd/lib/form';
-import DisabledContext from 'antd/es/config-provider/DisabledContext';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormHelperText from '@mui/material/FormHelperText';
 import Switch from '@mui/material/Switch';
@@ -55,8 +53,8 @@ const MuiSwitchControl = ({
     helpText,
     switchLabel,
 }: MuiSwitchControlProps) => {
-    const contextDisabled = useContext(DisabledContext);
-    const isDisabled = contextDisabled || disabled;
+    const { componentDisabled } = ConfigProvider.useConfig();
+    const isDisabled = componentDisabled || disabled;
     const { status } = Form.Item.useStatus();
     const form = Form.useFormInstance();
     const isError = status === 'error';

--- a/src/pages/Agency/Edit/components/RegistrationSettings/PostCodeRanges/index.tsx
+++ b/src/pages/Agency/Edit/components/RegistrationSettings/PostCodeRanges/index.tsx
@@ -1,6 +1,4 @@
-import { useContext } from 'react';
-import DisabledContext from 'antd/es/config-provider/DisabledContext';
-import { Form } from 'antd';
+import { ConfigProvider, Form } from 'antd';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import AddIcon from '@mui/icons-material/Add';
@@ -12,7 +10,7 @@ import styles from './styles.module.scss';
 
 export const PostCodeRanges = () => {
     const { t } = useTranslation();
-    const contextDisabled = useContext(DisabledContext);
+    const { componentDisabled } = ConfigProvider.useConfig();
 
     return (
         <div className={styles.postCodeRangesContainer}>
@@ -45,8 +43,8 @@ export const PostCodeRanges = () => {
                                 <button
                                     type="button"
                                     aria-label={t('agency.form.registrationSettings.removePostCode')}
-                                    disabled={contextDisabled}
-                                    className={classNames(styles.remove, { [styles.disabled]: contextDisabled })}
+                                    disabled={componentDisabled}
+                                    className={classNames(styles.remove, { [styles.disabled]: componentDisabled })}
                                     onClick={() => remove(field.name)}
                                 >
                                     <XIcon />
@@ -61,7 +59,7 @@ export const PostCodeRanges = () => {
                                 {t('agency.form.registrationSettings.newPostCodeLabel')}
                             </p>
                             {elements}
-                            {!contextDisabled && (
+                            {!componentDisabled && (
                                 <M3Button
                                     variant="outlined"
                                     className={styles.addButton}


### PR DESCRIPTION
Fixes #752

## Problem
MUI-backed form fields read the surrounding `<Form disabled>` through a deep import of `antd/es/config-provider/DisabledContext`. Under Vitest that path resolves to a second antd module instance, so the context value never arrives — fields inside a non-editing `CardEditable` render **enabled**. Found while writing the DocumentMasterDataCard test for #735; this is the documented remedy from #689 / #693.

## What changed
- All six `src/components/mui/*` fields plus `FormSwitchField` and `PostCodeRanges` now use the public API `ConfigProvider.useConfig().componentDisabled` instead of the deep `DisabledContext` import.
- New `CardEditable.test.tsx`: a non-editing card renders its MUI fields disabled, and re-enables them after clicking edit. Verified to fail against the previous implementation.
- `MuiFormField.test.tsx`: added a `<Form disabled>` test.
- `MuiSwitchField.test.tsx` now imports `Form` from root `antd` — its old `antd/es/form` deep import was the same dual-instance trap in the opposite direction and had kept its disabled-context test falsely green.

## Verification
- `npm run test` — 239 files / 1479 tests pass
- `npx eslint <changed dirs> --max-warnings=0`, `npx prettier --check` — clean
- `npm run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)