### PR TITLE
Fix the rollout story's editor contract and colour pairings (#607 follow-up)

### DIFF
--- a/src/components/FormPluginEditor/M3RichTextEditorRollout.module.scss
+++ b/src/components/FormPluginEditor/M3RichTextEditorRollout.module.scss
@@ -1,6 +1,9 @@
 /* Presentation for the rollout-plan story. It is documentation, not a product
    surface, but it renders in the same Storybook as the components it is about —
-   so it uses the same M3 tokens rather than a private set of hex values. */
+   so it uses the same M3 colour tokens and the same 8px spacing grid rather than
+   a private set of literals. */
+
+@use '../../styles/muiSpacing' as mui;
 
 .page {
     max-width: 900px;
@@ -10,32 +13,32 @@
 }
 
 .title {
-    margin: 0 0 4px;
+    margin: 0 0 mui.$mui-unit * 0.5;
     font-size: 24px;
     font-weight: 400;
 }
 
 .sectionHeading {
-    margin: 28px 0 8px;
+    margin: mui.$mui-unit * 3.5 0 mui.$mui-unit;
     font-size: 18px;
     font-weight: 400;
 }
 
 .lead {
-    margin: 0 0 24px;
+    margin: 0 0 mui.$mui-unit * 3;
     color: var(--m3-on-surface-variant, #444748);
 }
 
 .leadTight {
-    margin: 0 0 12px;
+    margin: 0 0 mui.$mui-unit * 1.5;
     color: var(--m3-on-surface-variant, #444748);
 }
 
 .surface {
-    margin-bottom: 12px;
-    padding: 12px 16px;
+    margin-bottom: mui.$mui-unit * 1.5;
+    padding: mui.$mui-unit * 1.5 mui.$mui-unit * 2;
     border: 1px solid var(--m3-outline-variant, #c4c7c8);
-    border-radius: 12px;
+    border-radius: mui.$mui-unit * 1.5;
 }
 
 /* Out-of-scope entries stay readable but recede — they are context, not work. */
@@ -46,7 +49,7 @@
 .surfaceHead {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: mui.$mui-unit;
     align-items: baseline;
 }
 
@@ -55,7 +58,7 @@
 }
 
 .verdict {
-    padding: 2px 10px;
+    padding: 2px mui.$mui-unit * 1.25;
     border-radius: 100px;
     font-size: 12px;
 }
@@ -82,7 +85,7 @@
 
 .path {
     display: block;
-    margin: 6px 0;
+    margin: mui.$mui-unit * 0.75 0;
     color: var(--m3-on-surface-variant, #444748);
     font-size: 12px;
 }
@@ -93,7 +96,7 @@
 }
 
 .note {
-    margin: 6px 0 0;
+    margin: mui.$mui-unit * 0.75 0 0;
 }
 
 .reusableList {
@@ -101,7 +104,7 @@
 }
 
 .reusableItem {
-    margin-bottom: 10px;
+    margin-bottom: mui.$mui-unit * 1.25;
 }
 
 .reusableName {
@@ -115,6 +118,6 @@
 
 .questions {
     margin: 0;
-    padding-left: 20px;
+    padding-left: mui.$mui-unit * 2.5;
     color: var(--m3-on-surface-variant, #444748);
 }

--- a/src/components/FormPluginEditor/M3RichTextEditorRollout.module.scss
+++ b/src/components/FormPluginEditor/M3RichTextEditorRollout.module.scss
@@ -1,0 +1,120 @@
+/* Presentation for the rollout-plan story. It is documentation, not a product
+   surface, but it renders in the same Storybook as the components it is about —
+   so it uses the same M3 tokens rather than a private set of hex values. */
+
+.page {
+    max-width: 900px;
+    color: var(--m3-on-surface, #1b1b1c);
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.title {
+    margin: 0 0 4px;
+    font-size: 24px;
+    font-weight: 400;
+}
+
+.sectionHeading {
+    margin: 28px 0 8px;
+    font-size: 18px;
+    font-weight: 400;
+}
+
+.lead {
+    margin: 0 0 24px;
+    color: var(--m3-on-surface-variant, #444748);
+}
+
+.leadTight {
+    margin: 0 0 12px;
+    color: var(--m3-on-surface-variant, #444748);
+}
+
+.surface {
+    margin-bottom: 12px;
+    padding: 12px 16px;
+    border: 1px solid var(--m3-outline-variant, #c4c7c8);
+    border-radius: 12px;
+}
+
+/* Out-of-scope entries stay readable but recede — they are context, not work. */
+.surfaceOut {
+    opacity: 0.65;
+}
+
+.surfaceHead {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: baseline;
+}
+
+.surfaceName {
+    flex: 1 1 260px;
+}
+
+.verdict {
+    padding: 2px 10px;
+    border-radius: 100px;
+    font-size: 12px;
+}
+
+/* Each verdict pairs a container token with its matching `on-` token: the container
+   carries the background, the `on-` colour the text. Using an `on-` token as a
+   surface (as the first version did) only happens to be legible in one scheme. */
+
+.verdictAdopted {
+    background: var(--m3-surface-container-high, #eae7e8);
+    color: var(--m3-on-surface-variant, #444748);
+}
+
+.verdictCandidate {
+    background: var(--m3-secondary-container, #39414b);
+    color: var(--m3-on-secondary-container, #e7effc);
+}
+
+.verdictOut {
+    background: transparent;
+    border: 1px solid currentcolor;
+    color: var(--m3-outline, #747878);
+}
+
+.path {
+    display: block;
+    margin: 6px 0;
+    color: var(--m3-on-surface-variant, #444748);
+    font-size: 12px;
+}
+
+.today {
+    color: var(--m3-on-surface-variant, #444748);
+    font-size: 13px;
+}
+
+.note {
+    margin: 6px 0 0;
+}
+
+.reusableList {
+    margin: 0;
+}
+
+.reusableItem {
+    margin-bottom: 10px;
+}
+
+.reusableName {
+    font-weight: 600;
+}
+
+.reusableWhat {
+    margin: 2px 0 0;
+    color: var(--m3-on-surface-variant, #444748);
+}
+
+.questions {
+    margin: 0;
+    padding-left: 20px;
+    color: var(--m3-on-surface-variant, #444748);
+}

--- a/src/components/FormPluginEditor/M3RichTextEditorRollout.stories.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditorRollout.stories.tsx
@@ -1,4 +1,6 @@
+import classNames from 'classnames';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import styles from './M3RichTextEditorRollout.module.scss';
 
 /**
  * Where the M3 Rich Text Editor should be adopted next, and what each surface needs.
@@ -27,7 +29,7 @@ const SURFACES: Surface[] = [
         path: 'components/Tenants/LegalSettings/*',
         today: 'M3 Rich Text Editor',
         verdict: 'adopted',
-        note: 'The reference implementation: per-language content map, help text, blocker and success snackbars, version split button, department selector, device-local draft.',
+        note: 'The reference implementation: the card owns the per-language content map and feeds the editor one string at a time, plus help text, blocker and success snackbars, version split button, department selector and the draft.',
     },
     {
         name: 'Agency legal texts',
@@ -82,88 +84,56 @@ const REUSABLE = [
     ],
 ];
 
-const VERDICT_STYLE: Record<Surface['verdict'], { label: string; background: string; color: string }> = {
-    adopted: {
-        label: 'already on it',
-        background: 'var(--m3-surface-container-high, #eae7e8)',
-        color: 'var(--m3-on-surface-variant, #444748)',
-    },
-    candidate: { label: 'candidate', background: 'var(--m3-on-secondary-container, #e7effc)', color: '#000' },
-    out: { label: 'out of scope', background: 'transparent', color: 'var(--m3-outline, #747878)' },
+const VERDICT: Record<Surface['verdict'], { label: string; className: string }> = {
+    adopted: { label: 'already on it', className: styles.verdictAdopted },
+    candidate: { label: 'candidate', className: styles.verdictCandidate },
+    out: { label: 'out of scope', className: styles.verdictOut },
 };
 
 const RolloutPlan = () => (
-    <div style={{ maxWidth: 900, color: 'var(--m3-on-surface, #1b1b1c)', fontSize: 14, lineHeight: 1.5 }}>
-        <h2 style={{ fontSize: 24, fontWeight: 400, margin: '0 0 4px' }}>M3 Rich Text Editor — rollout plan</h2>
-        <p style={{ margin: '0 0 24px', color: 'var(--m3-on-surface-variant, #444748)' }}>
+    <div className={styles.page}>
+        <h2 className={styles.title}>M3 Rich Text Editor — rollout plan</h2>
+        <p className={styles.lead}>
             Every multiline text field in the admin panel, and whether the editor belongs there. Taken from the code, so
             two surfaces that looked like candidates turned out not to be: the agency legal texts already use the
             editor, and the demo cards are not mounted anywhere.
         </p>
 
         {SURFACES.map((surface) => {
-            const style = VERDICT_STYLE[surface.verdict];
+            const verdict = VERDICT[surface.verdict];
             return (
                 <section
                     key={surface.path}
-                    style={{
-                        marginBottom: 12,
-                        padding: '12px 16px',
-                        border: '1px solid var(--m3-outline-variant, #c4c7c8)',
-                        borderRadius: 12,
-                        opacity: surface.verdict === 'out' ? 0.65 : 1,
-                    }}
+                    className={classNames(styles.surface, { [styles.surfaceOut]: surface.verdict === 'out' })}
                 >
-                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'baseline' }}>
-                        <strong style={{ flex: '1 1 260px' }}>{surface.name}</strong>
-                        <span
-                            style={{
-                                padding: '2px 10px',
-                                borderRadius: 100,
-                                background: style.background,
-                                color: style.color,
-                                fontSize: 12,
-                                border: surface.verdict === 'out' ? '1px solid currentColor' : 'none',
-                            }}
-                        >
-                            {style.label}
-                        </span>
+                    <div className={styles.surfaceHead}>
+                        <strong className={styles.surfaceName}>{surface.name}</strong>
+                        <span className={classNames(styles.verdict, verdict.className)}>{verdict.label}</span>
                     </div>
-                    <code
-                        style={{
-                            display: 'block',
-                            margin: '6px 0',
-                            fontSize: 12,
-                            color: 'var(--m3-on-surface-variant, #444748)',
-                        }}
-                    >
-                        {surface.path}
-                    </code>
-                    <div style={{ fontSize: 13, color: 'var(--m3-on-surface-variant, #444748)' }}>
+                    <code className={styles.path}>{surface.path}</code>
+                    <div className={styles.today}>
                         <em>today:</em> {surface.today}
                     </div>
-                    <p style={{ margin: '6px 0 0' }}>{surface.note}</p>
+                    <p className={styles.note}>{surface.note}</p>
                 </section>
             );
         })}
 
-        <h3 style={{ fontSize: 18, fontWeight: 400, margin: '28px 0 8px' }}>What comes with the editor</h3>
-        <p style={{ margin: '0 0 12px', color: 'var(--m3-on-surface-variant, #444748)' }}>
+        <h3 className={styles.sectionHeading}>What comes with the editor</h3>
+        <p className={styles.leadTight}>
             These are the parts worth reusing in other molecules and atoms, not just inside the legal cards.
         </p>
-        <dl style={{ margin: 0 }}>
+        <dl className={styles.reusableList}>
             {REUSABLE.map(([name, what]) => (
-                <div key={name} style={{ marginBottom: 10 }}>
-                    <dt style={{ fontWeight: 600 }}>{name}</dt>
-                    <dd style={{ margin: '2px 0 0', color: 'var(--m3-on-surface-variant, #444748)' }}>{what}</dd>
+                <div key={name} className={styles.reusableItem}>
+                    <dt className={styles.reusableName}>{name}</dt>
+                    <dd className={styles.reusableWhat}>{what}</dd>
                 </div>
             ))}
         </dl>
 
-        <h3 style={{ fontSize: 18, fontWeight: 400, margin: '28px 0 8px' }}>
-            Open questions before the first migration
-        </h3>
-        <ul style={{ margin: 0, paddingLeft: 20, color: 'var(--m3-on-surface-variant, #444748)' }}>
+        <h3 className={styles.sectionHeading}>Open questions before the first migration</h3>
+        <ul className={styles.questions}>
             <li>
                 Does the target store plain text today? Switching to HTML needs a read path that survives the old
                 values.
@@ -177,8 +147,10 @@ const RolloutPlan = () => (
                 want image upload.
             </li>
             <li>
-                Per-language already, or single value? The editor expects a language map; a single string needs a
-                decision, not a default.
+                Per-language already, or single value? The editor itself takes a single HTML <code>value</code> — the
+                language map lives in the host, which picks the current string and passes <code>languages</code> /{' '}
+                <code>language</code> / <code>onLanguageChange</code> to get the switcher. A surface with one value can
+                adopt the editor without any of that; whether it should become multilingual is a separate decision.
             </li>
         </ul>
     </div>


### PR DESCRIPTION
## Problem

Two CodeRabbit findings on #765 were merged unaddressed.

1. **The documented contract was wrong.** The story told readers `M3RichTextEditor` "expects a language map". It does not — it takes a single HTML `value`; the *host* owns the map and passes `languages` / `language` / `onLanguageChange` to get the switcher. Stated that way, the note would have scared off exactly the single-value candidates the page lists.
2. **The verdict chips used the tokens backwards.** `candidate` had `--m3-on-secondary-container` as its **background** with hardcoded `#000` text. It only looked right because that token happens to be light in this scheme.

## What changed

- The "per-language or single value?" question now describes the real contract and says a single-value surface can adopt the editor without the language plumbing.
- Presentation moves from inline styles into `M3RichTextEditorRollout.module.scss`; each verdict chip pairs a container token with its matching `on-` token.

## Verification

`npm run test`, `npx eslint . --max-warnings=0`, `npx prettier . --check`, `npm run build` — green. `stylelint` on the new module: 0 errors; the remaining property-order/flexbox-gap warnings match what the rest of `src` already produces (136 repo-wide, exit 0).

Docs-only story — no product surface changes.

Refs #607, #765

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added polished rollout-plan styling with consistent colors, typography, spacing, surfaces, badges, and responsive layouts.
  * Improved visual treatment for out-of-scope entries, notes, reusable items, and open questions.
* **Documentation**
  * Clarified legal-text and multilingual editor guidance in the rollout plan.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->