### PR TITLE
fix(lint): restore the CSS gate on pre-dev

### DIFF
--- a/src/components/Tenants/LegalSettings/components/LegalConsentField/styles.module.scss
+++ b/src/components/Tenants/LegalSettings/components/LegalConsentField/styles.module.scss
@@ -17,6 +17,7 @@
 
 /* The platform's fixed addendum: shown exactly where the help-seeker reads it,
    visibly not part of the editable sentence. */
+
 .addendum {
     display: grid;
     margin: 0;


### PR DESCRIPTION
Refs #773

## Problem

`lint:css` went red on `pre-dev` the moment #774/#776 merged. The gate work branched off before #770 added `LegalConsentField/styles.module.scss`, so neither PR's CI ever linted that file — the branches were mergeable and green in isolation, but not together.

## Changes

- One `rule-empty-line-before` fix in `LegalConsentField/styles.module.scss`, produced by `lint:css:fix`.

## Verification

Fresh `npm ci` on merged `pre-dev`: `npm run lint:css` → exit 0, working tree byte-identical afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)