### PR TITLE
Gate the Fachbereich legal editors behind the legal-text right (#609)

### DIFF
--- a/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.test.tsx
@@ -6,6 +6,7 @@ const h = vi.hoisted(() => ({
     useDepartmentDpp: vi.fn(),
     refetch: vi.fn(),
     card: vi.fn(),
+    canEditLegalText: vi.fn(() => true),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -25,6 +26,9 @@ vi.mock('../../../../../hooks/useSingleTenantData', () => ({ useSingleTenantData
 vi.mock('../../../../../hooks/useTenantAdminData.hook', () => ({ useTenantAdminData: () => ({ data: undefined }) }));
 vi.mock('../../../../../hooks/useTranslateLegalContent.hook', () => ({
     useTranslateLegalContent: () => ({ translate: vi.fn() }),
+}));
+vi.mock('../../../../../hooks/useUserPermission', () => ({
+    useUserPermissions: () => ({ can: h.canEditLegalText, permissions: {} }),
 }));
 vi.mock('../DepartmentDataProtectionCard', () => ({
     DepartmentDataProtectionCard: (props: any) => {
@@ -57,6 +61,7 @@ describe('AgencyLegalTextContainer', () => {
     beforeEach(() => {
         h.useDepartmentDpp.mockReset();
         h.card.mockReset();
+        h.canEditLegalText.mockReset().mockReturnValue(true);
     });
 
     it('edits the agency-wide text before a department is chosen', () => {
@@ -156,5 +161,26 @@ describe('AgencyLegalTextContainer', () => {
         await selectDepartment('U25 Suizidprävention');
 
         expect(h.card.mock.calls.at(-1)?.[0].initialContentByLanguage).toEqual({ de: '<p>agency wide</p>' });
+    });
+
+    /**
+     * #609: this editor shipped without any permission check, so an admin who may not
+     * change legal content was still offered publish and draft-save.
+     */
+    it('hands the card a read-only state when the admin may not change legal content', () => {
+        h.canEditLegalText.mockReturnValue(false);
+        h.useDepartmentDpp.mockReturnValue({ data: undefined, isLoading: false, isError: false, isSuccess: true });
+
+        renderContainer();
+
+        expect(h.card.mock.calls.at(-1)?.[0].readOnly).toBe(true);
+    });
+
+    it('leaves the card editable when the admin may', () => {
+        h.useDepartmentDpp.mockReturnValue({ data: undefined, isLoading: false, isError: false, isSuccess: true });
+
+        renderContainer();
+
+        expect(h.card.mock.calls.at(-1)?.[0].readOnly).toBe(false);
     });
 });

--- a/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/index.tsx
@@ -8,6 +8,9 @@ import { usePublishDepartmentImprint } from '../../../../../hooks/usePublishDepa
 import { useSingleTenantData } from '../../../../../hooks/useSingleTenantData';
 import { useTenantAdminData } from '../../../../../hooks/useTenantAdminData.hook';
 import { useTranslateLegalContent } from '../../../../../hooks/useTranslateLegalContent.hook';
+import { useUserPermissions } from '../../../../../hooks/useUserPermission';
+import { PermissionAction } from '../../../../../enums/PermissionAction';
+import { Resource } from '../../../../../enums/Resource';
 import { AgencyData } from '../../../../../types/agency';
 import { DepartmentDataProtectionCard } from '../DepartmentDataProtectionCard';
 import { ALL_DEPARTMENTS, DepartmentSelect } from '../DepartmentSelect';
@@ -48,6 +51,10 @@ export const AgencyLegalTextContainer = ({
     saving,
 }: AgencyLegalTextContainerProps) => {
     const { t } = useTranslation();
+    const { can } = useUserPermissions();
+    // #609: this editor used to have no permission check at all. It is the same
+    // right the Träger-level cards ask for, one rung down the ladder.
+    const canEditLegalText = can(PermissionAction.Update, Resource.LegalText);
     const [selected, setSelected] = useState<number | typeof ALL_DEPARTMENTS>(ALL_DEPARTMENTS);
 
     const agencyId = Number(agencyData?.id);
@@ -171,6 +178,7 @@ export const AgencyLegalTextContainer = ({
             initialContentByLanguage={contentByLanguage}
             languages={languages}
             publicationStatus={isDepartment ? departmentQuery.data?.publicationStatus : undefined}
+            readOnly={!canEditLegalText}
             onSave={onSave}
             saving={saving || departmentPublish.isPending}
             onTranslate={translate}

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.permissions.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.permissions.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DepartmentDataProtectionCard } from './index';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        i18n: { language: 'de' },
+        t: (key: string, options?: unknown) => (typeof options === 'string' ? options : key),
+    }),
+}));
+
+// The real editor pulls TipTap; this stub exposes exactly the part of the contract
+// the gate is about — whether the write actions are offered and whether it is inert.
+vi.mock('../../../../FormPluginEditor/M3RichTextEditor', () => ({
+    M3RichTextEditor: ({
+        value,
+        readOnly,
+        onChange,
+        onPublish,
+        onSaveDraft,
+        aboveEditorSlot,
+        belowSlot,
+    }: {
+        value?: string;
+        readOnly?: boolean;
+        onChange?: (html: string) => void;
+        onPublish?: () => void;
+        onSaveDraft?: () => void;
+        aboveEditorSlot?: React.ReactNode;
+        belowSlot?: React.ReactNode;
+    }) => (
+        <div data-testid="editor" data-readonly={String(!!readOnly)} data-editable={String(!!onChange)}>
+            {aboveEditorSlot}
+            {onPublish && (
+                <button type="button" onClick={onPublish}>
+                    publish
+                </button>
+            )}
+            {onSaveDraft && (
+                <button type="button" onClick={onSaveDraft}>
+                    saveDraft
+                </button>
+            )}
+            {belowSlot}
+            <span>{value}</span>
+        </div>
+    ),
+}));
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: (query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: () => undefined,
+            removeListener: () => undefined,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+            dispatchEvent: () => false,
+        }),
+    });
+});
+
+const renderCard = (readOnly: boolean) =>
+    render(
+        <DepartmentDataProtectionCard
+            consentByLanguage={{ de: 'Ich habe die {{legal_links}} gelesen.' }}
+            initialContentByLanguage={{ de: '<p>Fachbereichs-Richtlinie</p>' }}
+            languages={['de']}
+            readOnly={readOnly}
+            onSave={() => undefined}
+        />,
+    );
+
+/**
+ * #609: the Fachbereich data-protection editor shipped with no permission check at
+ * all — any admin who owned the agency could publish a policy. These assertions are
+ * about what an admin WITHOUT the legal-text right is offered.
+ */
+describe('DepartmentDataProtectionCard — legal-text permission gate', () => {
+    it('offers publish and draft-save to an admin who may change legal content', () => {
+        renderCard(false);
+        expect(screen.getByRole('button', { name: 'publish' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'saveDraft' })).toBeInTheDocument();
+        expect(screen.getByTestId('editor')).toHaveAttribute('data-editable', 'true');
+    });
+
+    it('offers neither write action to an admin who may not', () => {
+        renderCard(true);
+        expect(screen.queryByRole('button', { name: 'publish' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'saveDraft' })).not.toBeInTheDocument();
+    });
+
+    it('hands the editor its own read-only state rather than only withholding the callbacks', () => {
+        renderCard(true);
+        const editor = screen.getByTestId('editor');
+        expect(editor).toHaveAttribute('data-readonly', 'true');
+        expect(editor).toHaveAttribute('data-editable', 'false');
+    });
+
+    it('makes the consent sentence inert too — it is published with the policy', () => {
+        renderCard(true);
+        expect(screen.getByRole('textbox')).toBeDisabled();
+    });
+
+    it('still shows the document, so a viewer can read what the Fachbereich has', () => {
+        renderCard(true);
+        expect(screen.getByText('<p>Fachbereichs-Richtlinie</p>')).toBeInTheDocument();
+    });
+});

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/index.tsx
@@ -77,6 +77,13 @@ interface DepartmentDataProtectionCardProps {
      * (Figma 1261:52149). Absent when the card edits a single fixed department.
      */
     departmentSlot?: React.ReactNode;
+    /**
+     * The signed-in admin may not change legal content (#609). The card then reads —
+     * editor, publish, draft-save and the consent sentence all inert — instead of
+     * offering actions the server would refuse. Disabled rather than hidden, so it
+     * stays visible which document the Fachbereich has.
+     */
+    readOnly?: boolean;
 }
 
 /**
@@ -100,6 +107,7 @@ export const DepartmentDataProtectionCard = ({
     versions = [],
     versionsUnavailable = false,
     consentByLanguage,
+    readOnly = false,
 }: DepartmentDataProtectionCardProps) => {
     const { t, i18n } = useTranslation();
     const locale = i18n?.language?.split('-')[0] || 'de';
@@ -186,7 +194,8 @@ export const DepartmentDataProtectionCard = ({
                 )}
                 icon={documentType === 'imprint' ? ImprintIcon : GdprIcon}
                 value={currentContent}
-                onChange={handleEditorChange}
+                readOnly={readOnly}
+                onChange={readOnly ? undefined : handleEditorChange}
                 publishing={saving}
                 versionLabel={t('legal.m3Editor.versionLabel')}
                 versions={editorVersions}
@@ -229,7 +238,9 @@ export const DepartmentDataProtectionCard = ({
                             <Button
                                 size="small"
                                 loading={fieldTranslating}
-                                disabled={fieldTranslateDisabled}
+                                // Translating writes into the editor, so it is an edit
+                                // like any other and follows the same gate (#609).
+                                disabled={fieldTranslateDisabled || readOnly}
                                 onClick={translateActiveField}
                             >
                                 {t('legal.translation.field.button')}
@@ -240,9 +251,14 @@ export const DepartmentDataProtectionCard = ({
                         </div>
                     )
                 }
-                onPublish={handlePublish}
-                onSaveDraft={() =>
-                    consentEnabled ? onSave(buildPublishMap(), false, consentMap) : onSave(buildPublishMap(), false)
+                onPublish={readOnly ? undefined : handlePublish}
+                onSaveDraft={
+                    readOnly
+                        ? undefined
+                        : () =>
+                              consentEnabled
+                                  ? onSave(buildPublishMap(), false, consentMap)
+                                  : onSave(buildPublishMap(), false)
                 }
                 belowSlot={
                     <>
@@ -273,7 +289,7 @@ export const DepartmentDataProtectionCard = ({
             {consentEnabled && (
                 <LegalConsentField
                     language={activeLanguage}
-                    readOnly={isViewingVersion}
+                    readOnly={readOnly || isViewingVersion}
                     value={(viewedConsent ?? consentMap)[activeLanguage] ?? ''}
                     onChange={(next) => {
                         setPublishBlocked(false);

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/DepartmentDataProtectionContainer.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/DepartmentDataProtectionContainer.test.tsx
@@ -19,6 +19,11 @@ vi.mock('../../../../../hooks/useLegalTextVersions.hook', () => ({ useLegalTextV
 vi.mock('../../../../../hooks/usePublishDepartmentDpp.hook', () => ({
     usePublishDepartmentDpp: () => ({ mutate: publishMutate, isPending: false }),
 }));
+// #609: the container now asks whether the admin may change legal content. The real
+// hook needs tenant data and app config; this suite is about the content mapping.
+vi.mock('../../../../../hooks/useUserPermission', () => ({
+    useUserPermissions: () => ({ can: () => true, permissions: {} }),
+}));
 
 // Stub the card to a plain node that echoes props and exposes onSave.
 vi.mock('../../../../../hooks/useTranslateLegalContent.hook', () => ({

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/index.tsx
@@ -4,6 +4,9 @@ import { useLegalTextVersions } from '../../../../../hooks/useLegalTextVersions.
 import { usePublishDepartmentDpp } from '../../../../../hooks/usePublishDepartmentDpp.hook';
 import { useTenantAdminData } from '../../../../../hooks/useTenantAdminData.hook';
 import { useTranslateLegalContent } from '../../../../../hooks/useTranslateLegalContent.hook';
+import { useUserPermissions } from '../../../../../hooks/useUserPermission';
+import { PermissionAction } from '../../../../../enums/PermissionAction';
+import { Resource } from '../../../../../enums/Resource';
 import { DepartmentDataProtectionCard } from '../DepartmentDataProtectionCard';
 import { getEditableLanguages, parseLegalContentMap } from '../../utils/legalContentLanguages';
 
@@ -29,6 +32,8 @@ export const DepartmentDataProtectionContainer = ({
     const { mutate: publish, isPending } = usePublishDepartmentDpp(agencyId, topicId);
     const { data: tenantData } = useTenantAdminData();
     const { translate } = useTranslateLegalContent();
+    const { can } = useUserPermissions();
+    const canEditLegalText = can(PermissionAction.Update, Resource.LegalText);
     const { data: versions = [], isError: versionsUnavailable } = useLegalTextVersions({
         level: 'department',
         agencyId,
@@ -63,6 +68,7 @@ export const DepartmentDataProtectionContainer = ({
             publicationStatus={data?.publicationStatus}
             versions={versions}
             versionsUnavailable={versionsUnavailable}
+            readOnly={!canEditLegalText}
             onSave={(contentByLang, doPublish, consentByLang) =>
                 publish({ content: contentByLang, publish: doPublish, consentText: consentByLang })
             }

--- a/src/components/Tenants/LegalSettings/components/DepartmentImprintContainer/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentImprintContainer/index.tsx
@@ -4,6 +4,9 @@ import { useLegalTextVersions } from '../../../../../hooks/useLegalTextVersions.
 import { usePublishDepartmentImprint } from '../../../../../hooks/usePublishDepartmentImprint.hook';
 import { useTenantAdminData } from '../../../../../hooks/useTenantAdminData.hook';
 import { useTranslateLegalContent } from '../../../../../hooks/useTranslateLegalContent.hook';
+import { useUserPermissions } from '../../../../../hooks/useUserPermission';
+import { PermissionAction } from '../../../../../enums/PermissionAction';
+import { Resource } from '../../../../../enums/Resource';
 import { DepartmentDataProtectionCard } from '../DepartmentDataProtectionCard';
 import { getEditableLanguages, parseLegalContentMap } from '../../utils/legalContentLanguages';
 
@@ -20,6 +23,8 @@ export const DepartmentImprintContainer = ({
     const { mutate: publish, isPending } = usePublishDepartmentImprint(agencyId, topicId);
     const { data: tenantData } = useTenantAdminData();
     const { translate } = useTranslateLegalContent();
+    const { can } = useUserPermissions();
+    const canEditLegalText = can(PermissionAction.Update, Resource.LegalText);
     const { data: versions = [], isError: versionsUnavailable } = useLegalTextVersions({
         level: 'department',
         agencyId,
@@ -44,6 +49,7 @@ export const DepartmentImprintContainer = ({
             publicationStatus={data?.publicationStatus}
             versions={versions}
             versionsUnavailable={versionsUnavailable}
+            readOnly={!canEditLegalText}
             onSave={(content, doPublish) => publish({ content, publish: doPublish })}
             saving={isPending}
             onTranslate={translate}

--- a/src/constants/userRolesToPermissions.legalText.test.tsx
+++ b/src/constants/userRolesToPermissions.legalText.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { UserRole } from '../enums/UserRole';
+
+const { useUserRoles, useTenantData, useAppConfigContext } = vi.hoisted(() => ({
+    useUserRoles: vi.fn(),
+    useTenantData: vi.fn(),
+    useAppConfigContext: vi.fn(),
+}));
+
+vi.mock('../hooks/useUserRoles.hook', () => ({ useUserRoles }));
+vi.mock('../hooks/useTenantData.hook', () => ({ useTenantData }));
+vi.mock('../context/useAppConfig', () => ({ useAppConfigContext }));
+
+// eslint-disable-next-line import/first
+import { useUserRolesToPermission } from './userRolesToPermissions';
+
+const setup = ({
+    roles,
+    multitenancyWithSingleDomainEnabled = false,
+    legalContentChangesBySingleTenantAdminsAllowed = false,
+}: {
+    roles: UserRole[];
+    multitenancyWithSingleDomainEnabled?: boolean;
+    legalContentChangesBySingleTenantAdminsAllowed?: boolean;
+}) => {
+    useUserRoles.mockReturnValue({ roles, isSuperAdmin: false });
+    useTenantData.mockReturnValue({ data: { settings: {} } });
+    useAppConfigContext.mockReturnValue({
+        settings: { multitenancyWithSingleDomainEnabled, legalContentChangesBySingleTenantAdminsAllowed },
+    });
+    return renderHook(() => useUserRolesToPermission()).result.current;
+};
+
+/**
+ * #609: the Fachbereich legal editors had no permission check at all, because the
+ * agency-admin role carried no `LegalText` entry — `can(update, LegalText)` was
+ * simply false and nobody asked. The role now mirrors the tenant-level rule.
+ */
+describe('agency admin — legal-text permission (#609)', () => {
+    it('may change legal content in a deployment without single-domain multitenancy', () => {
+        const permissions = setup({ roles: [UserRole.AgencyAdmin] });
+        expect(permissions.LegalText?.update).toBe(true);
+    });
+
+    it('may not change it when single-domain multitenancy withholds the delegation', () => {
+        const permissions = setup({
+            roles: [UserRole.AgencyAdmin],
+            multitenancyWithSingleDomainEnabled: true,
+            legalContentChangesBySingleTenantAdminsAllowed: false,
+        });
+        expect(permissions.LegalText?.update).toBe(false);
+    });
+
+    it('may change it again once the Träger delegates legal content', () => {
+        const permissions = setup({
+            roles: [UserRole.AgencyAdmin],
+            multitenancyWithSingleDomainEnabled: true,
+            legalContentChangesBySingleTenantAdminsAllowed: true,
+        });
+        expect(permissions.LegalText?.update).toBe(true);
+    });
+
+    it('can always read the text — a policy nobody may look at helps no one', () => {
+        const permissions = setup({
+            roles: [UserRole.AgencyAdmin],
+            multitenancyWithSingleDomainEnabled: true,
+            legalContentChangesBySingleTenantAdminsAllowed: false,
+        });
+        expect(permissions.LegalText?.read).toBe(true);
+    });
+
+    it('leaves a tenant admin unaffected — they keep the unconditional right', () => {
+        const permissions = setup({
+            roles: [UserRole.TenantAdmin],
+            multitenancyWithSingleDomainEnabled: true,
+            legalContentChangesBySingleTenantAdminsAllowed: false,
+        });
+        expect(permissions.LegalText?.update).toBe(true);
+    });
+});

--- a/src/constants/userRolesToPermissions.ts
+++ b/src/constants/userRolesToPermissions.ts
@@ -104,6 +104,13 @@ export const useUserRolesToPermission = () => {
         [UserRole.AgencyAdmin]: {
             Agency: { read: true, create: true, update: true, delete: true },
             Statistic: { read: true },
+            // #609: the Fachbereich legal editors had NO permission check at all —
+            // any admin who owned the agency could publish a data-protection policy
+            // regardless of role or delegation. This mirrors the tenant-level rule
+            // one rung down the ladder: reading is always allowed, changing follows
+            // the same delegation switch. In a deployment without single-domain
+            // multitenancy `singleCanEditLegalText` is true, so nothing changes there.
+            LegalText: { read: true, update: singleCanEditLegalText },
         },
         [UserRole.TenantAdmin]: {
             // Tenant-scoped admins can manage tenant settings, but only super-admins may create/delete tenants.


### PR DESCRIPTION
## Problem

The Fachbereich data-protection and imprint editors had **no permission check at all**. `AgencyLegalTextContainer` and the department containers rendered the editor always-editable, and the agency-admin role carried no `LegalText` entry — so nothing ever asked. Any admin who owned the agency could publish a data-protection policy regardless of role or delegation.

## What changed

- `UserRole.AgencyAdmin` gains `LegalText: { read: true, update: singleCanEditLegalText }` — the tenant-level rule one rung down the ladder. Without single-domain multitenancy that flag is `true`, so default deployments behave exactly as before.
- `DepartmentDataProtectionCard` takes `readOnly`: editor inert, no publish, no draft-save, consent sentence and per-field translate disabled. Disabled rather than hidden, so a viewer still sees which document the Fachbereich has.
- `AgencyLegalTextContainer`, `DepartmentDataProtectionContainer` and `DepartmentImprintContainer` pass it from `can(Update, Resource.LegalText)`.

## Deliberately not in this PR

**Server-side enforcement.** ORISO-AgencyService has no legal delegation toggle today — no `legalContentChangesBySingleTenantAdminsAllowed`, no equivalent; `DepartmentDataProtectionService` enforces agency/tenant *ownership* only. Where that switch belongs (platform setting vs. the ADR-013 agency admin controls) is a product decision, raised on #609.

**Restricted agency admins.** They inherit the new right through `UserRole.AgencyAdmin` and are not capped by `enforceRestrictedAgencyAdminCeiling`. That matches today's behaviour (they could already edit unconditionally); whether they should is a separate question, also raised on #609.

## Verification

- `npm run test` — 276 files, 1830 tests, green
- `npx eslint . --max-warnings=0`, `npx prettier . --check`, `npm run build` — green
- Both gates mutation-checked: removing the permission row fails 4 assertions, ignoring `readOnly` fails 2.

Refs #609