### PR TITLE
Clear the three Stylelint errors blocking every PR

### DIFF
--- a/src/components/Dpia/styles.module.scss
+++ b/src/components/Dpia/styles.module.scss
@@ -15,6 +15,7 @@
     --dpia-success-ink: #075e26;
     --dpia-success-wash: #e8f3eb;
     --dpia-success-line: #b9dcc2;
+
     /* "Planned/not shipped" amber family, used by the appointment-module card
        and its badges. Named aliases so the shade is declared once instead of
        repeated as raw hex at every call site. */
@@ -316,6 +317,7 @@
 /** Chapters not yet ported into this view (see AVAILABLE_CHAPTER_IDS) — shown
     for orientation but not a link, so there is nothing for the anchor to fail
     to reach. */
+
 .chipDisabled {
     border-color: var(--dpia-hair-soft);
     color: var(--m3-on-surface-variant, #444748);

--- a/src/pages/GlobalSettings/styles.module.scss
+++ b/src/pages/GlobalSettings/styles.module.scss
@@ -13,6 +13,7 @@
 
 /* ORISO-Admin#735: the document master data card has four field groups, so it takes the
    full width of the grid rather than sharing a row. */
+
 .documentMasterDataCardSlot {
     min-width: 0;
     grid-column: 1 / -1;


### PR DESCRIPTION
**Blocks every open pull request.** `pre-dev` currently fails its own Stylelint step, so any PR that merges it inherits a red build.

## Problem

`lint:css` was changed to check-only — correctly, since the mutating variant should never run in CI. But three errors that `--fix` used to silence became a hard failure. Verified on a clean `origin/pre-dev` checkout, not inferred from a branch: `1516 problems (3 errors, 1513 warnings)`.

The errors are in `src/components/Dpia/styles.module.scss` (2) and `src/pages/GlobalSettings/styles.module.scss` (1).

## What changed

Exactly what `npm run lint:css:fix` produces for those two files: three blank lines. No hand-written style choices. Afterwards: `1513 problems (0 errors, 1513 warnings)`.

## Worth a follow-up

Two of the three fixes separate a doc comment from the rule it documents, because `rule-empty-line-before` runs without `ignore: ["after-comment"]`. If that reads wrong to you, the better answer is that config option rather than reformatting every commented rule. I did not change the config here — that is a call for whoever owns the Stylelint setup, and it should not hold up unblocking the pipeline.

## Verification

- `npm run lint:css` on clean `origin/pre-dev`: 3 errors.
- `npm run lint:css` on this branch: 0 errors.

## How should I test this?

- [ ] Check out this branch and run `npm run lint:css` → 0 errors.
- [ ] Confirm the same command on `pre-dev` still reports 3 errors, so the failure is pre-existing and not from any feature branch.
- [ ] Open `src/components/Dpia/styles.module.scss` around lines 15–20 and 315–320 and decide whether the blank line between comment and rule is acceptable, or whether you would rather set `ignore: ["after-comment"]` instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved stylesheet formatting and readability.
  * No functional or visual behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->