### PR TITLE
Unblock the Admin Stylelint quality gate

### DIFF
--- a/src/components/Dpia/styles.module.scss
+++ b/src/components/Dpia/styles.module.scss
@@ -15,6 +15,7 @@
     --dpia-success-ink: #075e26;
     --dpia-success-wash: #e8f3eb;
     --dpia-success-line: #b9dcc2;
+
     /* "Planned/not shipped" amber family, used by the appointment-module card
        and its badges. Named aliases so the shade is declared once instead of
        repeated as raw hex at every call site. */
@@ -316,6 +317,7 @@
 /** Chapters not yet ported into this view (see AVAILABLE_CHAPTER_IDS) — shown
     for orientation but not a link, so there is nothing for the anchor to fail
     to reach. */
+
 .chipDisabled {
     border-color: var(--dpia-hair-soft);
     color: var(--m3-on-surface-variant, #444748);

--- a/src/pages/GlobalSettings/styles.module.scss
+++ b/src/pages/GlobalSettings/styles.module.scss
@@ -13,6 +13,7 @@
 
 /* ORISO-Admin#735: the document master data card has four field groups, so it takes the
    full width of the grid rather than sharing a row. */
+
 .documentMasterDataCardSlot {
     min-width: 0;
     grid-column: 1 / -1;


### PR DESCRIPTION
## Summary

- add the three missing blank lines in the existing DPia and Global Settings stylesheets
- unblock the shared Stylelint gate before the Admin UI regression PRs are evaluated
- keep this prerequisite maintenance change separate from the three product fixes

Refs #799

## Verification

- [x] targeted DPia and Global Settings Stylelint has zero errors
- [x] no runtime or rendered-style behavior changes

## Reviewer test plan

- [ ] Confirm the diff is formatting-only
- [ ] Confirm the full style gate proceeds past the former DPia errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved stylesheet formatting by adding spacing for readability.
  * No user-visible styling or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->