### PR TITLE
Refine permission-card hierarchy and neutral info icon

### DIFF
--- a/src/components/IconCatalog/iconCatalog.generated.json
+++ b/src/components/IconCatalog/iconCatalog.generated.json
@@ -1036,7 +1036,11 @@
         "fileName": "i.svg",
         "sourcePath": "src/resources/img/svg/i.svg",
         "exportNames": [],
-        "usageFiles": ["src/components/Card/index.tsx", "src/components/TwoFactorSetup/TwoFactorAuthTypeButtons.tsx"],
+        "usageFiles": [
+            "src/components/Card/index.tsx",
+            "src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettingsView.tsx",
+            "src/components/TwoFactorSetup/TwoFactorAuthTypeButtons.tsx"
+        ],
         "usage": "app-used"
     },
     {

--- a/src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettings.stories.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettings.stories.tsx
@@ -77,6 +77,43 @@ export const TenantView: Story = {
     },
 };
 
+/** Focused visual contract for the generic permission-card anatomy:
+ *  feature icon + title, leading neutral info copy, then the master switch. */
+export const OneOnOneCardHierarchy: Story = {
+    args: {
+        excludeCardKeys: ['liveChat', 'group', 'groupInternal'],
+        initialValues: { settings: filledSettings },
+    },
+    play: async ({ canvasElement, step }) => {
+        const canvas = within(canvasElement);
+
+        await step('description leads with a neutral 16px info icon', async () => {
+            const title = await canvas.findByRole('heading', { name: '1 zu 1 Beratungen' });
+            const cardItem = title.closest('[data-admin-card-deck-item]');
+            expect(cardItem).not.toBeNull();
+
+            const card = within(cardItem as HTMLElement);
+            const description = card.getByText(/Ratsuchende finden lokale Beratende/).closest('p');
+            const infoIcon = description?.firstElementChild;
+
+            expect(description).not.toBeNull();
+            expect(infoIcon?.tagName).toBe('svg');
+            expect(getComputedStyle(infoIcon as Element).width).toBe('16px');
+            expect(getComputedStyle(infoIcon as Element).color).toBe('rgb(68, 71, 72)');
+        });
+
+        await step('description appears before the activated switch', async () => {
+            const title = canvas.getByRole('heading', { name: '1 zu 1 Beratungen' });
+            const cardItem = title.closest('[data-admin-card-deck-item]') as HTMLElement;
+            const card = within(cardItem);
+            const description = card.getByText(/Ratsuchende finden lokale Beratende/).closest('p') as HTMLElement;
+            const activated = card.getByRole('switch', { name: 'Aktiviert' });
+
+            expect(description.compareDocumentPosition(activated)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+        });
+    },
+};
+
 /** Live-chat module switched off: its sub-toggles (video, audio, voice, …)
  *  are locked off while the master is off — "disable, don't hide". */
 export const LiveChatMasterOff: Story = {

--- a/src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettingsView.test.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettingsView.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { SVGProps } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PermissionsSettingsView } from './PermissionsSettingsView';
 
@@ -26,6 +27,9 @@ vi.mock('../../../../resources/img/svg/permissions/one_on_one.svg', () => ({ Rea
 vi.mock('../../../../resources/img/svg/permissions/live_chat.svg', () => ({ ReactComponent: () => null }));
 vi.mock('../../../../resources/img/svg/permissions/group.svg', () => ({ ReactComponent: () => null }));
 vi.mock('../../../../resources/img/svg/permissions/group_internal.svg', () => ({ ReactComponent: () => null }));
+vi.mock('../../../../resources/img/svg/i.svg', () => ({
+    ReactComponent: (props: SVGProps<SVGSVGElement>) => <svg data-testid="permission-description-info" {...props} />,
+}));
 
 const MASTER = ['settings', 'featureCallsEnabled'];
 const VIDEO = ['settings', 'featureVideoCallsOneOnOneChatsEnabled'];
@@ -53,6 +57,21 @@ const renderOneOnOne = (initialSettings: Record<string, boolean>, onToggleUpdate
 };
 
 describe('PermissionsSettingsView data parity (1-on-1 card)', () => {
+    it('orders the title, leading description info, and activated control for quick scanning', () => {
+        renderOneOnOne({ featureCallsEnabled: true });
+
+        const title = screen.getByRole('heading', { name: 'tenants.permissions.card.oneOnOne.title' });
+        const description = screen.getByText('tenants.permissions.card.oneOnOne.description').closest('p');
+        const descriptionInfo = screen.getByTestId('permission-description-info');
+        const activated = screen.getByRole('switch', { name: 'tenants.permissions.card.activated' });
+
+        expect(description).not.toBeNull();
+        expect(description?.firstElementChild).toBe(descriptionInfo);
+        expect(descriptionInfo).toHaveAttribute('aria-hidden', 'true');
+        expect(title.compareDocumentPosition(description as Node)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+        expect((description as Node).compareDocumentPosition(activated)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    });
+
     it('reads: master + child toggles reflect initialValues', () => {
         renderOneOnOne({ featureCallsEnabled: true, featureVideoCallsOneOnOneChatsEnabled: false });
 

--- a/src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettingsView.tsx
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/PermissionsSettingsView.tsx
@@ -11,6 +11,7 @@ import { CheckToggle } from './CheckToggle';
 import { M3Checkbox } from '../../../M3Checkbox';
 import { isSubToggleDisabled } from './permissionsSettingsUtils';
 import { runtimeConfig } from '../../../../config/runtimeConfig';
+import { ReactComponent as InfoIcon } from '../../../../resources/img/svg/i.svg';
 import type {
     ChatTypeCardKey,
     EnforceChangeHandler,
@@ -127,6 +128,21 @@ export const PermissionsSettingsView = ({
                                                     ) : undefined
                                                 }
                                             >
+                                                <p className={styles.cardDescription}>
+                                                    <InfoIcon
+                                                        aria-hidden="true"
+                                                        className={styles.cardDescriptionInfo}
+                                                        focusable="false"
+                                                    />
+                                                    <Trans
+                                                        i18nKey={card.descriptionKey}
+                                                        components={{
+                                                            strong: <strong />,
+                                                            small: <span className={styles.cardDescriptionSecondary} />,
+                                                        }}
+                                                    />
+                                                </p>
+
                                                 <div className={styles.masterRow}>
                                                     {enforceMode && masterField && (
                                                         <M3Checkbox
@@ -154,16 +170,6 @@ export const PermissionsSettingsView = ({
                                                         </span>
                                                     )}
                                                 </div>
-
-                                                <p className={styles.cardDescription}>
-                                                    <Trans
-                                                        i18nKey={card.descriptionKey}
-                                                        components={{
-                                                            strong: <strong />,
-                                                            small: <span className={styles.cardDescriptionSecondary} />,
-                                                        }}
-                                                    />
-                                                </p>
 
                                                 <div className={styles.cardDivider} />
 

--- a/src/components/Tenants/AppSettings/PermissionsSettings/styles.module.scss
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/styles.module.scss
@@ -157,6 +157,15 @@
     }
 }
 
+.cardDescriptionInfo {
+    width: 16px;
+    height: 16px;
+    margin: 4px 8px 2px 0;
+    color: var(--admin-form-muted-text, var(--m3-on-surface-variant, #444748));
+    fill: currentcolor;
+    float: left;
+}
+
 .cardDescriptionSecondary {
     display: block;
     margin-top: 14px;

--- a/src/components/Tenants/AppSettings/PermissionsSettings/styles.test.ts
+++ b/src/components/Tenants/AppSettings/PermissionsSettings/styles.test.ts
@@ -18,4 +18,13 @@ describe('PermissionsSettings responsive card contract', () => {
         expect(permissionsStyles).toMatch(/@media screen and \(max-width:\s*767px\)[\s\S]*max-height:\s*none;/);
         expect(permissionsStyles).toMatch(/@media screen and \(max-width:\s*767px\)[\s\S]*overflow:\s*visible;/);
     });
+
+    it('wraps the description around a neutral 16px leading info icon', () => {
+        expect(permissionsStyles).toMatch(/\.cardDescriptionInfo\s*\{[\s\S]*?width:\s*16px;/);
+        expect(permissionsStyles).toMatch(/\.cardDescriptionInfo\s*\{[\s\S]*?height:\s*16px;/);
+        expect(permissionsStyles).toMatch(/\.cardDescriptionInfo\s*\{[\s\S]*?float:\s*left;/);
+        expect(permissionsStyles).toMatch(
+            /\.cardDescriptionInfo\s*\{[\s\S]*?color:\s*var\(--admin-form-muted-text,\s*var\(--m3-on-surface-variant,\s*#444748\)\);/,
+        );
+    });
 });


### PR DESCRIPTION
## Summary

- keep the Permission Card surface on the existing `#EAE7E8` Admin token
- place the full description before the `Activated` master row
- lead the description with the shared neutral 16 px info icon and let copy wrap around it
- add focused component, style, and Storybook regression coverage

## Why

The master control previously interrupted the reading hierarchy between the card title and its explanation. The card also lacked the neutral information cue used for descriptive Admin content.

## Scope

This changes only the generic Permission Settings cards. It does not migrate other Admin surfaces or alter permission behavior, translations, card titles, or the existing 40 px feature icons.

## Validation

- `npx vitest run ...PermissionsSettingsView.test.tsx .../styles.test.ts src/utils/applyAdminTheme.test.ts` — 38/38 passed
- `npm run build` — passed
- `npm run build-storybook` — passed
- targeted ESLint and Prettier — passed
- targeted Stylelint — 0 errors; 48 pre-existing warnings outside the new block
- responsive local Storybook inspection — 390×844, 820×1180, and 1440×900

Two full-suite attempts under concurrent machine load hit the existing 30-second timeout in unrelated Invite, DSFA, and Onboarding tests. No Permission Settings test failed. The focused suite and both production builds pass on the rebased commit.

Visual evidence is published in the PR evidence comment.

### Reviewer test plan

- [ ] Open the focused Permission Settings story at 390×844 → title and feature icon remain at the top and all description text is readable.
- [ ] Inspect the description at 820×1180 → the neutral 16 px info icon leads the copy and the text wraps without overlap.
- [ ] Inspect the card at 1440×900 → `Activated` appears below the description and before configurable features.
- [ ] Compare German and English descriptions → neither locale clips or changes the intended hierarchy.
- [ ] Inspect the accessibility tree → the description remains readable and the decorative info icon is hidden from assistive technology.
- [ ] Compare the card surface with the Admin token → it remains `#EAE7E8`.

Closes OpenResilienceInitiative/ORISO-Admin#808
