### PR TITLE
style(editor): 16px horizontal inset for the chapter-chip bar

### DIFF
--- a/src/components/FormPluginEditor/M3RichTextEditor.module.scss
+++ b/src/components/FormPluginEditor/M3RichTextEditor.module.scss
@@ -181,7 +181,11 @@ $m3-state-active: rgb(39 50 112 / 12%);
         position: sticky;
         z-index: 2;
         bottom: 0;
-        padding: 16px 0 8px;
+
+        /* 16px inset left and right: the chips are a control strip, not body
+           text — flush with the text edge they read as clipped (owner request
+           2026-08-18). */
+        padding: 16px 16px 8px;
         border-top: 1px solid var(--m3-outline-variant, #c4c7c8);
 
         /* The ONE surface tone of the public page (#594.12) — the bar has to be
@@ -580,7 +584,10 @@ $m3-state-active: rgb(39 50 112 / 12%);
 // .RichEditor-anchorNav base rules regardless of bundle order.
 .editor .anchorNav {
     flex-shrink: 0;
-    padding: 16px 0 0;
+
+    // 16px inset left and right, matching the fluid reader's bar (owner
+    // request 2026-08-18): chips must not sit flush with the text edge.
+    padding: 16px 16px 0;
     background: #ffffff;
     border-bottom: 0;
 


### PR DESCRIPTION
## Why

Owner report (2026-08-18): the chapter-chip bar in the legal-document reader needs more horizontal padding left and right, and had drifted upward relative to the design. Measured on `origin/pre-dev` (Playwright, computed styles): both read-mode bar variants had **0px horizontal padding** — `chip.left == text.left`, the chips sat flush with the text edge.

**Regression attribution for the navigation defect reported alongside this** (chips not navigating in read mode): that is *not* broken on `pre-dev`. It was caused by the read-only editor never stamping heading ids for published HTML without them, was repaired on `pre-dev` last night by `321bdd8` ("Repair legal document read mode", PR #813, closes #811), and the storage-side root cause — ORISO-AgencyService's sanitizer stripping heading ids on save (TenantService fixed the identical gap in `7f37f30` on 2026-07-04; never ported) — is fixed in ORISO-AgencyService PR #271. The Pre-Dev environment still shows the defect because its Admin deployment runs a demo-branch image (`speed-16aug`) that predates `321bdd8`; getting the fix in front of the user is a deploy/image-provenance decision, not a further Admin patch.

## What

16px horizontal inset for the chip row in both read-mode variants of `M3RichTextEditor.module.scss`:

- fluid reader (sticky bottom bar): `padding: 16px 0 8px` → `16px 16px 8px`
- deck card: `padding: 16px 0 0` → `16px 16px 0`

The bar's vertical position (16px top spacing per #811) is unchanged — `321bdd8` already set it. The base `.RichEditor-anchorNav` rule used by the authoring form editor (8px 12px) is untouched.

## Verification (real browser, Playwright, local Storybook — Pre-Dev untouched)

Measured after: nav padding `16px 16px 8px` / `16px 16px 0`, chips inset 16px from the text edge.

Navigation re-verified on the same build, before and after the style change, at 390 / 820 / 1440 on: `DpaLegalReader` (desktop-with-chapters), TenantOnboarding organisation+DPA long text, DPA blocker (mobile + fullscreen dialog), `M3RichTextEditor` read-only-with-anchors, `DataProcessingAgreementCard` read-only. Every chip click scrolled the document and moved focus onto the target heading; keyboard activation (Tab to chip, Enter and Space) does the same in the reader, the 390px wizard and the fullscreen dialog.

Before/after screenshot pairs by finding id (F4 padding, H4 bar position, H1 navigation, H2 keyboard), all three viewports, with index: `~/ORISO/_e2e-artifacts/anchor-chips-20260818/screenshots/INDEX.md` (machine-local evidence contract path).

Unit tests: `M3RichTextEditor.anchors.test.tsx` + `M3RichTextEditor.readonly.test.tsx` — 27 passed. Stylelint on the changed file: 0 errors.

## Reviewer test plan

- [ ] Storybook `organisms-m3-rich-text-editor--read-only-with-anchors`: chips are inset 16px from the text edge, active chip fully visible
- [ ] `molecules-dpalegalreader--desktop-with-chapters` at 1440: sticky bottom bar keeps its 16px top spacing and now insets the chips horizontally
- [ ] Mobile 390 (`pages-tenantonboarding-flow--organisation-and-dpa-long-text`): bar does not clip chips at the edges; clicking a chip scrolls the agreement
- [ ] Keyboard: Tab to a chapter chip, press Enter, then Space on another chip → the document scrolls and focus lands on the heading both times
- [ ] Edit mode (`--with-anchor-navigation`): authoring chip row unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
