### PR TITLE
fix(lint): get pre-dev green — two stylelint errors, two different right answers

### DIFF
--- a/src/components/Dpia/styles.module.scss
+++ b/src/components/Dpia/styles.module.scss
@@ -15,6 +15,7 @@
     --dpia-success-ink: #075e26;
     --dpia-success-wash: #e8f3eb;
     --dpia-success-line: #b9dcc2;
+
     /* "Planned/not shipped" amber family, used by the appointment-module card
        and its badges. Named aliases so the shade is declared once instead of
        repeated as raw hex at every call site. */

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -78,6 +78,13 @@ module.exports = {
         "except": [
           "after-single-line-comment",
           "first-nested"
+        ],
+        // A comment directly above a rule documents it; forcing a blank line
+        // between them separates the explanation from its subject. "except"
+        // only covers single-line comments, so multi-line doc comments need
+        // this ignore.
+        "ignore": [
+          "after-comment"
         ]
       }
     ],


### PR DESCRIPTION
**`pre-dev` is red on its own `CI - Main`.** `npm run lint:css` exits non-zero, so every branch that merges `pre-dev` inherits the failure — the five Admin PRs repaired today each had to carry an identical carry-fix just to go green. This fixes it at source; those carry-fixes become no-ops.

| commit | `CI - Main` |
|---|---|
| `0fa59803` (17:46) | ✅ green |
| `4502e00c` (19:49) | ❌ red |
| `cb6e8a59` (HEAD) | ❌ red |

Introduced by the DPIA merges (#736 / #744 / #745).

## Three errors, two rules, two different right answers

This is deliberately **not** a blanket `stylelint --fix`.

### 1. `rule-empty-line-before` — config, not content

`src/components/Dpia/styles.module.scss:319` and `src/pages/GlobalSettings/styles.module.scss:16` are both **multi-line doc comments sitting directly above the rule they document**:

```scss
/** Chapters not yet ported into this view (see AVAILABLE_CHAPTER_IDS) — shown
    for orientation but not a link, so there is nothing for the anchor to fail
    to reach. */
.chipDisabled {
```

The config already carries `"after-single-line-comment"` in its `except` list, so the intent is established: *a comment immediately above a rule documents it and should not be forced apart from it.* That exception simply does not cover multi-line comments.

**`--fix` here would insert a blank line BETWEEN the doc comment and the rule it describes** — divorcing the explanation from its subject, the exact opposite of what the existing exception protects.

So the fix is `"after-single-line-comment"` → `"after-comment"`, which subsumes it.

### 2. `comment-empty-line-before` — content, not config

`src/components/Dpia/styles.module.scss:18` is a **different rule**, and here a blank line is genuinely correct: it is a section comment introducing a group of custom properties mid-block, not a doc comment glued to a following rule. Added the blank line.

## Verification

Confirmed `"after-comment"` is a valid stylelint 17 option and that it introduces nothing new — the **warning count is byte-identical** before and after:

| | problems |
|---|---|
| pristine `pre-dev` | `1516 problems (**3 errors**, 1513 warnings)` |
| with this change | `1513 problems (**0 errors**, 1513 warnings)` |

Only the errors change. The 1513 warnings (property order, unsupported browser features) are pre-existing and deliberately out of scope — this restores exactly the error-free state CI was last green on, and nothing more.

Also verified `npm run lint:js` and `npm run lint:formatting` pass.

## Reviewer test plan

- [ ] `CI - Main` / PR build is green
- [ ] `npx stylelint "src/**/*.(s(c|a)ss|css|less)"` reports **0 errors**
- [ ] Agree that widening the exception beats `--fix` splitting doc comments from their rules
- [ ] Confirm the 1513 pre-existing warnings staying untouched is the right scope (they are worth their own ticket)

Note: npm rewrites `yarn.lock` whenever it is present — that rewrite was reverted, so this PR touches only the two intended files.