### PR TITLE
Fix shared outlined field notches and date labels

### DIFF
--- a/src/components/mui/MuiFormField/MuiFormField.test.tsx
+++ b/src/components/mui/MuiFormField/MuiFormField.test.tsx
@@ -14,12 +14,21 @@ const sharedFieldSxSource = readFileSync(resolve(__dirname, '../fieldSx.ts'), 'u
 const renderWithForm = (children: React.ReactNode) => render(<Form>{children}</Form>);
 
 describe('MuiFormField', () => {
-    it('leaves outlined notch legend sizing to MUI', () => {
+    it('neutralizes the global Ant legend width without overriding MUI notch expansion', () => {
         const legendRule = (source: string) =>
             source.match(/'& \.MuiOutlinedInput-notchedOutline legend':\s*{([^}]*)}/s)?.[1] ?? '';
 
-        expect(legendRule(muiFormFieldSource)).not.toMatch(/\bwidth\s*:/);
-        expect(legendRule(sharedFieldSxSource)).not.toMatch(/\bwidth\s*:/);
+        expect(legendRule(muiFormFieldSource)).toMatch(/\bwidth\s*:\s*'auto'/);
+        expect(legendRule(sharedFieldSxSource)).toMatch(/\bwidth\s*:\s*'auto'/);
+        expect(legendRule(muiFormFieldSource)).not.toMatch(/\bmaxWidth\s*:/);
+        expect(legendRule(sharedFieldSxSource)).not.toMatch(/\bmaxWidth\s*:/);
+    });
+
+    it('floats an empty native date label before the field receives focus', () => {
+        renderWithForm(<MuiFormField name="reviewDate" label="Review date" type="date" />);
+
+        const input = screen.getByLabelText('Review date');
+        expect(document.getElementById(`${input.id}-label`)).toHaveAttribute('data-shrink', 'true');
     });
 
     it('uses the surrounding surface only for filled fields', () => {

--- a/src/components/mui/MuiFormField/MuiFormField.test.tsx
+++ b/src/components/mui/MuiFormField/MuiFormField.test.tsx
@@ -1,34 +1,41 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import React from 'react';
 import { Form } from 'antd';
+import antdResetCss from 'antd/dist/reset.css?inline';
 import InputAdornment from '@mui/material/InputAdornment';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
+import { MuiSelectField } from '../MuiSelectField';
 import { MuiFormField, MuiNumberFormField, MuiPasswordFormField } from './index';
-
-const muiFormFieldSource = readFileSync(resolve(__dirname, './index.tsx'), 'utf8');
-const sharedFieldSxSource = readFileSync(resolve(__dirname, '../fieldSx.ts'), 'utf8');
 
 const renderWithForm = (children: React.ReactNode) => render(<Form>{children}</Form>);
 
 describe('MuiFormField', () => {
     it('neutralizes the global Ant legend width without overriding MUI notch expansion', () => {
-        const legendRule = (source: string) =>
-            source.match(/'& \.MuiOutlinedInput-notchedOutline legend':\s*{([^}]*)}/s)?.[1] ?? '';
+        const resetStyle = document.createElement('style');
+        resetStyle.textContent = antdResetCss;
+        document.head.prepend(resetStyle);
 
-        expect(legendRule(muiFormFieldSource)).toMatch(/\bwidth\s*:\s*'auto'/);
-        expect(legendRule(sharedFieldSxSource)).toMatch(/\bwidth\s*:\s*'auto'/);
-        expect(legendRule(muiFormFieldSource)).not.toMatch(/\bmaxWidth\s*:/);
-        expect(legendRule(sharedFieldSxSource)).not.toMatch(/\bmaxWidth\s*:/);
+        render(
+            <Form component={false}>
+                <MuiFormField name="title" label="Title" />
+                <MuiSelectField name="category" label="Category" options={[{ value: 'general', label: 'General' }]} />
+            </Form>,
+        );
+
+        const legends = document.querySelectorAll<HTMLLegendElement>('.MuiOutlinedInput-notchedOutline legend');
+
+        expect(legends).toHaveLength(2);
+        expect(Array.from(legends, (legend) => getComputedStyle(legend).width)).toEqual(['auto', 'auto']);
+
+        resetStyle.remove();
     });
 
     it('floats an empty native date label before the field receives focus', () => {
         renderWithForm(<MuiFormField name="reviewDate" label="Review date" type="date" />);
 
-        const input = screen.getByLabelText('Review date');
-        expect(document.getElementById(`${input.id}-label`)).toHaveAttribute('data-shrink', 'true');
+        const input = screen.getByLabelText<HTMLInputElement>('Review date');
+        expect(input.labels?.[0]).toHaveAttribute('data-shrink', 'true');
     });
 
     it('uses the surrounding surface only for filled fields', () => {

--- a/src/components/mui/MuiFormField/MuiFormField.test.tsx
+++ b/src/components/mui/MuiFormField/MuiFormField.test.tsx
@@ -16,19 +16,27 @@ describe('MuiFormField', () => {
         resetStyle.textContent = antdResetCss;
         document.head.prepend(resetStyle);
 
-        render(
-            <Form component={false}>
-                <MuiFormField name="title" label="Title" />
-                <MuiSelectField name="category" label="Category" options={[{ value: 'general', label: 'General' }]} />
-            </Form>,
-        );
+        // The reset is global: if a render or an assertion throws, an un-removed <style> leaks the
+        // Ant legend rule into every later test in this file and turns one failure into several.
+        try {
+            render(
+                <Form component={false}>
+                    <MuiFormField name="title" label="Title" />
+                    <MuiSelectField
+                        name="category"
+                        label="Category"
+                        options={[{ value: 'general', label: 'General' }]}
+                    />
+                </Form>,
+            );
 
-        const legends = document.querySelectorAll<HTMLLegendElement>('.MuiOutlinedInput-notchedOutline legend');
+            const legends = document.querySelectorAll<HTMLLegendElement>('.MuiOutlinedInput-notchedOutline legend');
 
-        expect(legends).toHaveLength(2);
-        expect(Array.from(legends, (legend) => getComputedStyle(legend).width)).toEqual(['auto', 'auto']);
-
-        resetStyle.remove();
+            expect(legends).toHaveLength(2);
+            expect(Array.from(legends, (legend) => getComputedStyle(legend).width)).toEqual(['auto', 'auto']);
+        } finally {
+            resetStyle.remove();
+        }
     });
 
     it('floats an empty native date label before the field receives focus', () => {

--- a/src/components/mui/MuiFormField/index.tsx
+++ b/src/components/mui/MuiFormField/index.tsx
@@ -109,11 +109,13 @@ const MuiControl = ({
                   ...(startAdornment ? { startAdornment } : {}),
               }
             : undefined;
+    const shrinkLabel = type === 'date';
     const slotProps =
-        inputSlotProps || inputProps
+        inputSlotProps || inputProps || shrinkLabel
             ? {
                   ...(inputSlotProps ? { input: inputSlotProps } : {}),
                   ...(inputProps ? { htmlInput: inputProps } : {}),
+                  ...(shrinkLabel ? { inputLabel: { shrink: true } } : {}),
               }
             : undefined;
 
@@ -213,6 +215,7 @@ const MuiControl = ({
                     borderColor: 'var(--input-border-color)',
                 },
                 '& .MuiOutlinedInput-notchedOutline legend': {
+                    width: 'auto',
                     marginBottom: 0,
                     borderBottom: 'none',
                     fontSize: '0.75em',

--- a/src/components/mui/fieldSx.ts
+++ b/src/components/mui/fieldSx.ts
@@ -55,6 +55,7 @@ export const muiFieldSx = (isDisabled?: boolean): SxProps<Theme> => ({
         borderColor: 'var(--input-border-color)',
     },
     '& .MuiOutlinedInput-notchedOutline legend': {
+        width: 'auto',
         marginBottom: 0,
         borderBottom: 'none',
         fontSize: '0.75em',


### PR DESCRIPTION
## Summary

- neutralize the global Ant reset collision that collapses MUI outlined legends
- keep the shared field contract in both `MuiFormField` and `fieldSx`
- force date labels to shrink before focus so placeholders remain readable

Closes #800

## Verification

- [x] shared field unit tests
- [x] Document Master Data tests
- [x] full test suite (1,887 tests)
- [x] ESLint, formatting, app build, and Storybook build
- [ ] PreDev mobile, tablet, and desktop screenshots

## Reviewer test plan

- [ ] Verify the Login username outline before and after focus
- [ ] Verify Document Master Data date labels before and after focus
- [ ] Verify unrelated outlined MUI fields retain their normal notch behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outlined form field legend sizing to prevent width constraints.
  * Date input labels now shrink correctly even before the field receives focus.
  * Updated styling for more consistent label and outline display across form fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->