### PR TITLE
feat: render invite preview in the new email design system (#743)

### DIFF
--- a/src/components/PlaceholderTemplate/EmailKitPreview.module.scss
+++ b/src/components/PlaceholderTemplate/EmailKitPreview.module.scss
@@ -1,0 +1,41 @@
+.preview {
+    display: grid;
+    min-width: 0;
+    gap: 10px;
+}
+
+/* Inbox strip: what the recipient's mail client lists next to the mail. */
+
+.meta {
+    display: grid;
+    padding: 12px 16px;
+    border: 1px solid var(--m3-outline-variant, #cac4d0);
+    background: var(--m3-surface, #ffffff);
+    border-radius: 10px;
+    color: var(--m3-on-surface, #1d1b20);
+    gap: 4px;
+    overflow-wrap: anywhere;
+}
+
+.metaLabel {
+    color: var(--m3-on-surface-variant, #49454f);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.metaSubject {
+    font-size: 15px;
+    line-height: 1.4;
+}
+
+/* The mail itself, rendered by the ported e-mail kit inside the frame.
+   Background/border colours come inline from the kit's token set. */
+
+.frame {
+    display: block;
+    width: 100%;
+    border: 1px solid;
+    border-radius: 12px;
+}

--- a/src/components/PlaceholderTemplate/EmailKitPreview.test.tsx
+++ b/src/components/PlaceholderTemplate/EmailKitPreview.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { EmailKitPreview } from './EmailKitPreview';
+
+const t = (key: string, fallback?: string) => fallback ?? key;
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t }),
+}));
+
+afterEach(() => {
+    document.documentElement.style.removeProperty('--m3-primary');
+});
+
+const srcDoc = (preview: HTMLElement): string => preview.querySelector('iframe')?.getAttribute('srcdoc') ?? '';
+
+describe('EmailKitPreview', () => {
+    it('renders the subject in the inbox strip and the body into the mail document', () => {
+        render(<EmailKitPreview subject="Ihre Einladung" body="Hallo Lisa Beispiel" previewLabel="E-Mail-Vorschau" />);
+        const preview = screen.getByRole('region', { name: 'E-Mail-Vorschau' });
+        expect(within(preview).getByText('Ihre Einladung')).toBeInTheDocument();
+        expect(preview.querySelector('iframe')).toHaveAttribute('title', 'E-Mail-Vorschau');
+        expect(srcDoc(preview)).toContain('Hallo Lisa Beispiel');
+    });
+
+    it('shows unresolved subject tokens as chips in the inbox strip', () => {
+        render(<EmailKitPreview subject="Hallo {{wer}}" body="x" previewLabel="E-Mail-Vorschau" />);
+        const preview = screen.getByRole('region', { name: 'E-Mail-Vorschau' });
+        expect(within(preview).getByText('{{wer}}')).toBeInTheDocument();
+    });
+
+    it('applies the tenant primary colour from the admin theme to the shell', () => {
+        document.documentElement.style.setProperty('--m3-primary', '#336699');
+        render(<EmailKitPreview subject="A" body="B" previewLabel="E-Mail-Vorschau" />);
+        const preview = screen.getByRole('region', { name: 'E-Mail-Vorschau' });
+        expect(srcDoc(preview)).toContain('#336699');
+        expect(srcDoc(preview)).not.toContain('#a5000a');
+    });
+
+    it('renders the empty state with both hints instead of a broken frame', () => {
+        render(<EmailKitPreview subject="" body="" previewLabel="E-Mail-Vorschau" />);
+        const preview = screen.getByRole('region', { name: 'E-Mail-Vorschau' });
+        expect(within(preview).getByText('Betreff der E-Mail')).toBeInTheDocument();
+        expect(srcDoc(preview)).toContain('Inhalt der E-Mail');
+    });
+});

--- a/src/components/PlaceholderTemplate/EmailKitPreview.tsx
+++ b/src/components/PlaceholderTemplate/EmailKitPreview.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { TokenizedText } from './TokenizedText';
+import { emailColor, type EmailKitBrand } from './emailKit';
+import { ADMIN_EMAIL_SAMPLE_BRAND, renderInviteEmailPreviewHtml } from './invitePreviewMarkup';
+import styles from './EmailKitPreview.module.scss';
+
+export interface EmailKitPreviewProps {
+    /** Subject with known tokens already substituted (unknown ones stay `{{key}}`). */
+    subject: string;
+    /** Body with known tokens already substituted (unknown ones stay `{{key}}`). */
+    body: string;
+    /** Accessible name of the preview region (also the iframe title). */
+    previewLabel: string;
+}
+
+/** The tenant primary from the admin theme, as a literal the e-mail kit can inline. */
+const readTenantPrimary = (): string => {
+    const value =
+        typeof window === 'undefined'
+            ? ''
+            : window.getComputedStyle(document.documentElement).getPropertyValue('--m3-primary').trim();
+    return value || '#a5000a';
+};
+
+/**
+ * Grows the frame to fit the rendered document, so the preview shows the whole
+ * mail instead of a scroll stub. Ported from the e-mail kit's Storybook
+ * harness (ORISO-Frontend `src/emails/preview/EmailPreview.tsx`); re-measures
+ * once late because fonts settle after load.
+ */
+const useFittedFrame = (dependency: string) => {
+    const ref = useRef<HTMLIFrameElement>(null);
+    const [height, setHeight] = useState(600);
+
+    const measure = useCallback(() => {
+        const doc = ref.current?.contentDocument;
+        if (!doc?.body) {
+            return;
+        }
+        const next = Math.max(doc.body.scrollHeight, doc.documentElement.scrollHeight);
+        if (next > 40) {
+            setHeight((current) => (Math.abs(next - current) > 2 ? next : current));
+        }
+    }, []);
+
+    useEffect(() => {
+        measure();
+        const timer = window.setTimeout(measure, 250);
+        return () => window.clearTimeout(timer);
+    }, [dependency, measure]);
+
+    return { ref, height, measure };
+};
+
+/**
+ * Invite-mail preview in the NEW transactional e-mail design (ORISO-Frontend
+ * `src/emails/`, Storybook `Email/*`): branded header, white card, typography
+ * and footer exactly as the kit renders them. The document goes into an
+ * `<iframe>` because e-mail markup brings its own `<body>` background and a
+ * media query that must react to the *frame* width — which also makes the
+ * stacked mobile layout honest at 320px.
+ */
+export const EmailKitPreview = ({ subject, body, previewLabel }: EmailKitPreviewProps) => {
+    const { t } = useTranslation();
+    // Read once per mount: the admin theme applies the tenant palette to the
+    // document root before any editor screen renders.
+    const primaryColor = useMemo(readTenantPrimary, []);
+
+    const brand: EmailKitBrand = useMemo(
+        () => ({ ...ADMIN_EMAIL_SAMPLE_BRAND, primaryColor, accentColor: primaryColor }),
+        [primaryColor],
+    );
+
+    const html = useMemo(
+        () =>
+            renderInviteEmailPreviewHtml({
+                subject,
+                body,
+                brand,
+                lang: 'de',
+                strings: {
+                    subjectHint: t('links.templates.previewSubjectHint', 'Betreff der E-Mail'),
+                    bodyHint: t('links.templates.previewBodyHint', 'Inhalt der E-Mail'),
+                    assurance: t(
+                        'placeholderTemplate.preview.assurance',
+                        'Wir fragen Sie nie per E-Mail nach Ihrem Passwort. Geben Sie diesen Link an niemanden weiter.',
+                    ),
+                    offeredBy: t('placeholderTemplate.preview.offeredBy', '{{platform}} ist ein Angebot von {{org}}.', {
+                        platform: brand.platformName,
+                        org: brand.orgName,
+                    }),
+                    linkLabels: [
+                        t('placeholderTemplate.preview.privacy', 'Datenschutz'),
+                        t('placeholderTemplate.preview.imprint', 'Impressum'),
+                    ],
+                    automatedNote: t(
+                        'placeholderTemplate.preview.automatedNote',
+                        'Diese E-Mail wurde automatisch versendet. Bitte antworten Sie nicht darauf.',
+                    ),
+                },
+            }),
+        [subject, body, brand, t],
+    );
+
+    const { ref, height, measure } = useFittedFrame(html);
+
+    return (
+        <section aria-label={previewLabel} className={styles.preview}>
+            <div className={styles.meta}>
+                <span className={styles.metaLabel}>{t('links.templates.field.subject', 'Betreff')}</span>
+                <strong className={styles.metaSubject}>
+                    {subject ? (
+                        <TokenizedText text={subject} />
+                    ) : (
+                        t('links.templates.previewSubjectHint', 'Betreff der E-Mail')
+                    )}
+                </strong>
+            </div>
+            <iframe
+                ref={ref}
+                title={previewLabel}
+                srcDoc={html}
+                onLoad={measure}
+                className={styles.frame}
+                style={{ height, background: emailColor.canvas, borderColor: emailColor.outline }}
+            />
+        </section>
+    );
+};

--- a/src/components/PlaceholderTemplate/InviteEmailTemplateEditor.tsx
+++ b/src/components/PlaceholderTemplate/InviteEmailTemplateEditor.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { EmailTemplatePreview } from '../EmailTemplatePreview';
+import { EmailKitPreview } from './EmailKitPreview';
 import {
     PlaceholderTemplateEditor,
     type PlaceholderTemplateDefinition,
@@ -25,8 +25,9 @@ export interface InviteEmailTemplateEditorProps {
 /**
  * Variant 1 — invite e-mail template: subject + body with the exact token set
  * the UserService `AccountInviteService` substitutes, previewed live in the
- * e-mail design system's shell (reused {@link EmailTemplatePreview}) with
- * synthetic sample values. Unknown tokens stay visible as `{{key}}` chips.
+ * NEW transactional e-mail design system ({@link EmailKitPreview}, ported from
+ * ORISO-Frontend `src/emails/`) with synthetic sample values. Unknown tokens
+ * stay visible as highlighted `{{key}}` chips.
  */
 export const InviteEmailTemplateEditor = ({
     values,
@@ -50,7 +51,7 @@ export const InviteEmailTemplateEditor = ({
             fields={fields}
             heading={t('placeholderTemplate.invite.heading', 'Einladungs-E-Mail')}
             preview={
-                <EmailTemplatePreview
+                <EmailKitPreview
                     body={fillPlaceholders(values.body, samples)}
                     previewLabel={t('placeholderTemplate.invite.previewLabel', 'E-Mail-Vorschau')}
                     subject={fillPlaceholders(values.subject, samples)}

--- a/src/components/PlaceholderTemplate/PlaceholderTemplateEditor.stories.tsx
+++ b/src/components/PlaceholderTemplate/PlaceholderTemplateEditor.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
         docs: {
             description: {
                 component:
-                    'Reusable placeholder-template module: `{{token}}` fields with a picker, template selection on the M3 split button, and a live preview that substitutes synthetic sample values while typing. Unknown tokens stay visible as `{{key}}`. Presentational only — persistence and wiring into InviteComposer / the legal editors follow after Storybook approval.',
+                    'Reusable placeholder-template module: `{{token}}` fields with a picker, template selection on the M3 split button, and a live preview that substitutes synthetic sample values while typing. The invite e-mail previews in the NEW transactional e-mail design system (ported from ORISO-Frontend `src/emails/`, see the `Email/*` stories there): branded header with the tenant primary colour, white card, kit typography and footer. Unknown tokens stay visible as `{{key}}` chips. Presentational only — persistence and wiring into InviteComposer / the legal editors follow after Storybook approval.',
             },
         },
     },
@@ -85,6 +85,19 @@ export const InviteEmailUnknownToken: Story = {
                 subject: 'Einladung für {{firstName}}',
                 body: 'Hallo {{firstName}},\ndieser Platzhalter existiert nicht: {{unbekannterPlatzhalter}}',
             }}
+            onChange={() => {}}
+            onSelectTemplate={() => {}}
+        />
+    ),
+};
+
+export const InviteEmailEmpty: Story = {
+    name: 'Invite e-mail — empty draft keeps the shell intact',
+    render: () => (
+        <InviteEmailTemplateEditor
+            activeTemplateId={1}
+            templates={inviteTemplates}
+            values={{ subject: '', body: '' }}
             onChange={() => {}}
             onSelectTemplate={() => {}}
         />

--- a/src/components/PlaceholderTemplate/PlaceholderTemplateEditor.test.tsx
+++ b/src/components/PlaceholderTemplate/PlaceholderTemplateEditor.test.tsx
@@ -48,13 +48,18 @@ const InviteHarness = () => {
     );
 };
 
+/** The e-mail document the preview iframe renders (jsdom does not paint srcDoc). */
+const previewDocument = (preview: HTMLElement): string => preview.querySelector('iframe')?.getAttribute('srcdoc') ?? '';
+
 describe('InviteEmailTemplateEditor', () => {
     it('substitutes sample values into the live preview', () => {
         render(<InviteHarness />);
         const preview = screen.getByRole('region', { name: 'E-Mail-Vorschau' });
-        // firstName sample resolved, token no longer visible in the preview body.
+        // firstName sample resolved in the inbox strip and the mail document.
         expect(within(preview).getAllByText(/Lisa/).length).toBeGreaterThan(0);
         expect(within(preview).queryByText('{{firstName}}')).not.toBeInTheDocument();
+        expect(previewDocument(preview)).toContain('Hallo Lisa,');
+        expect(previewDocument(preview)).not.toContain('{{firstName}}');
     });
 
     it('updates the preview live while typing', () => {
@@ -62,7 +67,7 @@ describe('InviteEmailTemplateEditor', () => {
         const body = screen.getByRole('textbox', { name: 'Inhalt' });
         fireEvent.change(body, { target: { value: 'Guten Tag {{lastName}}!' } });
         const preview = screen.getByRole('region', { name: 'E-Mail-Vorschau' });
-        expect(within(preview).getByText(/Guten Tag Beispiel!/)).toBeInTheDocument();
+        expect(previewDocument(preview)).toContain('Guten Tag Beispiel!');
     });
 
     it('keeps unknown tokens visible as {{key}} in the preview', () => {
@@ -70,8 +75,20 @@ describe('InviteEmailTemplateEditor', () => {
         const body = screen.getByRole('textbox', { name: 'Inhalt' });
         fireEvent.change(body, { target: { value: 'Hallo {{firstName}} und {{unbekannt}}' } });
         const preview = screen.getByRole('region', { name: 'E-Mail-Vorschau' });
-        expect(within(preview).getByText('{{unbekannt}}')).toBeInTheDocument();
-        expect(within(preview).queryByText('{{firstName}}')).not.toBeInTheDocument();
+        expect(previewDocument(preview)).toContain('{{unbekannt}}');
+        expect(previewDocument(preview)).toContain('data-unknown-token');
+        expect(previewDocument(preview)).not.toContain('{{firstName}}');
+    });
+
+    it('renders the mail in the new e-mail design shell', () => {
+        render(<InviteHarness />);
+        const preview = screen.getByRole('region', { name: 'E-Mail-Vorschau' });
+        const doc = previewDocument(preview);
+        // Kit canvas + centred 600px column + responsive stylesheet (ported
+        // from ORISO-Frontend src/emails/kit).
+        expect(doc).toContain('background-color:#f2efef');
+        expect(doc).toContain('max-width:600px');
+        expect(doc).toContain('@media only screen and (max-width:620px)');
     });
 
     it('loads the picked template into the fields via the split button', async () => {

--- a/src/components/PlaceholderTemplate/emailKit.ts
+++ b/src/components/PlaceholderTemplate/emailKit.ts
@@ -1,0 +1,303 @@
+/**
+ * Minimal port of the ORISO transactional e-mail design system, for the admin
+ * preview pane only.
+ *
+ * Source of truth: ORISO-Frontend `src/emails/kit/` (merged with PR #881) —
+ * specifically `emailTokens.ts`, `emailAtoms.ts`, `emailMolecules.ts`,
+ * `emailOrganisms.ts` and `emailDocument.ts`. Admin cannot import cross-repo,
+ * hence this copy; keep the values and markup in sync with the frontend kit
+ * when the design changes there.
+ *
+ * House rules (same as the source kit): tables for layout, inline styles only,
+ * every colour and size from the token block below — the one exception is the
+ * `class` hook, because the `<style>` media query in {@link emailKitDocument}
+ * is the only way an e-mail can react to viewport width.
+ *
+ * Deliberate deviation: the logo lockup renders a tenant-coloured initial
+ * instead of the kit's `<img>` — the admin preview has no per-tenant logo URL,
+ * and a broken image in the header would read as a bug in the template.
+ */
+
+/* ------------------------------------------------------------------------- */
+/* Tokens (ported 1:1 from emailTokens.ts)                                   */
+/* ------------------------------------------------------------------------- */
+
+export const emailColor = {
+    /** Page background behind the card. */
+    canvas: '#f2efef',
+    /** The card itself. */
+    surface: '#ffffff',
+    outline: '#e0dada',
+    onSurface: '#1d1b1b',
+    onSurfaceVariant: '#5c5555',
+    /** Footer fine print. */
+    onSurfaceFaint: '#8a8080',
+    /** Separator dots between footer links. */
+    separator: '#c4bcbc',
+    onPrimary: '#ffffff',
+} as const;
+
+export const emailFontStack = "Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif";
+
+export const emailType = {
+    headline: { size: 24, line: 32, weight: 500, mobile: { size: 22, line: 30 } },
+    body: { size: 16, line: 26 },
+    label: { size: 14, line: 20, tracking: 0.25 },
+    caption: { size: 12, line: 18 },
+    /** Wordmark next to the logo. */
+    brand: { size: 16, line: 24, weight: 600, tracking: 0.15 },
+    orgName: { size: 13, line: 20, weight: 600 },
+} as const;
+
+export const emailSpace = {
+    /** Horizontal gutter inside the 600px column. */
+    gutter: 40,
+    /** Same gutter below the mobile breakpoint (applied via `.sp`). */
+    gutterMobile: 24,
+    /** Padding of the outer canvas cell. */
+    edge: { top: 32, side: 12, bottom: 48 },
+    edgeMobile: { top: 24, side: 8, bottom: 32 },
+} as const;
+
+export const emailRadius = {
+    card: 24,
+    logo: 8,
+    pill: 999,
+} as const;
+
+export const emailLayout = {
+    /** Canonical e-mail column width. */
+    width: 600,
+    /** Below this width the stacking media query kicks in. */
+    mobileBreakpoint: 620,
+    logoSize: 36,
+} as const;
+
+/** Brand values the preview fills per tenant (colours) and with samples (text). */
+export interface EmailKitBrand {
+    platformName: string;
+    orgName: string;
+    orgAddress: string;
+    contactLine: string;
+    primaryColor: string;
+    accentColor: string;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Atoms (ported from emailAtoms.ts)                                         */
+/* ------------------------------------------------------------------------- */
+
+/** Escapes the five XML specials — braces stay untouched so `{{tokens}}` survive. */
+export const emailEscape = (value: string): string =>
+    value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+
+const font = (size: number, line: number, extra: { weight?: number; tracking?: number; color?: string } = {}): string =>
+    [
+        `font-family:${emailFontStack}`,
+        `font-size:${size}px`,
+        `line-height:${line}px`,
+        extra.weight ? `font-weight:${extra.weight}` : '',
+        extra.tracking ? `letter-spacing:${extra.tracking}px` : '',
+        extra.color ? `color:${extra.color}` : '',
+    ]
+        .filter(Boolean)
+        .join(';');
+
+export interface EmailBlockOptions {
+    /** `top right bottom left`, in px. */
+    padding: [number, number, number, number];
+    className?: string;
+    align?: 'left' | 'center';
+    /** Typography for text blocks, appended to the cell's inline style. */
+    style?: string;
+}
+
+/** Wraps a fragment in the `<tr><td>` that carries its padding. */
+export const emailBlock = (content: string, { padding, className, align, style }: EmailBlockOptions): string => {
+    const [top, right, bottom, left] = padding;
+    const classes = ['sp', className].filter(Boolean).join(' ');
+    return (
+        `<tr><td class="${classes}"${align ? ` align="${align}"` : ''} ` +
+        `style="padding:${top}px ${right}px ${bottom}px ${left}px;` +
+        `${style ? `${style};` : ''}">${content}</td></tr>`
+    );
+};
+
+/** The short accent stroke above the headline (a spacer table, not an image). */
+export const emailAccentRule = (brand: EmailKitBrand): string =>
+    '<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="44" style="width:44px;">' +
+    `<tr><td height="4" bgcolor="${brand.accentColor}" ` +
+    `style="height:4px;line-height:4px;font-size:0;border-radius:${emailRadius.pill}px;` +
+    `background-color:${brand.accentColor};">&nbsp;</td></tr></table>`;
+
+/** Headline markup. `muted` renders the empty-state hint in the variant colour. */
+export const emailHeadline = (text: string, { muted = false }: { muted?: boolean } = {}): string =>
+    `<h1 class="h1" style="margin:0;${font(emailType.headline.size, emailType.headline.line, {
+        weight: emailType.headline.weight,
+        color: muted ? emailColor.onSurfaceVariant : emailColor.onSurface,
+    })};mso-line-height-rule:exactly;">${text}</h1>`;
+
+/** Body copy styling — the `<td>` carries it. */
+export const emailBodyTextStyle = (color: string = emailColor.onSurface): string =>
+    `${font(emailType.body.size, emailType.body.line, { color })};mso-line-height-rule:exactly`;
+
+/** Fine print: the encryption assurance and the footer. */
+export const emailCaptionStyle = (): string =>
+    font(emailType.caption.size, emailType.caption.line, { color: emailColor.onSurfaceVariant });
+
+export const emailDivider = (): string =>
+    '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">' +
+    `<tr><td height="1" bgcolor="${emailColor.outline}" ` +
+    'style="height:1px;line-height:1px;font-size:0;">&nbsp;</td></tr></table>';
+
+/**
+ * Logo plus wordmark. Adapted from `emailLogoLockup`: the tenant-coloured
+ * initial replaces the kit's `<img>` (see the file header).
+ */
+export const emailLogoLockup = (brand: EmailKitBrand): string =>
+    '<table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr>' +
+    `<td width="${emailLayout.logoSize}" height="${emailLayout.logoSize}" align="center" valign="middle" ` +
+    `bgcolor="${brand.primaryColor}" style="width:${emailLayout.logoSize}px;height:${emailLayout.logoSize}px;` +
+    `background-color:${brand.primaryColor};border-radius:${emailRadius.logo}px;` +
+    `${font(18, emailLayout.logoSize, { weight: 700, color: emailColor.onPrimary })};text-align:center;">` +
+    `${emailEscape(brand.platformName.charAt(0).toUpperCase())}</td>` +
+    `<td width="12" style="width:12px;font-size:0;line-height:0;">&nbsp;</td>` +
+    `<td valign="middle" style="${font(emailType.brand.size, emailType.brand.line, {
+        weight: emailType.brand.weight,
+        tracking: emailType.brand.tracking,
+        color: emailColor.onSurface,
+    })};">${emailEscape(brand.platformName)}</td>` +
+    '</tr></table>';
+
+/** A footer link, inert in the preview (a `<span>` styled like the kit's `<a>`). */
+export const emailFooterLink = (label: string): string =>
+    `<span style="color:${emailColor.onSurfaceVariant};text-decoration:underline;white-space:nowrap;">` +
+    `${emailEscape(label)}</span>`;
+
+export const emailFooterSeparator = (): string => `<span style="color:${emailColor.separator};">&nbsp; · &nbsp;</span>`;
+
+/* ------------------------------------------------------------------------- */
+/* Molecules (ported from emailMolecules.ts)                                 */
+/* ------------------------------------------------------------------------- */
+
+const G = emailSpace.gutter;
+
+/** Logo and platform name, sitting above the card on the bare canvas. */
+export const emailHeaderBar = (brand: EmailKitBrand): string =>
+    emailBlock(emailLogoLockup(brand), { padding: [0, G, 20, G] });
+
+/** The accent stroke plus the (pre-rendered) headline it belongs to. */
+export const emailTitleGroup = (headlineMarkup: string, brand: EmailKitBrand): string =>
+    emailBlock(emailAccentRule(brand), { padding: [36, G, 0, G] }) +
+    emailBlock(headlineMarkup, { padding: [18, G, 14, G] });
+
+/** Closing fine print inside the card, preceded by the divider. */
+export const emailAssurance = (text: string): string =>
+    emailBlock(emailDivider(), { padding: [28, G, 0, G] }) +
+    emailBlock(emailEscape(text), { padding: [16, G, 32, G], style: emailCaptionStyle() });
+
+export interface EmailKitFooterContent {
+    /** e.g. "Online-Beratung ist ein Angebot von {orgName}." */
+    offeredBy: string;
+    linkLabels: string[];
+    /** e.g. "Diese E-Mail wurde automatisch versendet…" */
+    automatedNote: string;
+}
+
+/** Sender identity, legal links and the do-not-reply note, below the card. */
+export const emailFooter = (footer: EmailKitFooterContent, brand: EmailKitBrand): string => {
+    const links = footer.linkLabels.map(emailFooterLink).join(emailFooterSeparator());
+    return emailBlock(
+        `<div style="color:${emailColor.onSurface};font-weight:${emailType.orgName.weight};` +
+            `font-size:${emailType.orgName.size}px;line-height:${emailType.orgName.line}px;">${emailEscape(
+                brand.orgName,
+            )}</div>` +
+            `<div style="padding-top:2px;">${emailEscape(brand.orgAddress)}</div>` +
+            `<div>${emailEscape(brand.contactLine)}</div>` +
+            `<div style="padding-top:14px;">${emailEscape(footer.offeredBy)}</div>` +
+            `<div class="flinks" style="padding-top:14px;">${links}</div>` +
+            `<div style="padding-top:14px;color:${emailColor.onSurfaceFaint};">${emailEscape(
+                footer.automatedNote,
+            )}</div>`,
+        { padding: [28, G, 0, G], style: `${emailCaptionStyle()};word-break:break-word` },
+    );
+};
+
+/* ------------------------------------------------------------------------- */
+/* Organisms (ported from emailOrganisms.ts)                                 */
+/* ------------------------------------------------------------------------- */
+
+/** The white card that holds the message. */
+export const emailCard = (rows: string): string =>
+    `${
+        '<tr><td style="padding:0;">' +
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" ' +
+        `bgcolor="${emailColor.surface}" style="background-color:${emailColor.surface};` +
+        `border-radius:${emailRadius.card}px;border:1px solid ${emailColor.outline};">`
+    }${rows}</table></td></tr>`;
+
+/** Canvas plus centred 600px column (`.wrap` releases the width on phones). */
+export const emailShell = (rows: string): string =>
+    `${
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" ' +
+        `style="background-color:${emailColor.canvas};">` +
+        `<tr><td class="edge" align="center" style="padding:${emailSpace.edge.top}px ${emailSpace.edge.side}px ` +
+        `${emailSpace.edge.bottom}px ${emailSpace.edge.side}px;">` +
+        `<table role="presentation" class="wrap" width="${emailLayout.width}" cellpadding="0" cellspacing="0" border="0" ` +
+        `style="width:${emailLayout.width}px;max-width:${emailLayout.width}px;">`
+    }${rows}</table></td></tr></table>`;
+
+/* ------------------------------------------------------------------------- */
+/* Document (ported from emailDocument.ts)                                   */
+/* ------------------------------------------------------------------------- */
+
+const responsiveStyles = (): string =>
+    `@media only screen and (max-width:${emailLayout.mobileBreakpoint}px){` +
+    '.wrap{width:100% !important;max-width:100% !important}' +
+    `.edge{padding:${emailSpace.edgeMobile.top}px ${emailSpace.edgeMobile.side}px ` +
+    `${emailSpace.edgeMobile.bottom}px ${emailSpace.edgeMobile.side}px !important}` +
+    `.sp{padding-left:${emailSpace.gutterMobile}px !important;padding-right:${emailSpace.gutterMobile}px !important}` +
+    `.h1{font-size:${emailType.headline.mobile.size}px !important;` +
+    `line-height:${emailType.headline.mobile.line}px !important}` +
+    '.flinks span{display:inline-block !important;white-space:normal !important;padding:3px 0 !important}' +
+    '}';
+
+const resetStyles = (): string =>
+    'img{border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic;max-width:100%}' +
+    'table{border-collapse:collapse}' +
+    'a[x-apple-data-detectors]{color:inherit !important;text-decoration:none !important;' +
+    'font-size:inherit !important;font-family:inherit !important;font-weight:inherit !important;' +
+    'line-height:inherit !important}';
+
+export interface EmailKitDocumentOptions {
+    /** BCP-47 language tag for `<html lang>`. */
+    lang: string;
+    /** Goes into `<title>`, which is what most clients use as the subject. */
+    subject: string;
+    /** Rows already wrapped by {@link emailShell}. */
+    body: string;
+}
+
+export const emailKitDocument = ({ lang, subject, body }: EmailKitDocumentOptions): string =>
+    `<!DOCTYPE html>
+<html lang="${lang}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${emailEscape(subject)}</title>
+<style>
+  ${resetStyles()}
+  ${responsiveStyles()}
+</style>
+</head>
+<body style="margin:0;padding:0;width:100%;background-color:${emailColor.canvas};` +
+    `-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;">
+${body}
+</body>
+</html>
+`;

--- a/src/components/PlaceholderTemplate/index.ts
+++ b/src/components/PlaceholderTemplate/index.ts
@@ -17,5 +17,6 @@ export {
     type PlaceholderTemplateEditorProps,
     type PlaceholderTemplateFieldConfig,
 } from './PlaceholderTemplateEditor';
+export { EmailKitPreview, type EmailKitPreviewProps } from './EmailKitPreview';
 export { InviteEmailTemplateEditor, type InviteEmailTemplateValues } from './InviteEmailTemplateEditor';
 export { LegalConsentTemplateEditor, type LegalConsentTemplateValues } from './LegalConsentTemplateEditor';

--- a/src/components/PlaceholderTemplate/invitePreviewMarkup.test.ts
+++ b/src/components/PlaceholderTemplate/invitePreviewMarkup.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { EmailKitBrand } from './emailKit';
+import {
+    ADMIN_EMAIL_SAMPLE_BRAND,
+    highlightUnknownTokens,
+    renderInviteEmailPreviewHtml,
+    type InvitePreviewStrings,
+} from './invitePreviewMarkup';
+
+const brand: EmailKitBrand = {
+    ...ADMIN_EMAIL_SAMPLE_BRAND,
+    primaryColor: '#a5000a',
+    accentColor: '#a5000a',
+};
+
+const strings: InvitePreviewStrings = {
+    subjectHint: 'Betreff der E-Mail',
+    bodyHint: 'Inhalt der E-Mail',
+    assurance: 'Wir fragen Sie nie per E-Mail nach Ihrem Passwort.',
+    offeredBy: 'Online-Beratung ist ein Angebot von Caritasverband für die Diözese Mainz e. V.',
+    linkLabels: ['Datenschutz', 'Impressum'],
+    automatedNote: 'Diese E-Mail wurde automatisch versendet. Bitte antworten Sie nicht darauf.',
+};
+
+const render = (subject: string, body: string) =>
+    renderInviteEmailPreviewHtml({ subject, body, brand, strings, lang: 'de' });
+
+describe('renderInviteEmailPreviewHtml', () => {
+    it('renders substituted subject and body copy into the kit shell', () => {
+        const html = render('Ihre Einladung, Lisa', 'Hallo Lisa Beispiel,\nhier ist Ihr Link.');
+        expect(html).toContain('Ihre Einladung, Lisa');
+        expect(html).toContain('Hallo Lisa Beispiel,<br>hier ist Ihr Link.');
+        // Kit shell: canvas colour, 600px column and the responsive stylesheet.
+        expect(html).toContain('background-color:#f2efef');
+        expect(html).toContain('max-width:600px');
+        expect(html).toContain('@media only screen and (max-width:620px)');
+    });
+
+    it('keeps unknown tokens visible as highlighted chips', () => {
+        const html = render('Einladung', 'Hallo {{unbekannt}}!');
+        expect(html).toContain('{{unbekannt}}');
+        expect(html).toContain('data-unknown-token');
+        expect(html).toContain('color:#a5000a');
+    });
+
+    it('splits blank-line separated text into kit paragraph blocks', () => {
+        const html = render('Einladung', 'Absatz eins.\n\nAbsatz zwei.');
+        expect(html).toContain('>Absatz eins.</td>');
+        expect(html).toContain('>Absatz zwei.</td>');
+    });
+
+    it('applies the tenant primary colour to the header logo and accent rule', () => {
+        const tenantBrand = { ...brand, primaryColor: '#123456', accentColor: '#123456' };
+        const html = renderInviteEmailPreviewHtml({ subject: 'A', body: 'B', brand: tenantBrand, strings, lang: 'de' });
+        expect(html).toContain('bgcolor="#123456"');
+        expect(html).toContain('background-color:#123456');
+    });
+
+    it('renders the muted hints for empty subject and body', () => {
+        const html = render('', '');
+        expect(html).toContain('Betreff der E-Mail');
+        expect(html).toContain('Inhalt der E-Mail');
+        expect(html).toContain('<title>Betreff der E-Mail</title>');
+        // Muted, not the regular on-surface headline colour.
+        expect(html).toContain('color:#5c5555');
+    });
+
+    it('renders the footer with sender identity, legal links and the automated note', () => {
+        const html = render('Einladung', 'Hallo');
+        expect(html).toContain('Caritasverband für die Diözese Mainz e. V.');
+        expect(html).toContain('Datenschutz');
+        expect(html).toContain('Impressum');
+        expect(html).toContain('Bitte antworten Sie nicht darauf.');
+        expect(html).toContain(strings.assurance);
+    });
+
+    it('escapes user-typed markup instead of executing it', () => {
+        const html = render('<b>Betreff</b>', '<script>alert(1)</script>');
+        expect(html).not.toContain('<script>alert(1)</script>');
+        expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+        expect(html).toContain('&lt;b&gt;Betreff&lt;/b&gt;');
+    });
+});
+
+describe('highlightUnknownTokens', () => {
+    it('wraps every remaining token and leaves surrounding text alone', () => {
+        const out = highlightUnknownTokens('Hallo {{a}} und {{b}}', brand);
+        expect(out.match(/data-unknown-token/g)).toHaveLength(2);
+        expect(out).toContain('Hallo ');
+    });
+
+    it('falls back to a neutral tint for non-hex theme colours', () => {
+        const out = highlightUnknownTokens('{{x}}', { ...brand, primaryColor: 'var(--m3-primary)' });
+        expect(out).toContain('background:#f5eded');
+    });
+});

--- a/src/components/PlaceholderTemplate/invitePreviewMarkup.ts
+++ b/src/components/PlaceholderTemplate/invitePreviewMarkup.ts
@@ -1,0 +1,142 @@
+/**
+ * Composes the invite-mail preview document out of the ported e-mail kit
+ * (`emailKit.ts`) — the admin-side equivalent of what ORISO-Frontend's
+ * `Email/Pages/EinladungTraeger` story renders: branded header bar, white
+ * card with accent rule + headline + body copy, assurance line, footer.
+ *
+ * Preview-specific additions on top of the kit:
+ *   - any `{{token}}` still present after sample substitution is highlighted
+ *     as a chip (the module's visual contract for "unresolved placeholder");
+ *   - empty subject/body render their hint texts in the muted colour, so the
+ *     frame never looks broken while the admin is still typing.
+ */
+
+import {
+    EmailKitBrand,
+    emailAssurance,
+    emailBlock,
+    emailBodyTextStyle,
+    emailCard,
+    emailColor,
+    emailEscape,
+    emailFooter,
+    emailHeaderBar,
+    emailHeadline,
+    emailKitDocument,
+    emailShell,
+    emailSpace,
+    emailTitleGroup,
+} from './emailKit';
+
+/**
+ * Sample sender identity for the preview, ported from the frontend kit's
+ * `emailSampleBrand` (ORISO-Frontend `src/emails/kit/emailTokens.ts`). The
+ * colours are intentionally absent — they come from the tenant theme at
+ * render time.
+ */
+export const ADMIN_EMAIL_SAMPLE_BRAND: Omit<EmailKitBrand, 'primaryColor' | 'accentColor'> = {
+    platformName: 'Online-Beratung',
+    orgName: 'Caritasverband für die Diözese Mainz e. V.',
+    orgAddress: 'Bahnhofstraße 6, 55116 Mainz',
+    contactLine: 'kontakt@beratung.example.org · 06131 0000-0',
+};
+
+export interface InvitePreviewStrings {
+    /** Shown as the headline while the subject field is empty. */
+    subjectHint: string;
+    /** Shown as the body while the body field is empty. */
+    bodyHint: string;
+    /** Closing fine print inside the card (the encryption/security assurance). */
+    assurance: string;
+    /** Footer sentence naming the operator, e.g. "… ist ein Angebot von …". */
+    offeredBy: string;
+    /** Footer legal-link labels, e.g. Datenschutz / Impressum. */
+    linkLabels: string[];
+    /** Footer do-not-reply note. */
+    automatedNote: string;
+}
+
+export interface InvitePreviewOptions {
+    /** Subject with known tokens already substituted (unknown ones stay `{{key}}`). */
+    subject: string;
+    /** Body with known tokens already substituted (unknown ones stay `{{key}}`). */
+    body: string;
+    brand: EmailKitBrand;
+    strings: InvitePreviewStrings;
+    /** BCP-47 tag for `<html lang>`. */
+    lang: string;
+}
+
+const TOKEN_PATTERN = /\{\{[^{}]+\}\}/g;
+
+/** 8% tint of a `#rrggbb` colour for the token-chip background. */
+const tint = (hex: string): string => {
+    const match = /^#([0-9a-f]{6})$/i.exec(hex.trim());
+    if (!match) {
+        return '#f5eded';
+    }
+    return `rgba(${parseInt(match[1].slice(0, 2), 16)},${parseInt(match[1].slice(2, 4), 16)},${parseInt(
+        match[1].slice(4, 6),
+        16,
+    )},0.08)`;
+};
+
+/** Wraps every `{{token}}` left in (already escaped) text in a highlight chip. */
+export const highlightUnknownTokens = (escapedText: string, brand: EmailKitBrand): string =>
+    escapedText.replace(
+        TOKEN_PATTERN,
+        (token) =>
+            `<code data-unknown-token style="padding:1px 5px;border-radius:4px;` +
+            `background:${tint(brand.primaryColor)};color:${brand.primaryColor};` +
+            `font-family:SFMono-Regular,Consolas,'Liberation Mono',monospace;` +
+            `font-size:14px;font-weight:700;">${token}</code>`,
+    );
+
+/**
+ * Body copy: blank lines separate paragraphs (each its own kit block, like
+ * `emailProse`), single newlines become `<br>`. `word-break` keeps a pasted
+ * invite URL from widening the 320px layout.
+ */
+const proseRows = (body: string, brand: EmailKitBrand, strings: InvitePreviewStrings): string => {
+    const G = emailSpace.gutter;
+    if (!body.trim()) {
+        return emailBlock(emailEscape(strings.bodyHint), {
+            padding: [0, G, 28, G],
+            style: emailBodyTextStyle(emailColor.onSurfaceVariant),
+        });
+    }
+    const paragraphs = body.split(/\n{2,}/);
+    return paragraphs
+        .map((paragraph, index) =>
+            emailBlock(highlightUnknownTokens(emailEscape(paragraph), brand).replace(/\n/g, '<br>'), {
+                padding: [0, G, index === paragraphs.length - 1 ? 28 : 16, G],
+                style: `${emailBodyTextStyle()};word-break:break-word`,
+            }),
+        )
+        .join('');
+};
+
+/** Renders the complete preview document for the invite e-mail. */
+export const renderInviteEmailPreviewHtml = ({ subject, body, brand, strings, lang }: InvitePreviewOptions): string => {
+    const headline = subject.trim()
+        ? emailHeadline(highlightUnknownTokens(emailEscape(subject), brand))
+        : emailHeadline(emailEscape(strings.subjectHint), { muted: true });
+
+    const cardRows =
+        emailTitleGroup(headline, brand) + proseRows(body, brand, strings) + emailAssurance(strings.assurance);
+
+    const bodyRows = emailShell(
+        emailHeaderBar(brand) +
+            emailCard(cardRows) +
+            emailFooter(
+                {
+                    offeredBy: strings.offeredBy,
+                    linkLabels: strings.linkLabels,
+                    automatedNote: strings.automatedNote,
+                },
+                brand,
+            ),
+    );
+
+    return emailKitDocument({ lang, subject: subject.trim() || strings.subjectHint, body: bodyRows });
+};


### PR DESCRIPTION
Closes #743

> **Stacked PR** — based on `feat/placeholder-template-module` (PR #727, not yet merged). Merge #727 first; this PR only contains the preview-shell commit on top.

## What

Replaces the legacy invite-mail preview shell in the PlaceholderTemplate module with the **new transactional email design system** (source of truth: ORISO-Frontend `src/emails/`, merged there with PR #881 — Storybook `Email/*`, reference look `Email/Pages/EinladungTraeger`).

- **`emailKit.ts`** — minimal 1:1 port of the kit (tokens, atoms, molecules, organisms, document) with source comments naming the origin files; Admin cannot import cross-repo. One deliberate deviation: the header logo renders a tenant-coloured initial instead of the kit's `<img>`, because the admin preview has no per-tenant logo URL.
- **`invitePreviewMarkup.ts`** — composes the preview document: branded header bar, white card (accent rule + headline + body copy), security assurance, kit footer. Unknown `{{tokens}}` remain visible as highlighted chips; empty subject/body render muted hint texts so the frame never looks broken while typing.
- **`EmailKitPreview.tsx`** — renders the document into a height-fitted `<iframe>` (same approach as the frontend kit's Storybook harness): the kit's media query reacts to the *frame* width, so a narrow preview column shows the honest stacked mobile layout. The tenant primary colour is read from the admin theme (`--m3-primary`) and inlined into the shell (logo, accent rule, token chips).
- Live `{{token}}` substitution with sample values is unchanged (`fillPlaceholders` / `sampleValues`); the subject line additionally shows in an inbox-style strip above the frame.
- Stories: the invite stories now preview in the new design; added an empty-draft story. The legal-consent variant is untouched (its preview is a registration checkbox, not an email).

**Follow-up note:** the invite-email templates the UserService actually *sends* are tracked separately in the FE#828 email epic — this PR is only the admin preview pane.

## Screenshots

| | Old (PR #727 state) | New (this PR) |
|---|---|---|
| Desktop | [<img src="https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/7086d6a9-b822-48ce-afa9-564f5534f9da/old-invite-desktop.png" width="380">](https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/7086d6a9-b822-48ce-afa9-564f5534f9da/old-invite-desktop.png) | [<img src="https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/9df17add-438f-4954-bc35-e5bf8762c95f/new-invite-desktop.png" width="380">](https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/9df17add-438f-4954-bc35-e5bf8762c95f/new-invite-desktop.png) |
| 320 px | [<img src="https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/4aa768bc-9ce2-49f8-9ed8-fac3adecf656/old-invite-320.png" width="190">](https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/4aa768bc-9ce2-49f8-9ed8-fac3adecf656/old-invite-320.png) | [<img src="https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/f4ef05c7-4cc3-4eaf-9fdc-97405020ae45/new-invite-320.png" width="190">](https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/f4ef05c7-4cc3-4eaf-9fdc-97405020ae45/new-invite-320.png) |
| Unknown token | [<img src="https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/724b1b07-3171-457b-bef1-ac825dcda761/old-invite-unknown-desktop.png" width="380">](https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/724b1b07-3171-457b-bef1-ac825dcda761/old-invite-unknown-desktop.png) | [<img src="https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/9cbad61c-8666-4f70-8aee-612c4954bdc2/new-invite-unknown-desktop.png" width="380">](https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/9cbad61c-8666-4f70-8aee-612c4954bdc2/new-invite-unknown-desktop.png) |
| Empty draft | — | [<img src="https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/a3148d01-b92b-4f22-bd58-d44ae3dc2937/new-invite-empty-desktop.png" width="380">](https://evidence.dreambau.com/e/zhon5jikrwdaey7k2t35ythbvb5jdpiv/a3148d01-b92b-4f22-bd58-d44ae3dc2937/new-invite-empty-desktop.png) |

## Reviewer test plan

- [ ] `Organisms/PlaceholderTemplateEditor → Invite Email`: the preview matches the `Email/*` Storybook look from ORISO-Frontend (canvas + header bar with tenant-coloured logo mark, white card with accent rule, kit typography, assurance line, footer with sender identity/legal links/do-not-reply note)
- [ ] Typing in subject/body updates the styled preview live; sample values are substituted; unknown tokens stay visible as highlighted `{{key}}` chips
- [ ] "Invite e-mail — empty draft" story: empty fields render the muted hints inside an intact shell
- [ ] At 320 px viewport the preview renders the stacked mobile e-mail layout without horizontal overflow
- [ ] `npm run test` (vitest) green: 244 files / 1511 tests, incl. new `invitePreviewMarkup.test.ts` + `EmailKitPreview.test.tsx`
- [ ] `npx tsc --noEmit` and `npx eslint src/components/PlaceholderTemplate --max-warnings=0` clean; Storybook builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
