### PR TITLE
test(admin): assert the omitted remarks payload and query the clear button accessibly

### DIFF
--- a/src/pages/users/Edit/index.test.tsx
+++ b/src/pages/users/Edit/index.test.tsx
@@ -259,10 +259,15 @@ describe('admin remarks are gated on the tenant-level admin role (#994)', () => 
         expect(await submit(user)).toMatchObject({ adminRemarks: 'Springt fuer die Kollegin ein.' });
     });
 
-    it('omits the remarks field for a restricted agency admin, whose submission carries no remarks', async () => {
-        // The backend refuses to read or write remarks for this role, so the
-        // field must be absent — not merely disabled.
-        mocks.roles = [UserRole.RestrictedAgencyAdmin];
+    it.each([
+        ['a restricted agency admin', UserRole.RestrictedAgencyAdmin],
+        ['a plain agency admin', UserRole.AgencyAdmin],
+    ])('omits the remarks field for %s, whose submission carries no remarks', async (_label, role) => {
+        // The backend refuses to read or write remarks for these roles, so the
+        // field must be absent — not merely disabled. Visibility alone would
+        // not prove it: a regression can hide the control and still serialize
+        // `adminRemarks`, so the payload is asserted as well.
+        mocks.roles = [role];
         const user = userEvent.setup();
         renderForm();
 
@@ -271,13 +276,6 @@ describe('admin remarks are gated on the tenant-level admin role (#994)', () => 
         await fillMandatoryFields();
 
         expect(await submit(user)).not.toHaveProperty('adminRemarks');
-    });
-
-    it('omits the remarks field for a plain agency admin', async () => {
-        mocks.roles = [UserRole.AgencyAdmin];
-        renderForm();
-
-        expect(screen.queryByLabelText('Interne Anmerkungen')).not.toBeInTheDocument();
     });
 });
 
@@ -304,12 +302,13 @@ describe('salutation control (#994)', () => {
         const salutation = screen.getByLabelText('Anrede');
         expect(salutation).toHaveValue('Keine Angabe');
         // MUI only renders the clear button once a value is set, so this is
-        // checked with the control populated.
-        expect(
-            (salutation.closest('.MuiAutocomplete-root') as HTMLElement).querySelector(
-                '.MuiAutocomplete-clearIndicator',
-            ),
-        ).toBeNull();
+        // checked with the control populated. Asked for by accessible name
+        // (MUI's `clearText`, "Clear") instead of the implementation class the
+        // indicator happens to carry today. The sibling popup toggle is
+        // asserted first so the absence below cannot pass vacuously: it proves
+        // MUI's indicator buttons ARE reachable by role and name here.
+        expect(screen.getAllByRole('button', { name: 'Open' }).length).toBeGreaterThan(0);
+        expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
 
         await fillMandatoryFields();
 


### PR DESCRIPTION
Refs OpenResilienceInitiative/ORISO-UserService#994

## Why
Follow-up to #764 (merged). Two CodeRabbit findings on the new render-based consultant form tests landed after the merge.

## What
- **The `AgencyAdmin` case only asserted field visibility.** A regression could keep the admin-remarks field hidden and still send `adminRemarks` in the payload. Both non-privileged roles now submit the form and assert the payload has no `adminRemarks` key (folded into one `it.each`; the `RestrictedAgencyAdmin` case already did this).
- **The absent clear button was queried by MUI implementation class.** Replaced `.MuiAutocomplete-clearIndicator` with `queryByRole('button', { name: 'Clear' })`, verified against the installed MUI that `clearText` defaults to `'Clear'` and no locale override exists in this app. A preceding assertion on the "Open" button ensures the absence check cannot pass vacuously.

Red-check for the payload assertion: an unconditional `initialValues` entry does not reproduce the defect (antd only serializes registered `Form.Item`s), but a control rendered inside a `display:none` wrapper does — the tests go red under that mutation.

## Gates
`npm run test` 267 files / 1758 tests, eslint (touched, `--max-warnings=0`), prettier, `typecheck:storybook`, `build`, `build-storybook` — all green.

## How should I test this?
- [ ] Open the consultant form as an agency admin → no "Interne Anmerkungen" field; save and confirm the consultant is created without remarks.
- [ ] Open it as a tenant admin → the field is there, and a typed value survives save and reopen.
- [ ] Open the salutation dropdown → there is no clear (X) affordance; the selected value can only be replaced, not emptied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
