### PR TITLE
Scope privacy and imprint history to the selected department

### DIFF
--- a/src/api/legal/getLegalTextVersions.test.ts
+++ b/src/api/legal/getLegalTextVersions.test.ts
@@ -21,34 +21,40 @@ import { getLegalTextVersions, legalTextVersionsUrl } from './getLegalTextVersio
 
 beforeEach(() => fetchData.mockClear());
 
+/**
+ * The URLs are the ones ORISO-AgencyService#256 actually serves: ONE `legal-versions`
+ * collection per level, with the document chosen by a `kind` query parameter — not a
+ * path segment per document, which is what this client guessed before the contract
+ * existed.
+ */
 describe('legalTextVersionsUrl', () => {
-    it('addresses the Träger level on the tenant service', () => {
-        expect(legalTextVersionsUrl({ level: 'tenant', tenantId: 7, kind: 'privacy' })).toBe(
-            '/service/tenantadmin/7/legal/privacy/versions',
-        );
-    });
-
     it('addresses the Beratungsstelle level on the agency service', () => {
-        expect(legalTextVersionsUrl({ level: 'agency', agencyId: 12, kind: 'dpp' })).toBe(
-            '/service/agencyadmin/agencies/12/dpp/versions',
+        expect(legalTextVersionsUrl({ level: 'agency', agencyId: 12, kind: 'DPP' })).toBe(
+            '/service/agencyadmin/agencies/12/legal-versions?kind=DPP',
         );
     });
 
     it('addresses the Fachbereich level as agency × topic', () => {
-        expect(legalTextVersionsUrl({ level: 'department', agencyId: 12, topicId: 3, kind: 'imprint' })).toBe(
-            '/service/agencyadmin/agencies/12/topics/3/imprint/versions',
+        expect(legalTextVersionsUrl({ level: 'department', agencyId: 12, topicId: 3, kind: 'IMPRINT' })).toBe(
+            '/service/agencyadmin/agencies/12/topics/3/legal-versions?kind=IMPRINT',
+        );
+    });
+
+    it('addresses the Träger level on the tenant service', () => {
+        expect(legalTextVersionsUrl({ level: 'tenant', tenantId: 7, kind: 'DPP' })).toBe(
+            '/service/tenantadmin/7/legal-versions?kind=DPP',
         );
     });
 });
 
 describe('getLegalTextVersions', () => {
-    const scope = { level: 'department', agencyId: 12, topicId: 3, kind: 'dpp' } as const;
+    const scope = { level: 'department', agencyId: 12, topicId: 3, kind: 'DPP' } as const;
 
     it('GETs with auth and silent error handling (a missing history must not toast)', () => {
         getLegalTextVersions(scope);
         expect(fetchData).toHaveBeenCalledWith(
             expect.objectContaining({
-                url: '/service/agencyadmin/agencies/12/topics/3/dpp/versions',
+                url: '/service/agencyadmin/agencies/12/topics/3/legal-versions?kind=DPP',
                 method: 'GET',
                 skipAuth: false,
                 responseHandling: ['NO_MATCH', 'CATCH_ALL_SILENT', 'FORBIDDEN_SILENT'],

--- a/src/api/legal/getLegalTextVersions.ts
+++ b/src/api/legal/getLegalTextVersions.ts
@@ -37,10 +37,10 @@ export const legalTextVersionsUrl = (scope: LegalVersionScope): string => {
  * admin answering "which policy was in force in March" must not be told "none"
  * because a 403 or a 500 was swallowed.
  *
- * The one failure folded into "empty" is 404: ORISO-AgencyService#256 is not merged
- * and the Träger level has no endpoint at all, so a level legitimately has no history
- * yet, and an error banner on four cards would be noise about a feature that has not
- * shipped.
+ * The one failure folded into "empty" is 404: the Träger level has no endpoint at all,
+ * and ORISO-AgencyService#256 is merged but not yet deployed everywhere, so a level
+ * legitimately has no history yet and an error banner on four cards would be noise
+ * about a feature that has not reached that environment.
  */
 export const getLegalTextVersions = (scope: LegalVersionScope): Promise<LegalTextVersion[]> =>
     (

--- a/src/api/legal/getLegalTextVersions.ts
+++ b/src/api/legal/getLegalTextVersions.ts
@@ -5,26 +5,26 @@ import { FETCH_ERRORS, FETCH_METHODS, fetchData } from '../fetchData';
 /**
  * Client for the generic legal-text version history (ADR-021 decision 3).
  *
- * TODO(#250): the endpoints are being built in ORISO-AgencyService on branch
- * `feat/legal-text-versioning-250` (PR against
- * OpenResilienceInitiative/ORISO-AgencyService#250). The paths and the DTO below
- * mirror the AVV blueprint (`GET /tenantadmin/{id}/dpa/versions`,
- * `DpaVersionDTO { activationDate, content }`) extended by the legal-text kind and
- * the optional `consentText` field. This module is deliberately the ONLY place
- * that knows the URLs, so aligning with the merged backend contract is a one-file
- * change. Until the endpoints exist the hook degrades to "no history" — see
- * `useLegalTextVersions`.
+ * The agency and department URLs are the ones ORISO-AgencyService#256 serves: one
+ * `legal-versions` collection per level, with the document selected by `?kind=`
+ * rather than by a path segment per document. This module is deliberately the ONLY
+ * place that knows the URLs.
+ *
+ * The Träger level is NOT covered by that contract — #256 states levels 1-2 live in
+ * ORISO-TenantService and their history has yet to be built there (its known gap 2).
+ * The tenant URL below therefore still anticipates a shape rather than matching one,
+ * and until it exists the request 404s and the hook degrades to "no history".
  */
 export const legalTextVersionsUrl = (scope: LegalVersionScope): string => {
     switch (scope.level) {
         case 'tenant':
             // Träger level lives in the TenantService, next to the DPA history it copies.
-            return `${tenantAdminEndpoint}/${scope.tenantId}/legal/${scope.kind}/versions`;
+            return `${tenantAdminEndpoint}/${scope.tenantId}/legal-versions?kind=${scope.kind}`;
         case 'agency':
-            return `${agencyEndpointBase}/${scope.agencyId}/${scope.kind}/versions`;
+            return `${agencyEndpointBase}/${scope.agencyId}/legal-versions?kind=${scope.kind}`;
         case 'department':
         default:
-            return `${agencyEndpointBase}/${scope.agencyId}/topics/${scope.topicId}/${scope.kind}/versions`;
+            return `${agencyEndpointBase}/${scope.agencyId}/topics/${scope.topicId}/legal-versions?kind=${scope.kind}`;
     }
 };
 
@@ -37,9 +37,10 @@ export const legalTextVersionsUrl = (scope: LegalVersionScope): string => {
  * admin answering "which policy was in force in March" must not be told "none"
  * because a 403 or a 500 was swallowed.
  *
- * The one failure folded into "empty" is 404: until the generic endpoints of #250
- * are deployed every level legitimately has no history, and an error banner on
- * four cards would be noise about a feature that has not shipped yet.
+ * The one failure folded into "empty" is 404: ORISO-AgencyService#256 is not merged
+ * and the Träger level has no endpoint at all, so a level legitimately has no history
+ * yet, and an error banner on four cards would be noise about a feature that has not
+ * shipped.
  */
 export const getLegalTextVersions = (scope: LegalVersionScope): Promise<LegalTextVersion[]> =>
     (

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -62,8 +62,15 @@ import styles from './M3RichTextEditor.module.scss';
 
 /** A saved, published version the editor can look back at (read-only). */
 export type EditorVersion = {
-    /** Stable id (e.g. the activation timestamp). */
+    /** Stable id (the AVV uses its activation timestamp, ADR-021 a surrogate id). */
     id: string;
+    /**
+     * When this version came into force (ISO). ADR-021 histories key a version by a
+     * surrogate id, so the date has to travel separately — feeding an id like `42`
+     * to `new Date()` would date the version to the year 2042. Absent for the AVV,
+     * whose id IS its activation timestamp.
+     */
+    publishedAt?: string;
     /** Human label shown in the version menu (e.g. a formatted date). */
     label: string;
     /** The version's HTML content. */
@@ -787,7 +794,10 @@ export const M3RichTextEditor = ({
     if (!editor) return null;
 
     const html = () => (editorSlot || editor.isEmpty ? '' : editor.getHTML());
-    const onlineSinceDate = versions.length > 0 ? parseVersionDate(versions[versions.length - 1].id) : null;
+    // Prefer the explicit publication timestamp; fall back to the id for the AVV,
+    // where the id is that timestamp.
+    const versionDate = (version: EditorVersion) => parseVersionDate(version.publishedAt ?? version.id);
+    const onlineSinceDate = versions.length > 0 ? versionDate(versions[versions.length - 1]) : null;
     // Read mode (published view / version look-back): text without box, outline
     // or padding (Figma 1261-51137). Only the built-in editor is restyled — an
     // editorSlot owns its own surface.
@@ -1028,9 +1038,8 @@ export const M3RichTextEditor = ({
                                                     ]
                                                   : []),
                                               ...versions.map((v, index) => {
-                                                  const from = parseVersionDate(v.id);
-                                                  const until =
-                                                      index > 0 ? parseVersionDate(versions[index - 1].id) : null;
+                                                  const from = versionDate(v);
+                                                  const until = index > 0 ? versionDate(versions[index - 1]) : null;
                                                   let range = v.label;
                                                   if (from && until) {
                                                       range = t('legal.m3Editor.versionRangePublished', {

--- a/src/components/FormPluginEditor/M3RichTextEditor.versions.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.versions.test.tsx
@@ -43,6 +43,49 @@ const openVersionMenu = async (user: ReturnType<typeof userEvent.setup>) => {
     await user.click(trigger);
 };
 
+/**
+ * ADR-021/ORISO-AgencyService#256 keys a legal-text version by a surrogate id and
+ * carries the publication timestamp beside it. The editor must date its entries
+ * from that timestamp — a numeric id fed to `new Date()` yields a year.
+ */
+describe('M3RichTextEditor — version dates from publishedAt (#812)', () => {
+    const surrogate = [
+        { id: '42', publishedAt: '2026-07-01T10:00', label: 'Juli', content: '<p>Fassung Juli</p>' },
+        { id: '17', publishedAt: '2026-05-02T09:00', label: 'Mai', content: '<p>Fassung Mai</p>' },
+    ];
+
+    it('reports online-since from the oldest publication date, not from its id', async () => {
+        const user = userEvent.setup();
+        render(
+            <M3RichTextEditor title="Datenschutz" value="<p>Entwurf</p>" versions={surrogate} enableAnchors={false} />,
+        );
+
+        await openVersionMenu(user);
+
+        const oldest = parseVersionDate('2026-05-02T09:00')!;
+        const formatted = `${oldest.toLocaleDateString('de', {
+            day: '2-digit',
+            month: '2-digit',
+            year: '2-digit',
+        })} | ${oldest.toLocaleTimeString('de', { hour: '2-digit', minute: '2-digit' })} Uhr`;
+        expect(await screen.findByText(`legal.m3Editor.versionOnlineSince:${formatted}`)).toBeInTheDocument();
+    });
+
+    it('dates the published range from publishedAt', async () => {
+        const user = userEvent.setup();
+        render(
+            <M3RichTextEditor title="Datenschutz" value="<p>Entwurf</p>" versions={surrogate} enableAnchors={false} />,
+        );
+
+        await openVersionMenu(user);
+
+        // Variant #1 is the older entry: published on 02.05., superseded on 01.07.
+        expect(
+            await screen.findByText(/legal\.m3Editor\.versionRangePublished:02\.05\.26.*01\.07\.26/),
+        ).toBeInTheDocument();
+    });
+});
+
 describe('M3RichTextEditor — version select (#268)', () => {
     it('parses date-only ids as the same local calendar date', () => {
         const parsed = parseVersionDate('2026-07-01');

--- a/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.test.tsx
@@ -30,6 +30,10 @@ vi.mock('../../../../../hooks/useTranslateLegalContent.hook', () => ({
 vi.mock('../../../../../hooks/useUserPermission', () => ({
     useUserPermissions: () => ({ can: h.canEditLegalText, permissions: {} }),
 }));
+// The department-scoped history has its own suite (AgencyLegalTextContainer.versions.test.tsx).
+vi.mock('../../../../../hooks/useLegalTextVersions.hook', () => ({
+    useLegalTextVersions: () => ({ data: [], isError: false }),
+}));
 vi.mock('../DepartmentDataProtectionCard', () => ({
     DepartmentDataProtectionCard: (props: any) => {
         h.card(props);

--- a/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.versions.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.versions.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LegalTextVersion } from '../../../../../types/legalVersion';
+
+const h = vi.hoisted(() => ({
+    useLegalTextVersions: vi.fn(),
+    card: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'de' } }),
+}));
+vi.mock('../../../../../hooks/useDepartmentDpp.hook', () => ({
+    useDepartmentDpp: () => ({ data: undefined, isLoading: false, isError: false, isSuccess: true }),
+}));
+vi.mock('../../../../../hooks/useDepartmentImprint.hook', () => ({
+    useDepartmentImprint: () => ({ data: undefined, isLoading: false, isError: false, isSuccess: true }),
+}));
+vi.mock('../../../../../hooks/usePublishDepartmentDpp.hook', () => ({
+    usePublishDepartmentDpp: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('../../../../../hooks/usePublishDepartmentImprint.hook', () => ({
+    usePublishDepartmentImprint: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('../../../../../hooks/useSingleTenantData', () => ({ useSingleTenantData: () => ({ data: undefined }) }));
+vi.mock('../../../../../hooks/useTenantAdminData.hook', () => ({ useTenantAdminData: () => ({ data: undefined }) }));
+vi.mock('../../../../../hooks/useTranslateLegalContent.hook', () => ({
+    useTranslateLegalContent: () => ({ translate: vi.fn() }),
+}));
+vi.mock('../../../../../hooks/useUserPermission', () => ({
+    useUserPermissions: () => ({ can: () => true, permissions: {} }),
+}));
+vi.mock('../../../../../hooks/useLegalTextVersions.hook', () => ({
+    useLegalTextVersions: h.useLegalTextVersions,
+}));
+vi.mock('../DepartmentDataProtectionCard', () => ({
+    DepartmentDataProtectionCard: (props: any) => {
+        h.card(props);
+        return <div data-testid="legal-editor">{props.departmentSlot}</div>;
+    },
+}));
+
+import { AgencyLegalTextContainer } from '.';
+
+const version = (id: number, ownerId: number, html: string): LegalTextVersion => ({
+    id,
+    kind: 'DPP',
+    ownerLevel: 'DEPARTMENT',
+    ownerId,
+    publishedAt: '2026-07-13T10:22:00Z',
+    content: JSON.stringify({ de: html }),
+});
+
+const agencyData: any = {
+    id: '55',
+    tenantId: '1',
+    topics: [
+        { id: 3, name: 'U25 Suizidprävention' },
+        { id: 4, name: 'Schuldnerberatung' },
+    ],
+    content: { privacy: { de: '<p>agency wide</p>' } },
+};
+
+const renderContainer = (field: 'privacy' | 'imprint' = 'privacy') =>
+    render(<AgencyLegalTextContainer agencyData={agencyData} field={field} onSaveAgencyWide={vi.fn()} />);
+
+const selectDepartment = async (name: string) => {
+    await userEvent.click(screen.getByRole('button', { name: /agency.legal.department.choose/i }));
+    await userEvent.click(await screen.findByText(name));
+};
+
+/** The last scope the container asked the history hook for. */
+const lastScope = () => h.useLegalTextVersions.mock.calls.at(-1)?.[0];
+
+/**
+ * #812: the Fachbereich switcher has to drive the privacy-policy and imprint
+ * histories. Versions of two departments must never be shown for one another —
+ * which means the request is scoped by the SELECTED department, not by the agency.
+ */
+describe('AgencyLegalTextContainer — department-scoped version history', () => {
+    beforeEach(() => {
+        h.card.mockReset();
+        h.useLegalTextVersions.mockReset().mockReturnValue({ data: [], isError: false });
+    });
+
+    it('asks for the agency-wide history while "Alle Fachbereiche" is selected', () => {
+        renderContainer();
+
+        expect(lastScope()).toEqual({ level: 'agency', agencyId: 55, kind: 'DPP' });
+    });
+
+    it('asks for the imprint history on the imprint editor', () => {
+        renderContainer('imprint');
+
+        expect(lastScope()).toEqual({ level: 'agency', agencyId: 55, kind: 'IMPRINT' });
+    });
+
+    it('scopes the history to the selected Fachbereich', async () => {
+        renderContainer();
+        await selectDepartment('U25 Suizidprävention');
+
+        expect(lastScope()).toEqual({ level: 'department', agencyId: 55, topicId: 3, kind: 'DPP' });
+    });
+
+    it('hands the card the versions of the selected department', async () => {
+        h.useLegalTextVersions.mockReturnValue({ data: [version(42, 3, '<p>U25</p>')], isError: false });
+
+        renderContainer();
+        await selectDepartment('U25 Suizidprävention');
+
+        expect(h.card.mock.calls.at(-1)?.[0].versions).toEqual([version(42, 3, '<p>U25</p>')]);
+    });
+
+    it('swaps the history when the admin switches departments — the two never mix', async () => {
+        h.useLegalTextVersions.mockImplementation((scope: any) =>
+            scope.level === 'department' && scope.topicId === 3
+                ? { data: [version(42, 3, '<p>U25</p>')], isError: false }
+                : { data: [version(77, 4, '<p>Schulden</p>')], isError: false },
+        );
+
+        renderContainer();
+        await selectDepartment('U25 Suizidprävention');
+        expect(h.card.mock.calls.at(-1)?.[0].versions).toEqual([version(42, 3, '<p>U25</p>')]);
+
+        await selectDepartment('Schuldnerberatung');
+
+        expect(lastScope()).toEqual({ level: 'department', agencyId: 55, topicId: 4, kind: 'DPP' });
+        expect(h.card.mock.calls.at(-1)?.[0].versions).toEqual([version(77, 4, '<p>Schulden</p>')]);
+    });
+
+    it('shows an empty history for a department that never published', async () => {
+        h.useLegalTextVersions.mockReturnValue({ data: [], isError: false });
+
+        renderContainer();
+        await selectDepartment('Schuldnerberatung');
+
+        expect(h.card.mock.calls.at(-1)?.[0].versions).toEqual([]);
+        expect(h.card.mock.calls.at(-1)?.[0].versionsUnavailable).toBe(false);
+    });
+
+    it('reports a failed history as unavailable rather than as "never published"', async () => {
+        h.useLegalTextVersions.mockReturnValue({ data: undefined, isError: true });
+
+        renderContainer();
+        await selectDepartment('U25 Suizidprävention');
+
+        expect(h.card.mock.calls.at(-1)?.[0].versionsUnavailable).toBe(true);
+    });
+});

--- a/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/index.tsx
@@ -7,11 +7,13 @@ import { usePublishDepartmentDpp } from '../../../../../hooks/usePublishDepartme
 import { usePublishDepartmentImprint } from '../../../../../hooks/usePublishDepartmentImprint.hook';
 import { useSingleTenantData } from '../../../../../hooks/useSingleTenantData';
 import { useTenantAdminData } from '../../../../../hooks/useTenantAdminData.hook';
+import { useLegalTextVersions } from '../../../../../hooks/useLegalTextVersions.hook';
 import { useTranslateLegalContent } from '../../../../../hooks/useTranslateLegalContent.hook';
 import { useUserPermissions } from '../../../../../hooks/useUserPermission';
 import { PermissionAction } from '../../../../../enums/PermissionAction';
 import { Resource } from '../../../../../enums/Resource';
 import { AgencyData } from '../../../../../types/agency';
+import { LegalTextKind } from '../../../../../types/legalVersion';
 import { DepartmentDataProtectionCard } from '../DepartmentDataProtectionCard';
 import { ALL_DEPARTMENTS, DepartmentSelect } from '../DepartmentSelect';
 import { getEditableLanguages, parseLegalContentMap } from '../../utils/legalContentLanguages';
@@ -29,6 +31,9 @@ interface AgencyLegalTextContainerProps {
 
 /** The agency-level content key differs from the department wording ("imprint" vs "impressum"). */
 const AGENCY_CONTENT_KEY: Record<LegalField, string> = { privacy: 'privacy', imprint: 'impressum' };
+
+/** The wire enum of the `kind` query parameter (ORISO-AgencyService#256). */
+const VERSION_KIND: Record<LegalField, LegalTextKind> = { privacy: 'DPP', imprint: 'IMPRINT' };
 
 /**
  * One legal-text editor per kind for the whole Beratungsstelle, with the Fachbereich chosen in the
@@ -101,6 +106,17 @@ export const AgencyLegalTextContainer = ({
     const dppQuery = useDepartmentDpp(agencyId, field === 'privacy' ? (topicId as number) : NaN);
     const imprintQuery = useDepartmentImprint(agencyId, field === 'imprint' ? (topicId as number) : NaN);
     const departmentQuery = field === 'privacy' ? dppQuery : imprintQuery;
+
+    // The publication history follows the switcher (#812): a Fachbereich shows its own
+    // versions, "Alle Fachbereiche" the agency-wide ones. Scoping the request itself —
+    // rather than filtering a shared list — is what makes it impossible for one
+    // department's wording to appear under another. Contract documents are untouched by
+    // this: they stay tenant-scoped in `DataProcessingAgreementContainer`.
+    const { data: versions = [], isError: versionsUnavailable } = useLegalTextVersions(
+        isDepartment
+            ? { level: 'department', agencyId, topicId: topicId as number, kind: VERSION_KIND[field] }
+            : { level: 'agency', agencyId, kind: VERSION_KIND[field] },
+    );
 
     const publishDpp = usePublishDepartmentDpp(agencyId, topicId as number);
     const publishImprint = usePublishDepartmentImprint(agencyId, topicId as number);
@@ -197,6 +213,8 @@ export const AgencyLegalTextContainer = ({
             initialContentByLanguage={contentByLanguage}
             languages={languages}
             publicationStatus={isDepartment ? departmentQuery.data?.publicationStatus : undefined}
+            versions={versions}
+            versionsUnavailable={versionsUnavailable}
             readOnly={!canEditLegalText}
             onSave={onSave}
             saving={saving || departmentPublish.isPending}

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.consent.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.consent.test.tsx
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DepartmentDataProtectionCard } from './index';
+import { LegalTextVersion } from '../../../../../types/legalVersion';
 
 vi.mock('react-i18next', () => ({
     useTranslation: () => ({
@@ -83,9 +84,20 @@ beforeAll(() => {
     });
 });
 
+/** ADR-021/ORISO-AgencyService#256: a version is identified by a surrogate id. */
+const version = (id: number, publishedAt: string, content: string, consentText?: string): LegalTextVersion => ({
+    id,
+    kind: 'DPP',
+    ownerLevel: 'DEPARTMENT',
+    ownerId: 3,
+    publishedAt,
+    content,
+    ...(consentText === undefined ? {} : { consentText }),
+});
+
 const versions = [
-    { activationDate: '2026-07-13T10:22:00Z', content: JSON.stringify({ de: '<p>neu</p>' }) },
-    { activationDate: '2026-05-02T09:00:00Z', content: JSON.stringify({ de: '<p>alt</p>' }) },
+    version(42, '2026-07-13T10:22:00Z', JSON.stringify({ de: '<p>neu</p>' })),
+    version(17, '2026-05-02T09:00:00Z', JSON.stringify({ de: '<p>alt</p>' })),
 ];
 
 describe('DepartmentDataProtectionCard — version look-back', () => {
@@ -179,16 +191,18 @@ describe('DepartmentDataProtectionCard — consent field', () => {
  */
 describe('DepartmentDataProtectionCard — consent follows the selected version', () => {
     const versionedConsent = [
-        {
-            activationDate: '2026-07-13T10:22:00Z',
-            content: JSON.stringify({ de: '<p>neu</p>' }),
-            consentText: JSON.stringify({ de: 'Neuer Satz mit {{legal_links}}.' }),
-        },
-        {
-            activationDate: '2026-05-02T09:00:00Z',
-            content: JSON.stringify({ de: '<p>alt</p>' }),
-            consentText: JSON.stringify({ de: 'Alter Satz mit {{legal_links}}.' }),
-        },
+        version(
+            42,
+            '2026-07-13T10:22:00Z',
+            JSON.stringify({ de: '<p>neu</p>' }),
+            JSON.stringify({ de: 'Neuer Satz mit {{legal_links}}.' }),
+        ),
+        version(
+            17,
+            '2026-05-02T09:00:00Z',
+            JSON.stringify({ de: '<p>alt</p>' }),
+            JSON.stringify({ de: 'Alter Satz mit {{legal_links}}.' }),
+        ),
     ];
 
     const renderCard = () =>
@@ -209,21 +223,21 @@ describe('DepartmentDataProtectionCard — consent follows the selected version'
         renderCard();
         expect(consentInput()).toHaveValue('Heutiger Satz mit {{legal_links}}.');
 
-        await userEvent.click(screen.getByRole('button', { name: 'view 2026-05-02T09:00:00Z' }));
+        await userEvent.click(screen.getByRole('button', { name: 'view 17' }));
 
         expect(consentInput()).toHaveValue('Alter Satz mit {{legal_links}}.');
     });
 
     it('makes the archived sentence read-only — the published chain is append-only', async () => {
         renderCard();
-        await userEvent.click(screen.getByRole('button', { name: 'view 2026-05-02T09:00:00Z' }));
+        await userEvent.click(screen.getByRole('button', { name: 'view 17' }));
 
         expect(consentInput()).toBeDisabled();
     });
 
     it('returns to the editable current sentence when the look-back ends', async () => {
         renderCard();
-        await userEvent.click(screen.getByRole('button', { name: 'view 2026-05-02T09:00:00Z' }));
+        await userEvent.click(screen.getByRole('button', { name: 'view 17' }));
         await userEvent.click(screen.getByRole('button', { name: 'back to draft' }));
 
         expect(consentInput()).toHaveValue('Heutiger Satz mit {{legal_links}}.');

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.versions.stories.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.versions.stories.tsx
@@ -19,19 +19,31 @@ type Story = StoryObj<typeof meta>;
 
 const versions = [
     {
-        activationDate: '2026-07-13T10:22:00Z',
+        id: 42,
+        kind: 'DPP' as const,
+        ownerLevel: 'DEPARTMENT' as const,
+        ownerId: 3,
+        publishedAt: '2026-07-13T10:22:00Z',
         content: JSON.stringify({
             de: '<h1>Datenschutzerklärung</h1><p>Fassung vom 13. Juli 2026 — aktuell online.</p>',
         }),
     },
     {
-        activationDate: '2026-05-02T09:00:00Z',
+        id: 17,
+        kind: 'DPP' as const,
+        ownerLevel: 'DEPARTMENT' as const,
+        ownerId: 3,
+        publishedAt: '2026-05-02T09:00:00Z',
         content: JSON.stringify({
             de: '<h1>Datenschutzerklärung</h1><p>Fassung vom 2. Mai 2026 — abgelöst.</p>',
         }),
     },
     {
-        activationDate: '2026-01-15T08:30:00Z',
+        id: 8,
+        kind: 'DPP' as const,
+        ownerLevel: 'DEPARTMENT' as const,
+        ownerId: 3,
+        publishedAt: '2026-01-15T08:30:00Z',
         content: JSON.stringify({
             de: '<h1>Datenschutzerklärung</h1><p>Erste veröffentlichte Fassung vom 15. Januar 2026.</p>',
         }),

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/index.tsx
@@ -89,9 +89,10 @@ interface DepartmentDataProtectionCardProps {
 /**
  * Editor card for a department's (Fachbereich = agency × topic) own data privacy policy
  * (Datenschutzerklärung) in the M3 editor shell. Mirrors the tenant DPA card but is
- * per-Fachbereich: it has no version history and offers both a draft-save and a publish
- * action, with the current status shown as a tag. Publishing offers to machine-translate
- * the source text into the other active languages.
+ * per-Fachbereich: it offers both a draft-save and a publish action, with the current
+ * status shown as a tag, and looks back at the publication history OF THAT Fachbereich —
+ * the container scopes `versions` to whatever the switcher selected (#812). Publishing
+ * offers to machine-translate the source text into the other active languages.
  */
 export const DepartmentDataProtectionCard = ({
     departmentName,

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionContainer/index.tsx
@@ -38,7 +38,7 @@ export const DepartmentDataProtectionContainer = ({
         level: 'department',
         agencyId,
         topicId,
-        kind: 'dpp',
+        kind: 'DPP',
     });
 
     const contentByLanguage = useMemo(() => parseLegalContentMap(data?.content), [data?.content]);

--- a/src/components/Tenants/LegalSettings/components/DepartmentImprintContainer/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentImprintContainer/index.tsx
@@ -29,7 +29,7 @@ export const DepartmentImprintContainer = ({
         level: 'department',
         agencyId,
         topicId,
-        kind: 'imprint',
+        kind: 'IMPRINT',
     });
     const contentByLanguage = useMemo(() => parseLegalContentMap(data?.content), [data?.content]);
     const languages = useMemo(

--- a/src/components/Tenants/LegalSettings/components/DepartmentSelect/DepartmentSelect.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentSelect/DepartmentSelect.test.tsx
@@ -68,6 +68,34 @@ describe('DepartmentSelect', () => {
 });
 
 /**
+ * #812: the menu opens on a header naming the choice being made, so the list of Fachbereich
+ * names is not left to speak for itself.
+ */
+describe('DepartmentSelect — menu header', () => {
+    it('names the choice at the top of the menu', async () => {
+        render(<DepartmentSelect departments={departments} value={ALL_DEPARTMENTS} onChange={vi.fn()} />);
+        await openMenu();
+
+        expect(await screen.findByText('Fachbereich auswählen')).toBeInTheDocument();
+    });
+
+    it('labels the options as a group instead of offering the header as an option', async () => {
+        const onChange = vi.fn();
+        render(<DepartmentSelect departments={departments} value={ALL_DEPARTMENTS} onChange={onChange} />);
+        await openMenu();
+
+        const header = await screen.findByText('Fachbereich auswählen');
+        // The header titles the group of options; a screen reader announces it as the
+        // group's name rather than as a further, unusable menu item.
+        expect(header.closest('[role="menuitem"]')).toBeNull();
+        expect(header.parentElement?.parentElement?.querySelector('[role="group"]')).not.toBeNull();
+
+        await userEvent.click(header);
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});
+
+/**
  * #583: an admin editing the agency-wide text has to see which Fachbereiche have left the
  * inherited text — they will NOT receive the correction being written.
  */

--- a/src/components/Tenants/LegalSettings/components/DepartmentSelect/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentSelect/index.tsx
@@ -34,6 +34,10 @@ interface DepartmentSelectProps {
  * department currently shows; publishing it breaks the inheritance and the department carries its
  * own text from then on (ADR-014 amendment 2026-07-28).
  *
+ * The menu opens on a header naming the choice (#812) — antd's own labelled group, the same
+ * pattern `DpiaSectionSelect` and `TemplateSplitButton` use on this control, so the header
+ * titles the options for a screen reader instead of sitting among them as an inert entry.
+ *
  * Departments that already left the inherited text are marked (#583): an admin editing the
  * agency-wide text has to see who will *not* receive the change — the one thing that matters when
  * a Beratungsstelle publishes a correction. The state comes from `departments[]` on the admin
@@ -66,35 +70,45 @@ export const DepartmentSelect = ({ departments, value, onChange }: DepartmentSel
                 selectedKeys: [String(value)],
                 items: [
                     {
-                        key: ALL_DEPARTMENTS,
-                        label: (
-                            <span className={styles.entry}>
-                                <span>{allLabel}</span>
-                                {withOwnText > 0 && (
-                                    <span className={styles.excludedHint} data-testid="departments-with-own-text">
-                                        {t('agency.legal.department.notInheriting', {
-                                            count: withOwnText,
-                                            defaultValue: '{{count}} mit eigenem Text',
-                                        })}
+                        key: 'department-choice',
+                        type: 'group' as const,
+                        label: t('agency.legal.department.menuHeader', 'Fachbereich auswählen'),
+                        children: [
+                            {
+                                key: ALL_DEPARTMENTS,
+                                label: (
+                                    <span className={styles.entry}>
+                                        <span>{allLabel}</span>
+                                        {withOwnText > 0 && (
+                                            <span
+                                                className={styles.excludedHint}
+                                                data-testid="departments-with-own-text"
+                                            >
+                                                {t('agency.legal.department.notInheriting', {
+                                                    count: withOwnText,
+                                                    defaultValue: '{{count}} mit eigenem Text',
+                                                })}
+                                            </span>
+                                        )}
                                     </span>
-                                )}
-                            </span>
-                        ),
+                                ),
+                            },
+                            { type: 'divider' as const },
+                            ...departments.map(({ id, name, hasOwnText }) => ({
+                                key: String(id),
+                                label: (
+                                    <span className={styles.entry}>
+                                        <span>{name}</span>
+                                        {hasOwnText && (
+                                            <span className={styles.ownTextTag} data-testid={`own-text-${id}`}>
+                                                {ownTextLabel}
+                                            </span>
+                                        )}
+                                    </span>
+                                ),
+                            })),
+                        ],
                     },
-                    { type: 'divider' as const },
-                    ...departments.map(({ id, name, hasOwnText }) => ({
-                        key: String(id),
-                        label: (
-                            <span className={styles.entry}>
-                                <span>{name}</span>
-                                {hasOwnText && (
-                                    <span className={styles.ownTextTag} data-testid={`own-text-${id}`}>
-                                        {ownTextLabel}
-                                    </span>
-                                )}
-                            </span>
-                        ),
-                    })),
                 ],
                 onClick: ({ key }) => onChange(key === ALL_DEPARTMENTS ? ALL_DEPARTMENTS : Number(key)),
             }}

--- a/src/components/Tenants/LegalSettings/components/LegalText/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalText/index.tsx
@@ -115,7 +115,7 @@ export const LegalText = ({
     // exactly as it did before. A genuine failure (403, 500, network) is NOT an
     // empty history and is reported as such.
     const { data: versions = [], isError: versionsUnavailable } = useLegalTextVersions(
-        { level: 'tenant', tenantId: Number(tenantId), kind: legalType === 'imprint' ? 'imprint' : 'privacy' },
+        { level: 'tenant', tenantId: Number(tenantId), kind: legalType === 'imprint' ? 'IMPRINT' : 'DPP' },
         !!legalType,
     );
     // Keeps the consent sentence on the same version as the body shown above it.

--- a/src/components/Tenants/LegalSettings/hooks/useViewedLegalVersion.test.tsx
+++ b/src/components/Tenants/LegalSettings/hooks/useViewedLegalVersion.test.tsx
@@ -1,0 +1,55 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LegalTextVersion } from '../../../../types/legalVersion';
+import { useViewedLegalVersion } from './useViewedLegalVersion';
+
+const versions: LegalTextVersion[] = [
+    {
+        id: 42,
+        kind: 'DPP',
+        ownerLevel: 'DEPARTMENT',
+        ownerId: 3,
+        publishedAt: '2026-07-13T10:22:00Z',
+        content: JSON.stringify({ de: '<p>neu</p>' }),
+        consentText: JSON.stringify({ de: 'Ich habe die {{legal_links}} gelesen.' }),
+    },
+    {
+        id: 17,
+        kind: 'DPP',
+        ownerLevel: 'DEPARTMENT',
+        ownerId: 3,
+        publishedAt: '2026-05-02T09:00:00Z',
+        content: JSON.stringify({ de: '<p>alt</p>' }),
+        consentText: JSON.stringify({ de: 'Alte Einwilligung {{legal_links}}.' }),
+    },
+];
+
+describe('useViewedLegalVersion', () => {
+    it('shows the draft until a version is picked', () => {
+        const { result } = renderHook(() => useViewedLegalVersion(versions));
+
+        expect(result.current.isViewingVersion).toBe(false);
+        expect(result.current.viewedConsent).toBeUndefined();
+    });
+
+    it('resolves the version the editor reports by its surrogate id', () => {
+        // The editor hands back `EditorVersion.id`, which is the surrogate id as a
+        // string (ORISO-AgencyService#256) — matching on a timestamp would never hit.
+        const { result } = renderHook(() => useViewedLegalVersion(versions));
+
+        act(() => result.current.onViewVersionChange('17'));
+
+        expect(result.current.isViewingVersion).toBe(true);
+        expect(result.current.viewedVersion?.id).toBe(17);
+        expect(result.current.viewedConsent).toEqual({ de: 'Alte Einwilligung {{legal_links}}.' });
+    });
+
+    it('drops back to the draft on reset', () => {
+        const { result } = renderHook(() => useViewedLegalVersion(versions));
+
+        act(() => result.current.onViewVersionChange('42'));
+        act(() => result.current.reset());
+
+        expect(result.current.isViewingVersion).toBe(false);
+    });
+});

--- a/src/components/Tenants/LegalSettings/hooks/useViewedLegalVersion.ts
+++ b/src/components/Tenants/LegalSettings/hooks/useViewedLegalVersion.ts
@@ -30,8 +30,10 @@ export interface ViewedLegalVersion {
 export const useViewedLegalVersion = (versions: LegalTextVersion[]): ViewedLegalVersion => {
     const [viewedVersionId, setViewedVersionId] = useState<string | null>(null);
 
+    // The editor reports `EditorVersion.id`, which is the surrogate id as a string
+    // (ORISO-AgencyService#256) — the version is resolved by that, never by a date.
     const viewedVersion = useMemo(
-        () => (viewedVersionId ? versions.find((version) => version.activationDate === viewedVersionId) : undefined),
+        () => (viewedVersionId ? versions.find((version) => String(version.id) === viewedVersionId) : undefined),
         [versions, viewedVersionId],
     );
 

--- a/src/components/Tenants/LegalSettings/utils/legalVersionOptions.test.ts
+++ b/src/components/Tenants/LegalSettings/utils/legalVersionOptions.test.ts
@@ -1,8 +1,18 @@
 import { describe, it, expect } from 'vitest';
+import { LegalTextVersion } from '../../../../types/legalVersion';
 import { formatLegalVersionLabel, toEditorVersions } from './legalVersionOptions';
 
+const version = (id: number, publishedAt: string, content: string): LegalTextVersion => ({
+    id,
+    kind: 'DPP',
+    ownerLevel: 'DEPARTMENT',
+    ownerId: 3,
+    publishedAt,
+    content,
+});
+
 describe('formatLegalVersionLabel', () => {
-    it('formats an ISO activation date in the given locale', () => {
+    it('formats an ISO publication date in the given locale', () => {
         expect(formatLegalVersionLabel('2026-07-13T10:22:00Z', 'de')).toMatch(/2026/);
     });
 
@@ -13,14 +23,22 @@ describe('formatLegalVersionLabel', () => {
 
 describe('toEditorVersions', () => {
     const versions = [
-        { activationDate: '2026-07-13T10:22:00Z', content: JSON.stringify({ de: '<p>neu</p>', en: '<p>new</p>' }) },
-        { activationDate: '2026-05-02T09:00:00Z', content: JSON.stringify({ de: '<p>alt</p>' }) },
+        version(42, '2026-07-13T10:22:00Z', JSON.stringify({ de: '<p>neu</p>', en: '<p>new</p>' })),
+        version(17, '2026-05-02T09:00:00Z', JSON.stringify({ de: '<p>alt</p>' })),
     ];
 
     it('shows the active language of every version', () => {
         const mapped = toEditorVersions(versions, 'de', 'de');
-        expect(mapped.map((version) => version.content)).toEqual(['<p>neu</p>', '<p>alt</p>']);
-        expect(mapped[0].id).toBe('2026-07-13T10:22:00Z');
+        expect(mapped.map((entry) => entry.content)).toEqual(['<p>neu</p>', '<p>alt</p>']);
+    });
+
+    it('keys an entry by the surrogate id and carries the date separately', () => {
+        // ADR-021/#256: identity is the surrogate id, never the timestamp. The editor
+        // formats its date ranges from `publishedAt`; reading a numeric id as a date
+        // would turn version 42 into the year 2042.
+        const mapped = toEditorVersions(versions, 'de', 'de');
+        expect(mapped[0]).toMatchObject({ id: '42', publishedAt: '2026-07-13T10:22:00Z' });
+        expect(mapped[1]).toMatchObject({ id: '17', publishedAt: '2026-05-02T09:00:00Z' });
     });
 
     it('falls back to the first stored language but forbids restoring it', () => {
@@ -38,11 +56,13 @@ describe('toEditorVersions', () => {
     });
 
     it('tolerates legacy plain-HTML content', () => {
-        const mapped = toEditorVersions(
-            [{ activationDate: '2026-01-01T00:00:00Z', content: '<p>legacy</p>' }],
-            'de',
-            'de',
-        );
+        const mapped = toEditorVersions([version(1, '2026-01-01T00:00:00Z', '<p>legacy</p>')], 'de', 'de');
         expect(mapped[0].content).toBe('<p>legacy</p>');
+    });
+
+    it('shows an empty page rather than crashing when a version carries no content', () => {
+        // `content` is nullable in the #256 DTO.
+        const mapped = toEditorVersions([{ ...version(1, '2026-01-01T00:00:00Z', ''), content: null }], 'de', 'de');
+        expect(mapped[0].content).toBe('');
     });
 });

--- a/src/components/Tenants/LegalSettings/utils/legalVersionOptions.ts
+++ b/src/components/Tenants/LegalSettings/utils/legalVersionOptions.ts
@@ -7,16 +7,18 @@ import { parseLegalContentMap } from './legalContentLanguages';
  * (ADR-021 decision 3). The mapping is the one the AVV card already performs
  * inline — extracted here because three more cards need exactly the same:
  *
- * - the id is the activation timestamp (the editor formats date ranges from it),
+ * - the id is the version's surrogate id (ORISO-AgencyService#256), and the
+ *   publication timestamp travels beside it, because the editor formats date
+ *   ranges from a date and a surrogate id is not one,
  * - the shown content is the ACTIVE language of that version, falling back to
  *   its first stored language so a look-back never shows an empty page,
  * - `restorable` is false for such a fallback: "adopt as new draft" would
  *   otherwise copy a foreign language into the language being edited.
  */
-export const formatLegalVersionLabel = (activationDate: string, locale: string): string => {
-    const date = new Date(activationDate);
+export const formatLegalVersionLabel = (publishedAt: string, locale: string): string => {
+    const date = new Date(publishedAt);
     return Number.isNaN(date.getTime())
-        ? activationDate
+        ? publishedAt
         : date.toLocaleString(locale, { dateStyle: 'medium', timeStyle: 'short' });
 };
 
@@ -29,9 +31,10 @@ export const toEditorVersions = (
 ): EditorVersion[] =>
     versions.map((version, index) => {
         const contentMap = parseLegalContentMap(version.content);
-        const dateLabel = formatLegalVersionLabel(version.activationDate, locale);
+        const dateLabel = formatLegalVersionLabel(version.publishedAt, locale);
         return {
-            id: version.activationDate,
+            id: String(version.id),
+            publishedAt: version.publishedAt,
             label: index === 0 && currentSuffix ? `${dateLabel} ${currentSuffix}` : dateLabel,
             content: contentMap[activeLanguage] ?? Object.values(contentMap)[0] ?? '',
             restorable: Object.prototype.hasOwnProperty.call(contentMap, activeLanguage),

--- a/src/hooks/usePublishDepartmentDpp.hook.test.tsx
+++ b/src/hooks/usePublishDepartmentDpp.hook.test.tsx
@@ -28,7 +28,7 @@ const setup = () => {
     return { result, invalidate };
 };
 
-const versionsKey = legalTextVersionsKey({ level: 'department', agencyId: AGENCY, topicId: TOPIC, kind: 'dpp' });
+const versionsKey = legalTextVersionsKey({ level: 'department', agencyId: AGENCY, topicId: TOPIC, kind: 'DPP' });
 
 beforeEach(() => publishDepartmentDpp.mockClear());
 

--- a/src/hooks/usePublishDepartmentDpp.hook.ts
+++ b/src/hooks/usePublishDepartmentDpp.hook.ts
@@ -25,7 +25,7 @@ export const usePublishDepartmentDpp = (agencyId: number, topicId: number) => {
             // save appends nothing, so its history is still current.
             if (publish) {
                 queryClient.invalidateQueries({
-                    queryKey: legalTextVersionsKey({ level: 'department', agencyId, topicId, kind: 'dpp' }),
+                    queryKey: legalTextVersionsKey({ level: 'department', agencyId, topicId, kind: 'DPP' }),
                 });
             }
         },

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1771,6 +1771,7 @@
     "agency.legal.department.notInheriting_one": "{{count}} mit eigenem Text",
     "agency.legal.department.notInheriting_other": "{{count}} mit eigenem Text",
     "agency.legal.department.choose": "Fachbereich wählen",
+    "agency.legal.department.menuHeader": "Fachbereich auswählen",
     "agency.legal.department.loadError.title": "Rechtstext konnte nicht geladen werden",
     "agency.legal.department.loadError.text": "Der Text für „{{name}}“ ist gerade nicht abrufbar. Bearbeiten ist gesperrt, damit der vorhandene Text nicht versehentlich durch den geerbten ersetzt wird.",
     "agency.legal.department.loadError.retry": "Erneut versuchen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1771,6 +1771,7 @@
     "agency.legal.department.notInheriting_one": "{{count}} with its own text",
     "agency.legal.department.notInheriting_other": "{{count}} with their own text",
     "agency.legal.department.choose": "Choose department",
+    "agency.legal.department.menuHeader": "Select department",
     "agency.legal.department.loadError.title": "Legal text could not be loaded",
     "agency.legal.department.loadError.text": "The text for \"{{name}}\" is currently unavailable. Editing is blocked so the existing text is not accidentally replaced by the inherited one.",
     "agency.legal.department.loadError.retry": "Try again",

--- a/src/pages/Agency/Edit/components/LegalTextSettings/index.tsx
+++ b/src/pages/Agency/Edit/components/LegalTextSettings/index.tsx
@@ -65,7 +65,7 @@ export const LegalTextSettings = ({ agencyData, field, onSave, saving }: LegalTe
     const { data: versions = [], isError: versionsUnavailable } = useLegalTextVersions({
         level: 'agency',
         agencyId: Number(agencyData?.id),
-        kind: isPrivacy ? 'dpp' : 'imprint',
+        kind: isPrivacy ? 'DPP' : 'IMPRINT',
     });
     // Keeps the consent sentence on the same version as the body shown above it.
     const {

--- a/src/types/legalVersion.ts
+++ b/src/types/legalVersion.ts
@@ -1,25 +1,43 @@
 /**
  * Generic legal-text version history (ADR-021 decision 3).
  *
- * The AVV/DPA mechanism (`tenant_dpa_version`, TenantService changeset 0018,
- * `GET /tenantadmin/{id}/dpa/versions`) is the blueprint — this is the same
- * shape, generalised over the legal-text kind and the four levels of the
- * ladder (platform operator → Träger → Beratungsstelle → Fachbereich).
+ * The shape is the `LegalTextVersionDTO` of ORISO-AgencyService#256, which
+ * generalises the AVV/DPA mechanism (`tenant_dpa_version`, TenantService
+ * changeset 0018) over the legal-text kind and the levels of the ladder
+ * (platform operator → Träger → Beratungsstelle → Fachbereich).
  */
 
 /**
- * Which legal text a version belongs to. The values are the path segments the
- * existing endpoints already use (`/topics/{id}/dpp`, `/topics/{id}/imprint`),
- * so the history endpoints stay consistent with the read/publish endpoints.
+ * Which legal text a version belongs to. The values are the wire enum of the
+ * `kind` query parameter, not path segments: #256 serves ONE `legal-versions`
+ * collection per level and selects the document with `?kind=`.
  */
-export type LegalTextKind = 'privacy' | 'imprint' | 'dpp';
+export type LegalTextKind = 'DPP' | 'IMPRINT';
+
+/**
+ * Which rung of the ADR-021 ladder owns a version. `SHARED` is an ADR-014 shared
+ * legal-text object. The Träger and platform levels are absent on purpose: #256
+ * states their history has to be built in ORISO-TenantService and does not exist
+ * yet (known gap 2 of that PR).
+ */
+export type LegalTextOwnerLevel = 'DEPARTMENT' | 'AGENCY' | 'SHARED';
 
 /** One archived, published legal-text version. Newest first in every list. */
 export interface LegalTextVersion {
-    /** Activation timestamp (ISO) — the stable id of this version. */
-    activationDate: string;
+    /**
+     * Surrogate identity of this version — the ONLY key a client may use.
+     * Deliberately not the publication timestamp: MariaDB `datetime` has no
+     * sub-second precision, and keying versions by their timestamp is what
+     * forced the AVV work to truncate to seconds and made equality matches fail
+     * silently (#256).
+     */
+    id: number;
+    kind: LegalTextKind;
+    ownerLevel: LegalTextOwnerLevel;
+    /** Id of the owning row, interpreted per `ownerLevel`. */
+    ownerId: number;
     /** Published content: JSON map language → HTML (legacy plain HTML tolerated). */
-    content: string;
+    content?: string | null;
     /**
      * The consent sentence that belonged to THIS version of the data-protection
      * policy (ADR-021 decision 4 — the consent text is a field of the DPP, not a
@@ -31,10 +49,19 @@ export interface LegalTextVersion {
      * distinction to decide whether to offer the consent field at all.
      */
     consentText?: string | null;
+    /** When this wording came into force (ISO). */
+    publishedAt: string;
+    /**
+     * Keycloak user id of the publisher, or null where none was recorded. Null is
+     * an honest unknown, never a guessed value.
+     */
+    publishedBy?: string | null;
+    /** When a newer version replaced this one; null = still in force. */
+    supersededAt?: string | null;
 }
 
 /** Which level (and which object on it) a version history is requested for. */
 export type LegalVersionScope =
-    | { level: 'tenant'; tenantId: number; kind: Extract<LegalTextKind, 'privacy' | 'imprint'> }
-    | { level: 'agency'; agencyId: number; kind: Extract<LegalTextKind, 'dpp' | 'imprint'> }
-    | { level: 'department'; agencyId: number; topicId: number; kind: Extract<LegalTextKind, 'dpp' | 'imprint'> };
+    | { level: 'tenant'; tenantId: number; kind: LegalTextKind }
+    | { level: 'agency'; agencyId: number; kind: LegalTextKind }
+    | { level: 'department'; agencyId: number; topicId: number; kind: LegalTextKind };


### PR DESCRIPTION
## What changed

- bind the Fachbereich switcher to the privacy-policy and imprint publication history: the selected department shows **its own** versions, `Alle Fachbereiche` the agency-wide ones
- open the department menu on a `Fachbereich auswählen` / `Select department` header
- align the version-history client with the contract in OpenResilienceInitiative/ORISO-AgencyService#256: one `legal-versions` collection per level with `?kind=DPP|IMPRINT`, and the `LegalTextVersionDTO` shape
- key a version by its surrogate id and carry `publishedAt` beside it in `EditorVersion`

## Why

The Admin reader had every piece of the history look-back except the wiring: `DepartmentDataProtectionCard` already accepts `versions` / `versionsUnavailable`, but `AgencyLegalTextContainer` — the only live consumer, rendered twice on the agency Legal tab — never passed them, so switching Fachbereich changed the text and left the version menu behind.

The history is requested **per selection** rather than fetched once and filtered. Scoping the request is what makes it structurally impossible for one department's wording to appear under another; a shared list plus a filter would put that guarantee in a predicate one refactor away from being wrong.

The version-history client that landed before the backend contract existed guessed its URLs (`/agencies/{id}/{kind}/versions`) and its DTO (`{ activationDate, content }`). #256 serves neither. Aligning it was not cosmetic: the editor derived every date by parsing `EditorVersion.id`, which is now a surrogate id — `new Date("42")` is the year 2042, so the "online since" header and every published range would have been silently wrong. Identity and date are now separate fields, which is the same separation #256 makes and for the same reason.

Contract documents are untouched. Their history is served by `DataProcessingAgreementContainer`, which takes a tenant id and has no department input at all, so tenant scoping is structural here rather than a rule someone has to remember.

### Design system

No new control. The switcher keeps the shared `SplitDropdown`, and the header is antd's own labelled menu group — the pattern `DpiaSectionSelect` and `TemplateSplitButton` already use on that same control. That was preferred over the disabled-menu-item headers inside `M3RichTextEditor`, because a header announced as an unavailable option is worse for a screen reader than one announced as the group's name.

## Contract status and assumptions

**ORISO-AgencyService#256 is merged** (`acc2c9c`, reviewed and merged as part of this work package). This PR is built against `api/agencyadminservice.yaml` as merged. Until it is deployed to a given environment every call 404s and `getLegalTextVersions` folds a 404 into an empty history, so the editors behave exactly as they do today — no version menu, nothing broken.

Left ambiguous by the contract, and what was assumed:

- **The Träger level has no endpoint.** #256 states levels 1-2 live in ORISO-TenantService and their history has yet to be built there (its known gap 2). The `tenant` scope keeps a URL in the same shape as the two contracted ones; it is a placeholder, marked as such in the code, and 404s today.
- **`ownerLevel` is typed as the contracted `DEPARTMENT | AGENCY | SHARED`.** No `TENANT` member was invented for the placeholder above.
- **`supersededAt` is not consumed.** The editor derives a version's end from the publication date of the next-newer entry, which is the same instant. The authoritative field is available should the two ever diverge.
- **`consentText` is carried through unchanged**; this PR does not alter the consent behaviour that landed with #811.

## Verification

Local only — **not deployed to Pre-Dev**, see below.

- `npm test` -> **1903 passed, 6 failed (285 files)**. The 6 are pre-existing on `pre-dev` and unrelated (storage mocking): verified by stashing this branch and running the same five files on clean `pre-dev`, which fails the identical set. This branch introduces no failure and adds 23 tests.
- `npx tsc --noEmit` -> clean
- `npm run typecheck:storybook` -> clean
- `npm run lint:js` -> clean
- `npm run lint:formatting` -> clean
- `npm run build` -> built in 20.16s
- `npm run build-storybook` -> completed successfully
- axe-core (WCAG 2.0/2.1/2.2 A + AA) over the opened department menu -> 0 violations
- `npm run lint:css` was not run: no stylesheet is touched by this PR.

### Reviewer test plan

- [ ] Open the department menu on the agency Legal tab -> a `Fachbereich auswählen` / `Select department` header sits above the options.
- [ ] Select department A, then department B -> the version menu changes to the selected department's versions; no entry of A appears under B.
- [ ] Select a department that never published -> the version menu says no version has been published, and shows nothing belonging to another department or to the agency.
- [ ] Switch back to `Alle Fachbereiche` -> the agency-wide history is shown, not the last department's.
- [ ] Do the same on the imprint editor -> it lists imprint versions, never privacy-policy ones.
- [ ] Open a version from the look-back -> the archived wording is shown read-only, and for a policy the consent sentence archived with it appears underneath.
- [ ] Open contract documents, switch department, look at the contract history -> unchanged; it is tenant-level and does not follow the switcher.
- [ ] Test as a counsellor assigned to several departments -> only authorised departments are selectable.
- [ ] Navigate the selector by keyboard and with a screen reader -> the control's role and name, the group header, the options and the selected value are announced.
- [ ] Repeat the switch on a narrow mobile viewport (375px) -> the menu header and the version control stay readable and reachable, and the card does not scroll horizontally.
- [ ] With the backend history not yet deployed -> the editors behave as before: no version menu, no error banner.

Closes #812
Refs #810 · OpenResilienceInitiative/ORISO-AgencyService#256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
