### PR TITLE
fix(dpia): complete the role-matrix truth pass and fix Storybook viewport selection

### DIFF
--- a/src/components/Dpia/DpiaDocumentPage.stories.tsx
+++ b/src/components/Dpia/DpiaDocumentPage.stories.tsx
@@ -29,9 +29,15 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+// The named presets (phone/tablet/laptop/desktop) are registered once in .storybook/preview.tsx;
+// selecting one for a story is done via `globals.viewport.value` (Storybook 10's viewport addon),
+// NOT `parameters.viewport.defaultViewport` — the latter is a pre-10 API that this addon version
+// silently ignores, so a story using it renders at whatever the toolbar happens to be set to
+// instead of the viewport its name promises.
+
 /** Desktop reading view — the default surface for reviewers and auditors. */
 export const Desktop: Story = {
-    parameters: { viewport: { defaultViewport: 'desktop' } },
+    globals: { viewport: { value: 'desktop', isRotated: false } },
 };
 
 /**
@@ -40,19 +46,19 @@ export const Desktop: Story = {
  * inside its own container instead of widening the page.
  */
 export const Mobile: Story = {
-    parameters: { viewport: { defaultViewport: 'phone' } },
+    globals: { viewport: { value: 'phone', isRotated: false } },
 };
 
 /** Church data-protection preset — all norm citations render KDG paragraphs. */
 export const PresetKdg: Story = {
     args: { initialPreset: 'kdg' },
-    parameters: { viewport: { defaultViewport: 'laptop' } },
+    globals: { viewport: { value: 'laptop', isRotated: false } },
 };
 
 /** GDPR preset — the same document with the secular citations. */
 export const PresetDsgvo: Story = {
     args: { initialPreset: 'dsgvo' },
-    parameters: { viewport: { defaultViewport: 'laptop' } },
+    globals: { viewport: { value: 'laptop', isRotated: false } },
 };
 
 /**
@@ -61,5 +67,5 @@ export const PresetDsgvo: Story = {
  */
 export const WithInternalNotes: Story = {
     args: { initialShowInternalNotes: true },
-    parameters: { viewport: { defaultViewport: 'laptop' } },
+    globals: { viewport: { value: 'laptop', isRotated: false } },
 };

--- a/src/components/Dpia/DpiaDocumentPage.test.tsx
+++ b/src/components/Dpia/DpiaDocumentPage.test.tsx
@@ -71,18 +71,21 @@ describe('DpiaDocumentPage', () => {
         expect(screen.getByText('1')).toBeInTheDocument();
     });
 
-    it('documents the platform-admin tier with the full role bundle it actually needs (agency-admin + tenant-admin + user-admin)', () => {
+    it('documents every admin tier with the full role bundle userRolesToPermissions.ts actually requires for what the matrix claims', () => {
         render(<DpiaDocumentPage />);
 
-        // useUserRoles.hook.ts: isSuperAdmin = hasRole(AgencyAdmin) && hasRole(TenantAdmin) &&
-        // tenantId === 0 identifies the tier, but userRolesToPermissions.ts only grants Consultant
-        // CRUD (the matrix's "Beratende anlegen / einladen") to UserRole.UserAdmin — dropping it
-        // would make that matrix cell false. agency-admin/tenant-admin tags are shared with the
-        // tenant-admin tier below (same roles, different scope), so assert presence, not a single
-        // match; user-admin is unique to the platform tier.
-        expect(screen.getAllByText('agency-admin').length).toBeGreaterThan(0);
-        expect(screen.getAllByText('tenant-admin').length).toBeGreaterThan(0);
-        expect(screen.getByText('user-admin')).toBeInTheDocument();
+        // Every admin tier's realm-role tags are cross-checked against
+        // src/constants/userRolesToPermissions.ts (see the dpiaContent.ts header comment):
+        // - useUserRoles.hook.ts: isSuperAdmin = agency-admin + tenant-admin + tenantId 0.
+        // - Agency.create/read is granted ONLY by agency-admin (AdminSidebar.stories.tsx's
+        //   TenantAdmin story: "lacking Agency read" without it).
+        // - Consultant.create (the matrix's "Beratende anlegen / einladen") is granted ONLY by
+        //   user-admin.
+        // Tags are shared across tiers (same underlying Keycloak roles, different scope), so
+        // assert presence per role rather than a single exact match per tier.
+        expect(screen.getAllByText('agency-admin').length).toBeGreaterThanOrEqual(3); // platform, tenant, agency tiers
+        expect(screen.getAllByText('tenant-admin').length).toBeGreaterThanOrEqual(2); // platform, tenant tiers
+        expect(screen.getAllByText('user-admin').length).toBe(3); // platform, tenant, agency tiers
     });
 
     it('marks 2FA deferral as a platform-admin-only affordance, not for tenant admins', () => {

--- a/src/components/Dpia/DpiaDocumentPage.test.tsx
+++ b/src/components/Dpia/DpiaDocumentPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { DpiaDocumentPage } from './DpiaDocumentPage';
 
@@ -71,21 +71,36 @@ describe('DpiaDocumentPage', () => {
         expect(screen.getByText('1')).toBeInTheDocument();
     });
 
-    it('documents every admin tier with the full role bundle userRolesToPermissions.ts actually requires for what the matrix claims', () => {
+    it('documents every tier with the exact realm-role bundle userRolesToPermissions.ts requires for what the matrix claims', () => {
         render(<DpiaDocumentPage />);
 
-        // Every admin tier's realm-role tags are cross-checked against
+        // Scoped per tier card and asserted as an exact set: a regression that moves a role to the
+        // wrong tier, drops one, or duplicates a tag fails here. Cross-checked against
         // src/constants/userRolesToPermissions.ts (see the dpiaContent.ts header comment):
         // - useUserRoles.hook.ts: isSuperAdmin = agency-admin + tenant-admin + tenantId 0.
-        // - Agency.create/read is granted ONLY by agency-admin (AdminSidebar.stories.tsx's
-        //   TenantAdmin story: "lacking Agency read" without it).
-        // - Consultant.create (the matrix's "Beratende anlegen / einladen") is granted ONLY by
-        //   user-admin.
-        // Tags are shared across tiers (same underlying Keycloak roles, different scope), so
-        // assert presence per role rather than a single exact match per tier.
-        expect(screen.getAllByText('agency-admin').length).toBeGreaterThanOrEqual(3); // platform, tenant, agency tiers
-        expect(screen.getAllByText('tenant-admin').length).toBeGreaterThanOrEqual(2); // platform, tenant tiers
-        expect(screen.getAllByText('user-admin').length).toBe(3); // platform, tenant, agency tiers
+        // - Agency.create/read comes ONLY from agency-admin (AdminSidebar.stories.tsx's TenantAdmin
+        //   story renders "lacking Agency read" without it).
+        // - Consultant.create — the matrix's "Beratende anlegen / einladen" — ONLY from user-admin.
+        const expected: Record<string, string[]> = {
+            'Plattform-Admin': ['agency-admin', 'tenant-admin', 'user-admin'],
+            'Träger-Admin': ['tenant-admin', 'single-tenant-admin', 'agency-admin', 'user-admin'],
+            'Beratungsstellen-Admin': [
+                'agency-admin',
+                'restricted-agency-admin',
+                'restricted-consultant-admin',
+                'user-admin',
+            ],
+            'Beratende:r': ['consultant', 'group-chat-consultant', 'supervisor-consultant'],
+        };
+
+        Object.entries(expected).forEach(([tierName, realmRoles]) => {
+            const card = screen.getByRole('region', { name: tierName });
+            const rendered = within(card)
+                .getAllByTestId('realm-role')
+                .map((node) => node.textContent);
+
+            expect(rendered).toEqual(realmRoles);
+        });
     });
 
     it('marks 2FA deferral as a platform-admin-only affordance, not for tenant admins', () => {

--- a/src/components/Dpia/DpiaDocumentPage.tsx
+++ b/src/components/Dpia/DpiaDocumentPage.tsx
@@ -323,7 +323,11 @@ export const DpiaDocumentPage = ({
 
                     <div className={styles.roleGrid}>
                         {ROLE_TIERS.map((role) => (
-                            <div key={role.id} className={cx(styles.roleCard, TIER_CLASS[role.tier])}>
+                            <section
+                                key={role.id}
+                                aria-label={role.name}
+                                className={cx(styles.roleCard, TIER_CLASS[role.tier])}
+                            >
                                 <div className={styles.roleHead}>
                                     <DpiaIcon name={role.icon} size="18px" />
                                     <span className={styles.roleName}>{role.name}</span>
@@ -331,7 +335,7 @@ export const DpiaDocumentPage = ({
                                 <p className={styles.roleDesc}>{role.description}</p>
                                 <div className={styles.roleTags}>
                                     {role.realmRoles.map((realmRole) => (
-                                        <span key={realmRole} className={styles.realmRole}>
+                                        <span key={realmRole} data-testid="realm-role" className={styles.realmRole}>
                                             {realmRole}
                                         </span>
                                     ))}
@@ -341,7 +345,7 @@ export const DpiaDocumentPage = ({
                                         </span>
                                     )}
                                 </div>
-                            </div>
+                            </section>
                         ))}
                     </div>
 

--- a/src/components/Dpia/dpiaContent.ts
+++ b/src/components/Dpia/dpiaContent.ts
@@ -12,6 +12,14 @@
  *   contact calendar" (Accepted, 2026-08-12) — planned, nothing shipped yet
  *
  * Nothing may be added here that is not backed by one of those sources.
+ *
+ * ROLE_TIERS.realmRoles / MATRIX_ROWS cross-check (2026-08-14): every "yes" cell in MATRIX_ROWS
+ * was verified against `src/constants/userRolesToPermissions.ts` — each admin tier's realmRoles
+ * now lists every role actually required, per that file, for every capability the matrix claims
+ * that tier has (e.g. Agency.create only comes from `agency-admin`, Consultant.create only from
+ * `user-admin`; roles-permissions.mdx's narrative bundle per tier does not on its own guarantee
+ * the permission grants the matrix asserts). If either file changes, re-diff them before editing
+ * either.
  */
 import type { DpiaIconName } from './DpiaIcon';
 
@@ -75,8 +83,13 @@ export const ROLE_TIERS: RoleTier[] = [
         name: 'Träger-Admin',
         description:
             'Verantwortet einen Träger: legt Beratungsstellen und deren Administration an, pflegt ' +
-            'die Rechtstexte der Träger-Ebene. Von anderen Trägern vollständig isoliert.',
-        realmRoles: ['tenant-admin', 'single-tenant-admin'],
+            'die Rechtstexte der Träger-Ebene. Von anderen Trägern vollständig isoliert. Realm-' +
+            'Rolle tenant-admin/single-tenant-admin identifiziert die Stufe; agency-admin kommt ' +
+            'dazu, weil tenant-admin allein keine Agency-Berechtigung hat (kein Agency.create, ' +
+            'nicht mal Agency.read — siehe AdminSidebar.stories.tsx TenantAdmin-Story), und user-' +
+            'admin, weil nur diese Rolle Beratende anlegen/einladen darf (beides ' +
+            'userRolesToPermissions.ts).',
+        realmRoles: ['tenant-admin', 'single-tenant-admin', 'agency-admin', 'user-admin'],
         mfaMandatory: true,
     },
     {
@@ -86,8 +99,10 @@ export const ROLE_TIERS: RoleTier[] = [
         name: 'Beratungsstellen-Admin',
         description:
             'Leitet eine Beratungsstelle: lädt Beratende ein, konfiguriert Live-Chat-Link, Themen ' +
-            'und PLZ-Zuordnung, kann die Rechtstexte der eigenen Stelle überschreiben.',
-        realmRoles: ['agency-admin', 'restricted-agency-admin', 'restricted-consultant-admin'],
+            'und PLZ-Zuordnung, kann die Rechtstexte der eigenen Stelle überschreiben. agency-' +
+            'admin identifiziert die Stufe; user-admin kommt dazu, weil ausschließlich diese Rolle ' +
+            'Beratende anlegen/einladen darf (userRolesToPermissions.ts).',
+        realmRoles: ['agency-admin', 'restricted-agency-admin', 'restricted-consultant-admin', 'user-admin'],
         mfaMandatory: false,
     },
     {


### PR DESCRIPTION
## Why

The final review round on #745 was never committed before that PR merged, so `pre-dev` currently carries the **less accurate** version of the DPIA role matrix.

## What

- **Role matrix accuracy.** `ROLE_TIERS.realmRoles` now lists every realm role a tier actually needs for the capabilities the matrix claims it has — `agency-admin` for `Agency.create`, `user-admin` for `Consultant.create` — cross-checked line by line against `src/constants/userRolesToPermissions.ts`. Previously the Träger-Admin tier listed only `tenant-admin`/`single-tenant-admin`, which grant neither capability. For a document whose purpose is verifiable accuracy, that mismatch matters.
- **Storybook 10 viewport selection.** Stories now use `globals.viewport.value`. The pre-10 `parameters.viewport.defaultViewport` API is silently ignored by this addon version, so the Mobile story rendered at whatever the toolbar happened to be set to — the story did not show what its name promised.
- Tests updated accordingly.

## Verification

- `npx vitest run src/components/Dpia` — 8/8 green
- `npx tsc --noEmit` — clean
- Storybook: Desktop and Mobile stories now render at their named viewports

## Reviewer test plan

- [ ] Open `Dpia/DpiaDocumentPage` → Mobile story renders at 390px without touching the toolbar
- [ ] Role matrix: Träger-Admin row lists all four realm roles
- [ ] Cross-check one "yes" cell against `userRolesToPermissions.ts`

part of #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified administrator role descriptions, permissions, and role mappings.
  * Updated tenant-admin and agency-admin guidance to reflect required access levels and restrictions.

* **Accessibility**
  * Improved role card structure and labeling for assistive technologies.

* **Tests**
  * Expanded coverage to verify role labels and ordering across documented administrator tiers.

* **Style**
  * Updated component previews to use consistent desktop, mobile, and preset viewport configurations without rotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->