### PR TITLE
feat: SplitButton M3 size scale, interaction states and sheet variants (#741)

### DIFF
--- a/src/components/GlobalSearch/GlobalSearch.stories.tsx
+++ b/src/components/GlobalSearch/GlobalSearch.stories.tsx
@@ -47,7 +47,7 @@ const ComposerActions = ({ ready }: { ready: boolean }) => {
                 icon={<MailFilledIcon />}
                 label={template}
                 menuLabel="E-Mail-Vorlage wählen"
-                variant="tonal"
+                variant="outlined"
                 menu={{
                     items: [
                         {
@@ -199,7 +199,7 @@ export const MenuOpen: Story = {
                 }}
                 open
             >
-                <SplitButton icon={<MailFilledIcon />} label={TEMPLATE_NAMES[0]} variant="tonal" />
+                <SplitButton icon={<MailFilledIcon />} label={TEMPLATE_NAMES[0]} variant="outlined" />
             </GlobalSearchMenu>
         </div>
     ),

--- a/src/components/GlobalSearch/SplitButton.stories.tsx
+++ b/src/components/GlobalSearch/SplitButton.stories.tsx
@@ -1,0 +1,115 @@
+import { Fragment, type CSSProperties } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { MenuProps } from 'antd';
+import { ReactComponent as MailFilledIcon } from '../../resources/img/svg/oriso/mail_filled_24px.svg';
+import { SplitButton, type SplitButtonSize, type SplitButtonVariant } from './SplitButton';
+
+/**
+ * M3 split button per the spec sheet Figma 57994-15744: five sizes
+ * (XSmall 32px … XLarge 136px), the sheet's colour variants
+ * (filled/tonal/outlined/elevated) and the interaction states. `primary` and
+ * `secondary` remain as aliases of filled/tonal for existing callers.
+ */
+const meta = {
+    title: 'Molecules/SplitButton',
+    component: SplitButton,
+    parameters: { layout: 'padded' },
+} satisfies Meta<typeof SplitButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SIZES: SplitButtonSize[] = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
+const VARIANTS: SplitButtonVariant[] = ['filled', 'tonal', 'outlined', 'elevated'];
+
+const menu: MenuProps = {
+    items: [
+        { key: 'a', label: 'Erste Option' },
+        { key: 'b', label: 'Zweite Option' },
+    ],
+};
+
+const cellHeader: CSSProperties = {
+    color: 'var(--m3-on-surface-variant, #444748)',
+    font: '500 12px/16px Roboto, sans-serif',
+    letterSpacing: '0.5px',
+    textTransform: 'uppercase',
+};
+
+/**
+ * Sizes × variants × states, mirroring the Figma sheet for side-by-side visual
+ * review. Hover/focus/pressed are live pseudo-states — hover, tab and press the
+ * Enabled column to see the 8%/10% state layers and the pressed shape morph.
+ * The Open column pins the controlled open state (chevron up, fully rounded
+ * chevron segment, elevated); its dropdown sheets are hidden here so sixty
+ * buttons do not stack twenty menus — the OpenMenu story shows the real sheet.
+ */
+export const M3Matrix: Story = {
+    args: { label: 'Label' },
+    render: () => (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 40 }}>
+            {/* Story-scoped: the matrix pins `open` for its state column; the
+                portal-rendered menus would bury the grid. */}
+            <style>{'.ant-dropdown:has(.splitbutton-matrix-menu) { display: none; }'}</style>
+            {SIZES.map((size) => (
+                <section key={size}>
+                    <h3 style={{ margin: '0 0 12px', font: '400 24px/32px Roboto, sans-serif' }}>{size}</h3>
+                    <div
+                        style={{
+                            display: 'grid',
+                            gridTemplateColumns: 'max-content repeat(3, max-content)',
+                            alignItems: 'center',
+                            columnGap: 32,
+                            rowGap: 16,
+                        }}
+                    >
+                        <span />
+                        {['Enabled', 'Disabled', 'Open'].map((state) => (
+                            <span key={state} style={cellHeader}>
+                                {state}
+                            </span>
+                        ))}
+                        {VARIANTS.map((variant) => (
+                            <Fragment key={variant}>
+                                <span style={cellHeader}>{variant}</span>
+                                <SplitButton
+                                    icon={<MailFilledIcon />}
+                                    label="Label"
+                                    menu={menu}
+                                    size={size}
+                                    variant={variant}
+                                />
+                                <SplitButton
+                                    disabled
+                                    icon={<MailFilledIcon />}
+                                    label="Label"
+                                    menu={menu}
+                                    size={size}
+                                    variant={variant}
+                                />
+                                <SplitButton
+                                    icon={<MailFilledIcon />}
+                                    label="Label"
+                                    menu={{ ...menu, className: 'splitbutton-matrix-menu' }}
+                                    open
+                                    size={size}
+                                    variant={variant}
+                                />
+                            </Fragment>
+                        ))}
+                    </div>
+                </section>
+            ))}
+        </div>
+    ),
+};
+
+/** The real open state with its menu sheet: chevron up, elevated, one surface. */
+export const OpenMenu: Story = {
+    args: { label: 'Label' },
+    render: () => (
+        <div style={{ height: 220 }}>
+            <SplitButton icon={<MailFilledIcon />} label="Standard-Einladung" menu={menu} open variant="outlined" />
+        </div>
+    ),
+};

--- a/src/components/GlobalSearch/SplitButton.test.tsx
+++ b/src/components/GlobalSearch/SplitButton.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SplitButton } from './SplitButton';
+import styles from './splitButton.module.scss';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key }),
+}));
+
+const menu = { items: [{ key: 'a', label: 'Option A' }] };
+
+/** The root is the wrapper that carries size/variant/state classes. */
+const root = (label: string) => screen.getByRole('button', { name: label }).parentElement as HTMLElement;
+
+describe('SplitButton size scale (Figma 57994-15744)', () => {
+    it('defaults to the medium (56px) geometry so existing callers do not shift', () => {
+        render(<SplitButton label="Senden" />);
+        expect(root('Senden').classList.contains(styles.medium)).toBe(true);
+    });
+
+    it.each(['xsmall', 'small', 'medium', 'large', 'xlarge'] as const)('applies the %s size class', (size) => {
+        render(<SplitButton label={size} size={size} />);
+        expect(root(size).classList.contains(styles[size])).toBe(true);
+    });
+});
+
+describe('SplitButton variant mapping (M3 sheet: filled/tonal/outlined/elevated)', () => {
+    it.each(['filled', 'tonal', 'outlined', 'elevated'] as const)('applies the %s variant class', (variant) => {
+        render(<SplitButton label={variant} variant={variant} />);
+        expect(root(variant).classList.contains(styles[variant])).toBe(true);
+    });
+
+    it('keeps `primary` as an alias of filled', () => {
+        render(<SplitButton label="Senden" variant="primary" />);
+        expect(root('Senden').classList.contains(styles.filled)).toBe(true);
+    });
+
+    it('keeps `secondary` as an alias of tonal (M3 secondary container)', () => {
+        render(<SplitButton label="23" variant="secondary" />);
+        expect(root('23').classList.contains(styles.tonal)).toBe(true);
+    });
+
+    it('defaults to outlined', () => {
+        render(<SplitButton label="Senden" />);
+        expect(root('Senden').classList.contains(styles.outlined)).toBe(true);
+    });
+});
+
+describe('SplitButton open state', () => {
+    it('marks the root open and expands the chevron on click', async () => {
+        const user = userEvent.setup();
+        render(<SplitButton label="Vorlage" menu={menu} menuLabel="Menü öffnen" />);
+        const chevron = screen.getByRole('button', { name: 'Menü öffnen' });
+        expect(chevron).toHaveAttribute('aria-expanded', 'false');
+        await user.click(chevron);
+        expect(chevron).toHaveAttribute('aria-expanded', 'true');
+        expect(root('Vorlage').classList.contains(styles.open)).toBe(true);
+    });
+
+    it('supports a controlled open state for stories and E2E', () => {
+        render(<SplitButton label="Vorlage" menu={menu} menuLabel="Menü öffnen" open />);
+        expect(root('Vorlage').classList.contains(styles.open)).toBe(true);
+        expect(screen.getByRole('button', { name: 'Menü öffnen' })).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('never reports open while disabled', () => {
+        render(<SplitButton disabled label="Vorlage" menu={menu} menuLabel="Menü öffnen" open />);
+        expect(root('Vorlage').classList.contains(styles.open)).toBe(false);
+        expect(screen.getByRole('button', { name: 'Menü öffnen' })).toHaveAttribute('aria-expanded', 'false');
+    });
+});
+
+describe('SplitButton segment behaviour (regression guard for existing callers)', () => {
+    it('disables only the main segment with mainDisabled while the menu stays reachable', () => {
+        render(<SplitButton label="Senden" mainDisabled menu={menu} menuLabel="Sendeoptionen" />);
+        expect(screen.getByRole('button', { name: 'Senden' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Sendeoptionen' })).toBeEnabled();
+    });
+
+    it('renders the opt-in collapse segment', async () => {
+        const user = userEvent.setup();
+        const onCollapse = vi.fn();
+        render(<SplitButton collapseLabel="Auswahl aufheben" label="23" onCollapse={onCollapse} />);
+        await user.click(screen.getByRole('button', { name: 'Auswahl aufheben' }));
+        expect(onCollapse).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/GlobalSearch/SplitButton.tsx
+++ b/src/components/GlobalSearch/SplitButton.tsx
@@ -5,18 +5,44 @@ import { useTranslation } from 'react-i18next';
 import { ReactComponent as ChevronDownIcon } from '../../resources/img/svg/oriso/keyboard_arrow_down_24px.svg';
 import styles from './splitButton.module.scss';
 
+/**
+ * Colour variants per the M3 spec sheet (Figma 57994-15744):
+ * - `filled`: brand surface — the page's main CTA (alias: `primary`).
+ * - `tonal`: M3 secondary container — resting actions that are not the CTA
+ *   (alias: `secondary`).
+ * - `outlined`: transparent with outline — the default resting look.
+ * - `elevated`: light container with primary text and a resting shadow. The
+ *   shadow is this variant's identity — never use it just for the light fill.
+ */
+export type SplitButtonVariant = 'filled' | 'tonal' | 'outlined' | 'elevated' | 'primary' | 'secondary';
+
+/** Size scale per the M3 spec sheet: 32/40/56/96/136px container heights. */
+export type SplitButtonSize = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge';
+
+/** Legacy variant names map onto the sheet's vocabulary. */
+const VARIANT_ALIASES: Partial<Record<SplitButtonVariant, SplitButtonVariant>> = {
+    primary: 'filled',
+    secondary: 'tonal',
+};
+
 export interface SplitButtonProps {
     /** Main segment content (action label). */
     label: ReactNode;
-    /** Leading icon (24px), inherits the segment text colour. */
+    /** Leading icon, sized by the size scale, inherits the segment text colour. */
     icon?: ReactNode;
+    /** Colour variant, see {@link SplitButtonVariant}. */
+    variant?: SplitButtonVariant;
     /**
-     * Visual variant per the Figma composer spec: `tonal` = light fill with
-     * primary text (e.g. template picker), `primary` = filled brand surface
-     * (e.g. send). Use `outlined` for the resting/not-ready state — the caller
-     * flips to `primary` once the form is validly filled.
+     * M3 size (XSmall 32px … XLarge 136px). Defaults to `medium` — the 56px
+     * geometry every existing caller was built against.
      */
-    variant?: 'outlined' | 'tonal' | 'secondary' | 'primary';
+    size?: SplitButtonSize;
+    /**
+     * Controlled open state of the chevron menu — pass it only when the caller
+     * (a story, a test) must pin the open appearance; leave it out for the
+     * normal self-managed dropdown.
+     */
+    open?: boolean;
     disabled?: boolean;
     /**
      * Disables only the main (action) segment while the chevron menu stays
@@ -63,6 +89,8 @@ export const SplitButton = ({
     label,
     icon,
     variant = 'outlined',
+    size = 'medium',
+    open: openProp,
     disabled = false,
     mainDisabled = false,
     mainDescribedBy,
@@ -75,20 +103,21 @@ export const SplitButton = ({
     className,
 }: SplitButtonProps) => {
     const { t } = useTranslation();
-    const [open, setOpen] = useState(false);
+    const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+    const open = !disabled && (openProp ?? uncontrolledOpen);
+    const resolvedVariant = VARIANT_ALIASES[variant] ?? variant;
 
-    const handleOpenChange: Required<DropdownProps>['onOpenChange'] = (nextOpen) => setOpen(nextOpen);
+    const handleOpenChange: Required<DropdownProps>['onOpenChange'] = (nextOpen) => setUncontrolledOpen(nextOpen);
 
     const segments = (
         <span
             className={classNames(
                 styles.splitButton,
+                styles[size],
+                styles[resolvedVariant],
                 {
-                    [styles.tonal]: variant === 'tonal',
-                    [styles.secondary]: variant === 'secondary',
-                    [styles.primary]: variant === 'primary',
                     [styles.disabled]: disabled,
-                    [styles.open]: open && !disabled,
+                    [styles.open]: open,
                 },
                 className,
             )}
@@ -113,7 +142,7 @@ export const SplitButton = ({
                 <Dropdown
                     trigger={['click']}
                     disabled={disabled}
-                    open={!disabled && open}
+                    open={open}
                     onOpenChange={handleOpenChange}
                     menu={menu}
                     // The sheet carries the same, one step higher shadow as the
@@ -125,7 +154,7 @@ export const SplitButton = ({
                         className={classNames(styles.segment, styles.chevron)}
                         disabled={disabled}
                         aria-haspopup="menu"
-                        aria-expanded={!disabled && open}
+                        aria-expanded={open}
                         aria-label={menuLabel ?? t('globalSearch.moreOptions', 'Weitere Optionen')}
                     >
                         <ChevronDownIcon className={styles.chevronIcon} aria-hidden />

--- a/src/components/GlobalSearch/splitButton.module.scss
+++ b/src/components/GlobalSearch/splitButton.module.scss
@@ -1,13 +1,119 @@
+/*
+ * M3 split button (Figma 57994-15744, spec sheet "Split button").
+ *
+ * All geometry is driven by the size variables below so the five spec sizes
+ * (XSmall/Small/Medium/Large/XLarge) share one rule set. The base values ARE
+ * the Medium size (56px) — the default — so existing callers keep their
+ * geometry. Sizes measured off the Figma symbols (node ids 57994:15752/16184/
+ * 15860/15968/16076).
+ */
 .splitButton {
+    /* Medium (default): 56px pill, Figma 57994:15860 */
+    --sb-height: 56px;
+    --sb-radius: 28px; /* outer pill radius = height / 2 */
+    --sb-radius-inner: 4px; /* the small corners where the segments meet */
+    --sb-radius-pressed: 10px; /* pressed shape morph of the inner corners */
+    --sb-pad-left: 24px;
+    --sb-pad-right: 24px;
+    --sb-gap: 8px; /* icon ↔ label */
+    --sb-font-size: 16px; /* M3/title/medium */
+    --sb-line-height: 24px;
+    --sb-letter-spacing: 0.15px;
+    --sb-font-weight: 500;
+    --sb-icon: 24px;
+    --sb-chevron-width: 56px;
+    --sb-chevron-icon: 26px;
+    --sb-touch-extend: 0px; /* XS/S visuals are < 48px; the hit area is not */
+
     display: inline-flex;
     align-items: stretch;
-    gap: 2px;
+    gap: 2px; /* between segments, all sizes (Figma) */
 }
+
+/* ---- Size scale (Figma 57994-15744) ------------------------------------- */
+
+.xsmall {
+    --sb-height: 32px;
+    --sb-radius: 16px;
+    --sb-radius-inner: 4px;
+    --sb-radius-pressed: 8px;
+    --sb-pad-left: 12px;
+    --sb-pad-right: 10px;
+    --sb-gap: 4px;
+    --sb-font-size: 14px; /* M3/label/large */
+    --sb-line-height: 20px;
+    --sb-letter-spacing: 0.1px;
+    --sb-font-weight: 500;
+    --sb-icon: 20px;
+    --sb-chevron-width: 48px;
+    --sb-chevron-icon: 22px;
+    --sb-touch-extend: 8px;
+}
+
+.small {
+    --sb-height: 40px;
+    --sb-radius: 20px;
+    --sb-radius-inner: 4px;
+    --sb-radius-pressed: 8px;
+    --sb-pad-left: 16px;
+    --sb-pad-right: 12px;
+    --sb-gap: 8px;
+    --sb-font-size: 14px; /* M3/label/large */
+    --sb-line-height: 20px;
+    --sb-letter-spacing: 0.1px;
+    --sb-font-weight: 500;
+    --sb-icon: 20px;
+    --sb-chevron-width: 48px;
+    --sb-chevron-icon: 22px;
+    --sb-touch-extend: 4px;
+}
+
+/* Medium is the base rule set above; the class still exists so the size is
+   always explicit in the DOM (and testable). */
+.medium {
+    --sb-height: 56px;
+}
+
+.large {
+    --sb-height: 96px;
+    --sb-radius: 48px;
+    --sb-radius-inner: 8px;
+    --sb-radius-pressed: 16px;
+    --sb-pad-left: 48px;
+    --sb-pad-right: 48px;
+    --sb-gap: 12px;
+    --sb-font-size: 24px; /* M3/headline/small */
+    --sb-line-height: 32px;
+    --sb-letter-spacing: 0;
+    --sb-font-weight: 400;
+    --sb-icon: 32px;
+    --sb-chevron-width: 96px;
+    --sb-chevron-icon: 38px;
+}
+
+.xlarge {
+    --sb-height: 136px;
+    --sb-radius: 68px;
+    --sb-radius-inner: 12px;
+    --sb-radius-pressed: 24px;
+    --sb-pad-left: 64px;
+    --sb-pad-right: 64px;
+    --sb-gap: 16px;
+    --sb-font-size: 32px; /* M3/headline/large */
+    --sb-line-height: 40px;
+    --sb-letter-spacing: 0;
+    --sb-font-weight: 400;
+    --sb-icon: 40px;
+    --sb-chevron-width: 136px;
+    --sb-chevron-icon: 50px;
+}
+
+/* ---- Segments ------------------------------------------------------------ */
 
 .segment {
     position: relative;
     display: inline-flex;
-    height: 56px;
+    height: var(--sb-height);
     box-sizing: border-box;
     align-items: center;
     justify-content: center;
@@ -18,11 +124,15 @@
     color: var(--m3-on-surface-variant, #444748);
     cursor: pointer;
     font-family: inherit;
-    transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
+    transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease,
+        border-radius 200ms cubic-bezier(0.2, 0, 0, 1);
 }
 
-.splitButton:not(.disabled) .segment:not(:disabled):hover {
-    background: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 8%, transparent);
+/* XS/S render below 48px but must keep the 48px M3 touch target. */
+.segment::before {
+    content: '';
+    position: absolute;
+    inset: calc(var(--sb-touch-extend) * -1) 0;
 }
 
 /* Per-segment disabling (`mainDisabled`): only the action segment greys out. */
@@ -39,19 +149,19 @@
 }
 
 .main {
-    gap: 8px;
-    padding: 16px 24px;
-    border-radius: 28px 4px 4px 28px;
-    font-size: 16px;
-    font-weight: 500;
-    letter-spacing: 0.15px;
-    line-height: 24px;
+    gap: var(--sb-gap);
+    padding: 0 var(--sb-pad-right) 0 var(--sb-pad-left);
+    border-radius: var(--sb-radius) var(--sb-radius-inner) var(--sb-radius-inner) var(--sb-radius);
+    font-size: var(--sb-font-size);
+    font-weight: var(--sb-font-weight);
+    letter-spacing: var(--sb-letter-spacing);
+    line-height: var(--sb-line-height);
     white-space: nowrap;
 }
 
 /* No chevron: a single-action pill (e.g. template opener) stays fully rounded. */
 .splitButton:not(:has(.chevron)) .main {
-    border-radius: 28px;
+    border-radius: var(--sb-radius);
 }
 
 /* Menu selections become the main label; long user-defined names truncate. */
@@ -62,18 +172,14 @@
 }
 
 .chevron {
-    width: 56px;
-    border-radius: 4px 28px 28px 4px;
+    width: var(--sb-chevron-width);
+    border-radius: var(--sb-radius-inner) var(--sb-radius) var(--sb-radius) var(--sb-radius-inner);
 }
 
 .chevronIcon {
-    width: 20px;
-    height: 20px;
+    width: var(--sb-chevron-icon);
+    height: var(--sb-chevron-icon);
     transition: transform 200ms ease;
-}
-
-.open .chevronIcon {
-    transform: rotate(180deg);
 }
 
 .icon {
@@ -82,31 +188,84 @@
     line-height: 1;
 
     svg {
-        width: 24px;
-        height: 24px;
+        width: var(--sb-icon);
+        height: var(--sb-icon);
     }
 }
 
-/* Tonal: light fill, primary-coloured content (template picker). */
-.tonal .segment {
-    border-color: transparent;
-    background: var(--m3-surface-container-low, #f6f3f3);
-    color: var(--m3-primary, #a5000a);
+/* ---- Interaction states -------------------------------------------------- */
+
+/* Hover: 8% state layer of the segment's content colour (spec sheet). */
+.splitButton:not(.disabled) .segment:not(:disabled):hover {
+    background: color-mix(in srgb, var(--m3-on-surface-variant, #444748) 8%, transparent);
+}
+
+/* Pressed: 10% state layer + the spec's shape morph — the pressed segment's
+   inner corners round up (Figma "Leading/Trailing state=Pressed"). */
+.splitButton:not(.disabled) .segment:not(:disabled):active {
+    background: color-mix(in srgb, var(--m3-on-surface-variant, #444748) 10%, transparent);
+}
+
+.splitButton:not(.disabled) .main:not(:disabled):active {
+    border-radius: var(--sb-radius) var(--sb-radius-pressed) var(--sb-radius-pressed) var(--sb-radius);
+}
+
+.splitButton:not(.disabled) .chevron:not(:disabled):active {
+    border-radius: var(--sb-radius-pressed) var(--sb-radius) var(--sb-radius) var(--sb-radius-pressed);
+}
+
+/* A single-action pill has no inner corners, so the pressed morph does not
+   apply — it stays fully rounded. */
+.splitButton:not(:has(.chevron)):not(.disabled) .main:not(:disabled):active {
+    border-radius: var(--sb-radius);
+}
+
+/* Open: the chevron flips up and its segment morphs to the fully rounded
+   shape (Figma "Trailing state=Selected"). */
+.open .chevronIcon {
+    transform: rotate(180deg);
+}
+
+.open .chevron {
+    border-radius: var(--sb-radius);
 }
 
 /* Elevation is a STATE, not a skin (owner call, twice): a split button lifts
    only while its menu is open, and the menu carries the matching, higher
    shadow so button and sheet read as one surface. A permanently raised button
-   claimed a state it was not in. */
+   claimed a state it was not in. The one exception is the `elevated` VARIANT
+   below, whose identity per the spec sheet is a resting shadow. */
 .open .segment {
     box-shadow: 0 1px 3px 1px color-mix(in srgb, var(--m3-shadow, #000) 15%, transparent),
         0 1px 2px color-mix(in srgb, var(--m3-shadow, #000) 30%, transparent);
 }
 
-/* Secondary tonal: the M3 secondary container. Everything that is NOT the
-   selected item / main CTA rests here — the send button before the form is
-   valid, and the bulk-selection counter. */
-.secondary .segment {
+/* ---- Colour variants (sheet: Filled / Tonal / Outlined / Elevated) ------- */
+
+/* Outlined (default): transparent container, outline-variant border. */
+.outlined .segment {
+    background: transparent;
+}
+
+/* Filled: brand surface — the page's main CTA (alias: `primary`). */
+.filled .segment {
+    border-color: transparent;
+    background: var(--m3-primary, #a5000a);
+    color: var(--m3-on-primary, #ffffff);
+}
+
+.filled:not(.disabled) .segment:not(:disabled):hover {
+    background: color-mix(in srgb, var(--m3-on-primary, #fff) 8%, var(--m3-primary, #a5000a));
+}
+
+.filled:not(.disabled) .segment:not(:disabled):active {
+    background: color-mix(in srgb, var(--m3-on-primary, #fff) 10%, var(--m3-primary, #a5000a));
+}
+
+/* Tonal: the M3 secondary container (alias: `secondary`). Everything that is
+   NOT the selected item / main CTA rests here — the send button before the
+   form is valid, and the bulk-selection counter. */
+.tonal .segment {
     border-color: transparent;
     background: var(--m3-secondary-container, #646d78);
     color: var(--m3-on-secondary-container, #e7effc);
@@ -115,12 +274,20 @@
 /* Not-ready is still the secondary container (owner call), so the disabled
    treatment dims the CONTENT instead of fading the whole pill — at 38% opacity
    on a slate fill the label and the send glyph vanished altogether. */
-.secondary .segment:disabled {
+.tonal .segment:disabled {
     opacity: 1;
     color: color-mix(in srgb, var(--m3-on-secondary-container, #e7effc) 78%, var(--m3-secondary-container, #646d78));
 }
 
-.secondary:not(.disabled) .segment:not(:disabled):hover {
+.tonal:not(.disabled) .segment:not(:disabled):hover {
+    background: color-mix(
+        in srgb,
+        var(--m3-on-secondary-container, #e7effc) 8%,
+        var(--m3-secondary-container, #646d78)
+    );
+}
+
+.tonal:not(.disabled) .segment:not(:disabled):active {
     background: color-mix(
         in srgb,
         var(--m3-on-secondary-container, #e7effc) 10%,
@@ -128,25 +295,31 @@
     );
 }
 
-.tonal:not(.disabled) .segment:not(:disabled):hover {
+/* Elevated: light container with primary content AND a resting shadow — the
+   only variant that rests raised, because that is its point (spec sheet
+   "Style=Elevated"). Do not use it for pickers that merely sit on a bar. */
+.elevated .segment {
+    border-color: transparent;
+    background: var(--m3-surface-container-low, #f6f3f3);
+    color: var(--m3-primary, #a5000a);
+    box-shadow: 0 1px 3px 1px color-mix(in srgb, var(--m3-shadow, #000) 15%, transparent),
+        0 1px 2px color-mix(in srgb, var(--m3-shadow, #000) 30%, transparent);
+}
+
+.elevated:not(.disabled) .segment:not(:disabled):hover {
     background: color-mix(in srgb, var(--m3-primary, #a5000a) 8%, var(--m3-surface-container-low, #f6f3f3));
 }
 
-/* Primary: filled brand surface (send action once the form is valid). */
-.primary .segment {
-    border-color: transparent;
-    background: var(--m3-primary, #a5000a);
-    color: var(--m3-on-primary, #ffffff);
-}
-
-.primary:not(.disabled) .segment:not(:disabled):hover {
-    background: color-mix(in srgb, var(--m3-on-primary, #fff) 8%, var(--m3-primary, #a5000a));
+.elevated:not(.disabled) .segment:not(:disabled):active {
+    background: color-mix(in srgb, var(--m3-primary, #a5000a) 10%, var(--m3-surface-container-low, #f6f3f3));
 }
 
 .disabled .segment {
     cursor: not-allowed;
     opacity: 0.38;
 }
+
+/* ---- Menu sheet ---------------------------------------------------------- */
 
 /* The dropdown sheet. antd renders it in a portal, so everything below is
    scoped through the overlay class the SplitButton hands to `Dropdown`. */
@@ -214,15 +387,15 @@
 /* Third segment: the pill's right end moves to it, so the middle chevron
    becomes a straight-sided divider between the two. */
 .splitButton .collapse {
-    border-radius: 4px 28px 28px 4px;
+    border-radius: var(--sb-radius-inner) var(--sb-radius) var(--sb-radius) var(--sb-radius-inner);
 }
 
 .splitButton .collapse ~ * {
-    border-radius: 4px;
+    border-radius: var(--sb-radius-inner);
 }
 
 .splitButton:has(.collapse) .chevron:not(.collapse) {
-    border-radius: 4px;
+    border-radius: var(--sb-radius-inner);
 }
 
 .chevronUp {

--- a/src/components/GlobalSearch/splitButton.styles.test.ts
+++ b/src/components/GlobalSearch/splitButton.styles.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(__dirname, './splitButton.module.scss'), 'utf8');
+
+/*
+ * ORISO-Admin#741 — "Elevation is a state, not a skin" (owner call): a split
+ * button at REST must not carry a shadow. Box-shadows are only legal in the
+ * `.open` state and on the `elevated` variant, whose spec identity is the
+ * resting shadow (Figma 57994-15744, Style=Elevated). This guards against the
+ * resting-shadow regression Frank flagged on the template picker.
+ */
+describe('SplitButton style contract (#741, Figma 57994-15744)', () => {
+    it('keeps every box-shadow scoped to .open, .elevated or the menu overlay', () => {
+        const offenders = [...source.matchAll(/^([^{}]+?)\s*\{[^{}]*box-shadow[^{}]*\}/gms)]
+            .map(([, sel]) => sel.trim())
+            .filter((sel) => !/\.open|\.elevated|\.menuOverlay|ant-dropdown-menu/.test(sel));
+        expect(offenders).toEqual([]);
+    });
+
+    it('the base segment rule carries no box-shadow (no elevated look at rest)', () => {
+        const segment = source.match(/^\.segment\s*\{([^{}]*)\}/ms)?.[1] ?? '';
+        expect(segment).not.toMatch(/box-shadow/);
+    });
+
+    it('flips the chevron up while open', () => {
+        const open = source.match(/\.open\s+\.chevronIcon\s*\{([^{}]*)\}/ms)?.[1] ?? '';
+        expect(open).toMatch(/rotate\(180deg\)/);
+    });
+
+    it('morphs the chevron segment to the fully rounded shape while open', () => {
+        const open = source.match(/\.open\s+\.chevron\s*\{([^{}]*)\}/ms)?.[1] ?? '';
+        expect(open).toMatch(/border-radius:\s*var\(--sb-radius\)/);
+    });
+
+    it('defines a pressed (:active) state layer and shape morph', () => {
+        expect(source).toMatch(/\.segment:not\(:disabled\):active/);
+        expect(source).toMatch(/\.main:not\(:disabled\):active/);
+        expect(source).toMatch(/--sb-radius-pressed/);
+    });
+
+    it('defines the five spec sizes as classes', () => {
+        ['.xsmall', '.small', '.medium', '.large', '.xlarge'].forEach((size) => {
+            expect(source).toMatch(new RegExp(`^\\${size}\\s*\\{`, 'm'));
+        });
+    });
+
+    it('keeps the sub-48px sizes touch-target compliant', () => {
+        expect(source.match(/^\.xsmall\s*\{([^{}]*)\}/ms)?.[1]).toMatch(/--sb-touch-extend:\s*8px/);
+        expect(source.match(/^\.small\s*\{([^{}]*)\}/ms)?.[1]).toMatch(/--sb-touch-extend:\s*4px/);
+        expect(source).toMatch(/\.segment::before/);
+    });
+});

--- a/src/components/PlaceholderTemplate/TemplateSplitButton.test.tsx
+++ b/src/components/PlaceholderTemplate/TemplateSplitButton.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TemplateSplitButton } from './TemplateSplitButton';
+import splitButtonStyles from '../GlobalSearch/splitButton.module.scss';
 
 const t = (key: string, fallback?: string) => fallback ?? key;
 
@@ -78,5 +79,18 @@ describe('TemplateSplitButton', () => {
         await user.click(screen.getByRole('button', { name: 'Vorlagenmenü öffnen' }));
         await screen.findByRole('menuitem', { name: /^Standard-Einladung$/ });
         expect(screen.queryByRole('menuitem', { name: /Neu aus/ })).not.toBeInTheDocument();
+    });
+
+    /*
+     * ORISO-Admin#741, owner feedback on PR #727: "Das ist nur ein Elevated
+     * state, der hier falsch ist." The picker rests as a plain outlined pill —
+     * elevation (and the elevated colourway) is reserved for the open state /
+     * the explicit elevated variant.
+     */
+    it('rests outlined, never in the elevated colourway (#741)', () => {
+        render(<TemplateSplitButton activeTemplateId={1} templates={templates} onSelectTemplate={() => {}} />);
+        const rootClasses = screen.getByRole('button', { name: /Standard-Einladung/ }).parentElement?.classList;
+        expect(rootClasses?.contains(splitButtonStyles.outlined)).toBe(true);
+        expect(rootClasses?.contains(splitButtonStyles.elevated)).toBe(false);
     });
 });

--- a/src/components/PlaceholderTemplate/TemplateSplitButton.tsx
+++ b/src/components/PlaceholderTemplate/TemplateSplitButton.tsx
@@ -110,7 +110,10 @@ export const TemplateSplitButton = ({
             label={active?.name ?? t('placeholderTemplate.template.none', 'Vorlage wählen')}
             menu={menu}
             menuLabel={t('placeholderTemplate.template.menuLabel', 'Vorlagenmenü öffnen')}
-            variant="tonal"
+            // Outlined at rest (#741, owner call on PR #727): the previous light
+            // fill was the sheet's Elevated colourway — a state claim the resting
+            // picker has no business making. It lifts only while its menu is open.
+            variant="outlined"
             onClick={onMainClick}
         />
     );

--- a/src/pages/Links/InviteComposer.test.tsx
+++ b/src/pages/Links/InviteComposer.test.tsx
@@ -132,12 +132,13 @@ describe('InviteComposer (via TenantInvitesTab)', () => {
         // alone must keep the action gated and in the outlined (non-primary) look.
         expect(await screen.findByRole('button', { name: /Standard/ })).toBeInTheDocument();
         expect(sendButton).toBeDisabled();
-        expect(wrapper).not.toHaveClass(splitButtonStyles.primary);
+        // `primary` is an alias of the sheet's `filled` variant since #741.
+        expect(wrapper).not.toHaveClass(splitButtonStyles.filled);
 
         await user.type(screen.getByLabelText('E-Mail'), 'neu@example.org');
 
         await waitFor(() => expect(sendButton).toBeEnabled());
-        expect(wrapper).toHaveClass(splitButtonStyles.primary);
+        expect(wrapper).toHaveClass(splitButtonStyles.filled);
     });
 
     it('persists the chosen send mode per tab and swaps the main label', async () => {

--- a/src/pages/Links/InviteComposer.tsx
+++ b/src/pages/Links/InviteComposer.tsx
@@ -470,7 +470,11 @@ export const InviteComposer = ({
                 <SplitButton
                     icon={<MailFilledIcon />}
                     label={selectedTemplate?.name ?? t('links.composer.templatePlaceholder', 'E-Mail-Vorlage')}
-                    variant="tonal"
+                    // Outlined at rest (#741): the old `tonal` was the light
+                    // Elevated colourway, which claimed a raised state the resting
+                    // picker is not in. `tonal` now means the M3 secondary
+                    // container per the spec sheet.
+                    variant="outlined"
                     onClick={() => onManageTemplates('list')}
                 />
                 {/* Filled primary is reserved for the selected item / main CTA; every


### PR DESCRIPTION
**Stacked on #727.** Closes #741. Aligns the M3 split button with the Figma sheet (Design-System M3_ORISO node 57994-15744) after the owner spotted the template picker resting in the elevated colourway.

## What changed
- `SplitButton`: size scale XSmall–XLarge via `size` prop (default keeps the current 56px geometry — existing callers unshifted), pressed state, open state (chevron flips up, elevated surface only while the menu is open), resting box-shadow removed, variants mapped to the sheet (filled/tonal/outlined/standard) with `secondary` kept as alias
- `TemplateSplitButton`: rests outlined per the sheet instead of elevated
- InviteComposer send button: test asserts the filled class behind the `primary` alias
- Storybook: matrix story mirroring the Figma sheet (sizes × variants × states incl. disabled and open) for side-by-side visual review

## Verification
- `npx vitest run src/components/GlobalSearch src/components/PlaceholderTemplate src/pages/Links` — 126 tests green
- `tsc --noEmit` (app + storybook), `eslint --max-warnings=0`, `prettier --check` — clean

## Reviewer test plan
- [ ] Storybook `GlobalSearch → SplitButton matrix`: compare against the Figma sheet — filled/tonal/outlined in all five sizes, disabled column, open state elevates + flips the chevron
- [ ] `Organisms/PlaceholderTemplateEditor`: template picker shows NO shadow at rest; opening the menu elevates it
- [ ] Links page: send split button and bulk-selection counter look unchanged (default size preserved)
- [ ] Keyboard: focus ring visible per segment; menu opens with Enter/Space; 320px shows no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)