### PR TITLE
fix(lint): restore the stylelint gate on pre-dev

### DIFF
--- a/src/components/Dpia/styles.module.scss
+++ b/src/components/Dpia/styles.module.scss
@@ -15,6 +15,7 @@
     --dpia-success-ink: #075e26;
     --dpia-success-wash: #e8f3eb;
     --dpia-success-line: #b9dcc2;
+
     /* "Planned/not shipped" amber family, used by the appointment-module card
        and its badges. Named aliases so the shade is declared once instead of
        repeated as raw hex at every call site. */
@@ -313,9 +314,9 @@
     }
 }
 
-/** Chapters not yet ported into this view (see AVAILABLE_CHAPTER_IDS) — shown
-    for orientation but not a link, so there is nothing for the anchor to fail
-    to reach. */
+// Chapters not yet ported into this view (see AVAILABLE_CHAPTER_IDS) — shown
+// for orientation but not a link, so there is nothing for the anchor to fail
+// to reach.
 .chipDisabled {
     border-color: var(--dpia-hair-soft);
     color: var(--m3-on-surface-variant, #444748);

--- a/src/pages/GlobalSettings/styles.module.scss
+++ b/src/pages/GlobalSettings/styles.module.scss
@@ -11,8 +11,8 @@
     min-width: 0;
 }
 
-/* ORISO-Admin#735: the document master data card has four field groups, so it takes the
-   full width of the grid rather than sharing a row. */
+// ORISO-Admin#735: the document master data card has four field groups, so it
+// takes the full width of the grid rather than sharing a row.
 .documentMasterDataCardSlot {
     min-width: 0;
     grid-column: 1 / -1;


### PR DESCRIPTION
## Problem

`pre-dev` is red on its own `CI - Main` workflow. The `Lint (Stylelint)` step of `.github/actions/node-build` fails because `npm run lint:css` exits 2:

```
✖ 1516 problems (3 errors, 1513 warnings)
```

Example run: https://github.com/OpenResilienceInitiative/ORISO-Admin/actions/runs/31968762048

The 3 errors were introduced by the DPIA merges (#736 / #744 / #745). Because every feature branch that merges `pre-dev` in inherits them, the identical throwaway `stylelint --fix` commit had to be carried into five open PRs (#712, #702, #699, #704, #673) just to get their gates green. This replaces those duplicates with one fix.

## The three errors, and why they get two different treatments

| File | Rule |
|---|---|
| `src/components/Dpia/styles.module.scss:18` | `comment-empty-line-before` |
| `src/components/Dpia/styles.module.scss:319` | `rule-empty-line-before` |
| `src/pages/GlobalSettings/styles.module.scss:16` | `rule-empty-line-before` |

**`comment-empty-line-before` — blank line added.** The comment introducing the amber custom-property group sits flush against the group above it. Here the blank line is the right read: it separates two groups of declarations rather than binding a doc comment to one of them. This is the plain autofix and it is correct.

**`rule-empty-line-before` — switched to the `//` comment form.** Both cases are a multi-line block comment documenting the rule directly beneath it. The plain autofix inserts a blank line *between* the doc comment and the rule it documents, splitting the two things that belong together.

Instead they now use the `//` form, which is exactly what `except: ["after-single-line-comment"]` in `stylelint.config.js` exists to permit — and what the same `Dpia/styles.module.scss` already does for the comment above `.section`:

```scss
// The app bar is no longer sticky at this width, so only the (still sticky) chapter nav's
// own height needs to be cleared when jumping to a chapter via anchor.
.section {
```

`//` comments are also stripped by Sass rather than emitted into the built CSS, which suits an internal doc comment.

## The gate is not weakened

**No change to `stylelint.config.js`.** `rule-empty-line-before` still enforces in both directions — putting a blank line after these comments is now an error, verified:

```
17:1  ✖  Expected no empty line before rule    rule-empty-line-before
```

The `//` form is the shape the rule *requires*, not an exemption from it.

### A note on the shorter route

Adding `"after-comment"` to the rule's `except` list looks like the tidy fix matching the config's intent, but stylelint does not accept it there — only `ignore` takes `after-comment` (`except` accepts `after-rule`, `after-single-line-comment`, `first-nested`, `inside-block-and-after-rule`, `inside-block`). Tried against the pinned stylelint 17:

```
Invalid Option: Invalid value "after-comment" for option "except" of rule "rule-empty-line-before"
⚠ 1513 problems (0 errors, 1513 warnings)
```

Note the `0 errors`: an invalid option makes stylelint skip the rule entirely. That route would have produced a green gate with `rule-empty-line-before` silently disabled repo-wide — a worse outcome than the red gate it fixed.

Using `ignore: ["after-comment"]` is valid but also weakens the gate: `ignore` is evaluated before `except`, so it would stop enforcing the existing no-blank-line-after-single-line-comment rule as well.

## Verification

Run in a clean worktree off `pre-dev` with `npm ci --ignore-scripts`, matching the CI step:

- `npm run lint:css` → **exit 0**, `⚠ 1513 problems (0 errors, 1513 warnings)`
- `npx prettier . --check --ignore-unknown` → **exit 0**, `All matched files use Prettier code style!`

Warnings go 1516 → 1513: exactly the three errors removed, no new warnings introduced. The remaining 1513 are pre-existing and non-blocking (`severity: "warning"`).

## Follow-up for the five PRs

Once this merges, the `style(lint): restore the stylelint gate broken on pre-dev` commit in #712, #702, #699, #704 and #673 becomes redundant. Those branches should drop it and merge `pre-dev` in instead — if both survive, the two versions of the `rule-empty-line-before` fix will conflict in the same lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)