### PR TITLE
fix: preserve platform tenant branding id

### DIFF
--- a/src/components/Tenants/GeneralSettings/index.tsx
+++ b/src/components/Tenants/GeneralSettings/index.tsx
@@ -16,6 +16,7 @@ import { NameAndSlogan } from './components/NameAndSlogan';
 import { ThemeBuilder } from './components/ThemeBuilder';
 import { TypeOfLanguage } from './components/TypeOfLanguage';
 import { AppConfigInterface } from '../../../types/AppConfigInterface';
+import { resolveTenantId } from '../../../utils/resolveTenantId';
 import styles from './styles.module.scss';
 
 /**
@@ -52,7 +53,7 @@ const setStoredAppearanceAllowed = (value: boolean) => {
 export const GeneralSettings = ({ tenantId, section = 'all' }: GeneralSettingsProps) => {
     const { t } = useTranslation();
     const { data } = useTenantData();
-    const finalTenantId = tenantId || `${data?.id || ''}`;
+    const finalTenantId = resolveTenantId(tenantId, data?.id);
     const { can } = useUserPermissions();
     const { isSuperAdmin } = useUserRoles();
     const showAppearance = section === 'all' || section === 'appearance';

--- a/src/pages/GlobalSettings/index.tsx
+++ b/src/pages/GlobalSettings/index.tsx
@@ -24,6 +24,7 @@ import { sendGlobalSmtpTestEmail } from '../../api/settings/sendGlobalSmtpTestEm
 import { TranslationApiKeysCardContainer } from '../../components/GlobalSettings/TranslationApiKeysCardContainer';
 import { DocumentMasterDataCardContainer } from '../../components/GlobalSettings/DocumentMasterDataCardContainer';
 import styles from './styles.module.scss';
+import { resolveTenantId } from '../../utils/resolveTenantId';
 import { extractApiErrorMessage } from '../../utils/extractApiErrorMessage';
 
 export const GlobalSettingsPage = () => {
@@ -50,8 +51,11 @@ export const GlobalSettingsPage = () => {
 export const GlobalLoginSettingsPage = () => {
     const { t } = useTranslation();
     const { data, isLoading } = useTenantData();
-    const tenantId = data?.id ? `${data.id}` : '';
-    const seedTenantAdminData = useMemo(() => (data?.id ? mapTenantDataToTenantAdminData(data) : undefined), [data]);
+    const tenantId = resolveTenantId(undefined, data?.id);
+    const seedTenantAdminData = useMemo(
+        () => (data?.id == null ? undefined : mapTenantDataToTenantAdminData(data)),
+        [data],
+    );
     const { mutate } = useTenantAdminDataMutation({
         id: tenantId,
         seedTenantAdminData,

--- a/src/utils/resolveTenantId.test.ts
+++ b/src/utils/resolveTenantId.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTenantId } from './resolveTenantId';
+
+describe('resolveTenantId', () => {
+    it('preserves the technical platform tenant id', () => {
+        expect(resolveTenantId(undefined, 0)).toBe('0');
+    });
+
+    it('prefers an explicitly selected tenant', () => {
+        expect(resolveTenantId('42', 0)).toBe('42');
+    });
+
+    it('returns an empty value only when neither id exists', () => {
+        expect(resolveTenantId(undefined, undefined)).toBe('');
+    });
+});

--- a/src/utils/resolveTenantId.ts
+++ b/src/utils/resolveTenantId.ts
@@ -1,0 +1,7 @@
+/** Converts a tenant id to the route value without treating platform id 0 as absent. */
+export const resolveTenantId = (explicitTenantId?: string, loadedTenantId?: number | null): string => {
+    if (explicitTenantId !== undefined && explicitTenantId !== '') {
+        return explicitTenantId;
+    }
+    return loadedTenantId === null || loadedTenantId === undefined ? '' : `${loadedTenantId}`;
+};


### PR DESCRIPTION
## Summary

- preserve tenant id 0 when resolving the active settings tenant
- use the same resolver in tenant appearance and global login settings
- avoid treating platform tenant id 0 as missing seed data

## Verification

- targeted Vitest suites: 5 tests green
- ESLint green
- production build green
- Prettier and `git diff --check` green

The full Admin suite still reports pre-existing slow failures in the unrelated MuiSelectField and M3RichTextEditor version suites.

## Dependency

Effective inherited values are provided by OpenResilienceInitiative/ORISO-TenantService#214.

Refs #81