### PR TITLE
fix(reader): 8px text inset on all read surfaces, chip-row edge fade, URL anchor on chapter pick (H1/H2/H4/I3)

### DIFF
--- a/src/components/FormPluginEditor/AnchorChips.overflow.test.tsx
+++ b/src/components/FormPluginEditor/AnchorChips.overflow.test.tsx
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import AnchorChips from './AnchorChips';
+import type { HeadingAnchor } from './headingAnchors';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}));
+
+const anchors: HeadingAnchor[] = [
+    { id: 'rechtsdokumente', text: 'Rechtsdokumente', level: 1, pos: 0 },
+    { id: 'anlage-1-avv', text: 'Anlage 1: AVV', level: 2, pos: 10 },
+    { id: 'anlage-2', text: 'Anlage 2: Beratungsgrundsätze', level: 2, pos: 20 },
+    { id: 'anlage-3', text: 'Anlage 3: Leistungsumfang und Verfügbarkeit', level: 3, pos: 30 },
+];
+
+/**
+ * jsdom has no layout: scrollWidth/clientWidth are 0 and the row never
+ * overflows. These prototype mocks simulate the owner's screenshot geometry
+ * (2026-08-18 before-state H4/I3): a chip row wider than its scrollport,
+ * scrolled to the start — the state in which the last chip was hard-clipped
+ * down to a single letter.
+ */
+const mockRowGeometry = ({ scrollWidth, clientWidth, scrollLeft }: Record<string, number>) => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, get: () => scrollWidth });
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => clientWidth });
+    Object.defineProperty(HTMLElement.prototype, 'scrollLeft', {
+        configurable: true,
+        get: () => scrollLeft,
+        set: () => {},
+    });
+};
+
+describe('AnchorChips — overflow affordance (before-state H4/I3, 2026-08-18)', () => {
+    beforeEach(() => {
+        vi.stubGlobal('ResizeObserver', undefined);
+    });
+
+    afterEach(() => {
+        // Remove the shadowing own properties again — jsdom's originals live on
+        // Element.prototype and become visible again automatically.
+        Reflect.deleteProperty(HTMLElement.prototype, 'scrollWidth');
+        Reflect.deleteProperty(HTMLElement.prototype, 'clientWidth');
+        Reflect.deleteProperty(HTMLElement.prototype, 'scrollLeft');
+        vi.unstubAllGlobals();
+    });
+
+    it('fades only the end while the row sits at its start (the screenshot state)', async () => {
+        // Geometry of the owner's screenshot: 4 chips ≈ 990px in a 762px
+        // scrollport (production measurement at 3fb58d9: scrollWidth 990,
+        // clientWidth 762, last chip clipped by 228px).
+        mockRowGeometry({ scrollWidth: 990, clientWidth: 762, scrollLeft: 0 });
+        const { container } = render(<AnchorChips anchors={anchors} onSelect={() => {}} />);
+
+        await waitFor(() => {
+            const row = container.querySelector('.RichEditor-anchorNavRow')!;
+            expect(row.classList.contains('RichEditor-anchorNavRow--fadeEnd')).toBe(true);
+            expect(row.classList.contains('RichEditor-anchorNavRow--fadeStart')).toBe(false);
+        });
+        // The forward arrow is the second half of the affordance.
+        expect(container.querySelector('.RichEditor-anchorNavBtn')).toBeTruthy();
+    });
+
+    it('fades both edges mid-scroll', async () => {
+        mockRowGeometry({ scrollWidth: 990, clientWidth: 762, scrollLeft: 100 });
+        const { container } = render(<AnchorChips anchors={anchors} onSelect={() => {}} />);
+
+        await waitFor(() => {
+            const row = container.querySelector('.RichEditor-anchorNavRow')!;
+            expect(row.classList.contains('RichEditor-anchorNavRow--fadeEnd')).toBe(true);
+            expect(row.classList.contains('RichEditor-anchorNavRow--fadeStart')).toBe(true);
+        });
+    });
+
+    it('shows no fade at all when every chip fits', async () => {
+        mockRowGeometry({ scrollWidth: 500, clientWidth: 762, scrollLeft: 0 });
+        const { container } = render(<AnchorChips anchors={anchors} onSelect={() => {}} />);
+
+        await waitFor(() => expect(container.querySelector('.RichEditor-anchorNavRow')).toBeTruthy());
+        const row = container.querySelector('.RichEditor-anchorNavRow')!;
+        expect(row.classList.contains('RichEditor-anchorNavRow--fadeEnd')).toBe(false);
+        expect(row.classList.contains('RichEditor-anchorNavRow--fadeStart')).toBe(false);
+    });
+});

--- a/src/components/FormPluginEditor/AnchorChips.tsx
+++ b/src/components/FormPluginEditor/AnchorChips.tsx
@@ -111,9 +111,9 @@ const AnchorChips = ({
                 "there is more". The fade only sits on a side that can actually
                 scroll further — like the arrows. */}
             <div
-                className={`RichEditor-anchorNavRow${nav.overflow && !nav.atStart ? ' RichEditor-anchorNavRow--fadeStart' : ''}${
-                    nav.overflow && !nav.atEnd ? ' RichEditor-anchorNavRow--fadeEnd' : ''
-                }`}
+                className={`RichEditor-anchorNavRow${
+                    nav.overflow && !nav.atStart ? ' RichEditor-anchorNavRow--fadeStart' : ''
+                }${nav.overflow && !nav.atEnd ? ' RichEditor-anchorNavRow--fadeEnd' : ''}`}
                 ref={rowRef}
             >
                 {anchors.map((anchor) => {

--- a/src/components/FormPluginEditor/AnchorChips.tsx
+++ b/src/components/FormPluginEditor/AnchorChips.tsx
@@ -105,7 +105,17 @@ const AnchorChips = ({
                     <ArrowBack />
                 </button>
             )}
-            <div className="RichEditor-anchorNavRow" ref={rowRef}>
+            {/* Scroll-state classes drive an edge fade (owner request 2026-08-18,
+                before-state H4/I3): without it the row hard-clips mid-chip and a
+                chip cut down to a single letter reads as a rendering bug, not as
+                "there is more". The fade only sits on a side that can actually
+                scroll further — like the arrows. */}
+            <div
+                className={`RichEditor-anchorNavRow${nav.overflow && !nav.atStart ? ' RichEditor-anchorNavRow--fadeStart' : ''}${
+                    nav.overflow && !nav.atEnd ? ' RichEditor-anchorNavRow--fadeEnd' : ''
+                }`}
+                ref={rowRef}
+            >
                 {anchors.map((anchor) => {
                     const active = anchor.id === activeId;
                     return (

--- a/src/components/FormPluginEditor/FormPluginEditor.styles.scss
+++ b/src/components/FormPluginEditor/FormPluginEditor.styles.scss
@@ -176,6 +176,31 @@
         &::-webkit-scrollbar {
             display: none;
         }
+
+        /* Edge fade for the scrolling chip row (owner request 2026-08-18,
+           before-state H4/I3). The row stays ONE scrollable line (Figma
+           1299-81676; wrapping 11 chips would stack three rows into the sticky
+           bottom bar at 390px and eat the reading space) — but a hard clip cut
+           the last chip mid-letter ("A|"), which reads as a rendering bug. The
+           32px fade makes the cut chip dissolve toward the edge instead, and it
+           only appears on a side that can still scroll (classes toggled by
+           AnchorChips alongside the arrows). Mask, not a gradient overlay: an
+           overlay would tint the chips, and it would sit on top of the click
+           targets. */
+        &--fadeEnd {
+            -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 32px), transparent);
+            mask-image: linear-gradient(to right, #000 calc(100% - 32px), transparent);
+        }
+
+        &--fadeStart {
+            -webkit-mask-image: linear-gradient(to right, transparent, #000 32px);
+            mask-image: linear-gradient(to right, transparent, #000 32px);
+        }
+
+        &--fadeStart#{&}--fadeEnd {
+            -webkit-mask-image: linear-gradient(to right, transparent, #000 32px, #000 calc(100% - 32px), transparent);
+            mask-image: linear-gradient(to right, transparent, #000 32px, #000 calc(100% - 32px), transparent);
+        }
     }
 
     // Prev/next nav for an overflowing chip row (Chapter Navbar, Figma

--- a/src/components/FormPluginEditor/FormPluginEditor.styles.scss
+++ b/src/components/FormPluginEditor/FormPluginEditor.styles.scss
@@ -187,19 +187,17 @@
            AnchorChips alongside the arrows). Mask, not a gradient overlay: an
            overlay would tint the chips, and it would sit on top of the click
            targets. */
+
         &--fadeEnd {
-            -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 32px), transparent);
-            mask-image: linear-gradient(to right, #000 calc(100% - 32px), transparent);
+            mask-image: linear-gradient(to right, #000000 calc(100% - 32px), transparent);
         }
 
         &--fadeStart {
-            -webkit-mask-image: linear-gradient(to right, transparent, #000 32px);
-            mask-image: linear-gradient(to right, transparent, #000 32px);
+            mask-image: linear-gradient(to right, transparent, #000000 32px);
         }
 
         &--fadeStart#{&}--fadeEnd {
-            -webkit-mask-image: linear-gradient(to right, transparent, #000 32px, #000 calc(100% - 32px), transparent);
-            mask-image: linear-gradient(to right, transparent, #000 32px, #000 calc(100% - 32px), transparent);
+            mask-image: linear-gradient(to right, transparent, #000000 32px, #000000 calc(100% - 32px), transparent);
         }
     }
 

--- a/src/components/FormPluginEditor/M3RichTextEditor.anchors.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.anchors.test.tsx
@@ -150,6 +150,31 @@ describe('M3RichTextEditor — anchor navigation (read-only)', () => {
         window.history.replaceState(null, '', '/');
     });
 
+    it('arriving with a #hash jumps to that chapter and marks its chip (shared link)', async () => {
+        // The other half of the shareable URL: what the chip click writes must
+        // work when pasted into a fresh tab.
+        scrollIntoViewMock.mockClear();
+        window.history.replaceState(null, '', '/read#details');
+        const { container } = render(<M3RichTextEditor value={content} readOnly />);
+
+        await waitFor(() => expect(scrollIntoViewMock).toHaveBeenCalled());
+        await waitFor(() =>
+            expect(container.querySelector('[data-anchor-chip="details"].RichEditor-anchorChip--active')).toBeTruthy(),
+        );
+        window.history.replaceState(null, '', '/');
+    });
+
+    it('ignores a hash that matches no chapter (stale or foreign link): no throw, no jump', async () => {
+        scrollIntoViewMock.mockClear();
+        window.history.replaceState(null, '', '/read#does-not-exist');
+        const { container } = render(<M3RichTextEditor value={content} readOnly />);
+
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(2));
+        expect(scrollIntoViewMock).not.toHaveBeenCalled();
+        expect(container.querySelector('.RichEditor-anchorChip--active')).toBeFalsy();
+        window.history.replaceState(null, '', '/');
+    });
+
     it('intercepts in-text #anchor links: scrolls instead of navigating', async () => {
         scrollIntoViewMock.mockClear();
         const { container } = render(<M3RichTextEditor value={content} readOnly />);

--- a/src/components/FormPluginEditor/M3RichTextEditor.anchors.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.anchors.test.tsx
@@ -125,6 +125,31 @@ describe('M3RichTextEditor — anchor navigation (read-only)', () => {
         expect(onChange).not.toHaveBeenCalled();
     });
 
+    it('writes the picked chapter into the URL hash (owner report 2026-08-18, F4/H4)', async () => {
+        // „die anchor tags werden nicht gesetzt": picking a chapter must be
+        // visible in the URL — it is the only feedback left when a short
+        // document has no scroll distance, and it makes the chapter shareable.
+        window.history.replaceState(null, '', '/read');
+        const { container } = render(<M3RichTextEditor value={content} readOnly />);
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(2));
+
+        fireEvent.click(container.querySelector('[data-anchor-chip="details"] .RichEditor-anchorChipLabel')!);
+
+        expect(window.location.hash).toBe('#details');
+        window.history.replaceState(null, '', '/');
+    });
+
+    it('never rewrites the URL while the author is editing', async () => {
+        window.history.replaceState(null, '', '/edit');
+        const { container } = render(<M3RichTextEditor value={content} />);
+        await waitFor(() => expect(container.querySelectorAll(chipSelector)).toHaveLength(2));
+
+        fireEvent.click(container.querySelector('[data-anchor-chip="details"] .RichEditor-anchorChipLabel')!);
+
+        expect(window.location.hash).toBe('');
+        window.history.replaceState(null, '', '/');
+    });
+
     it('intercepts in-text #anchor links: scrolls instead of navigating', async () => {
         scrollIntoViewMock.mockClear();
         const { container } = render(<M3RichTextEditor value={content} readOnly />);

--- a/src/components/FormPluginEditor/M3RichTextEditor.module.scss
+++ b/src/components/FormPluginEditor/M3RichTextEditor.module.scss
@@ -1192,11 +1192,28 @@ $m3-state-active: rgb(39 50 112 / 12%);
         }
     }
 
+    /* Owner call 2026-08-18 (before-state H1/H2), REVERSING the owner call of
+       2026-07-30 that made the reading text run edge to edge: „text braucht
+       padding min. 8px … an allen 4 Seiten!". Measured before this rule the
+       text sat 0-1px from its clipping frame (`editorContentScroll`) in every
+       read surface — wizard step, DPA blocker, fullscreen reader, settings
+       deck. The inset lives HERE and not on `.editor`, because the chapter bar
+       is a sibling inside `.editor` and must keep spanning the full surface
+       (its opaque sticky background masks text scrolling underneath). The
+       vertical 8px comes from `.editor` above; the fluid variant's 56px
+       bottom clearance wins by specificity, which is intended. */
+    .editorContentScroll {
+        padding-inline: 8px;
+    }
+
     // Owner call 2026-07-30, desktop AND mobile: with the outer box gone there
     // is no edge left for the text to keep its distance from, so the side inset
     // goes too — the reading measure gets those 16px back on both sides. The
     // chapter row lives in the same wrapper, which is why its arrows move out
     // to the edges with it.
+    // (Partially superseded 2026-08-18: the text now keeps an 8px inset — see
+    // `.editorContentScroll` above — while the chapter row still spans the
+    // full width with its own 16px control inset from #818.)
     .editorWrap {
         padding-inline: 0;
     }

--- a/src/components/FormPluginEditor/M3RichTextEditor.module.scss
+++ b/src/components/FormPluginEditor/M3RichTextEditor.module.scss
@@ -1202,6 +1202,7 @@ $m3-state-active: rgb(39 50 112 / 12%);
        (its opaque sticky background masks text scrolling underneath). The
        vertical 8px comes from `.editor` above; the fluid variant's 56px
        bottom clearance wins by specificity, which is intended. */
+
     .editorContentScroll {
         padding-inline: 8px;
     }

--- a/src/components/FormPluginEditor/legalReader.styles.test.ts
+++ b/src/components/FormPluginEditor/legalReader.styles.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const moduleStyles = readFileSync(resolve(__dirname, './M3RichTextEditor.module.scss'), 'utf8');
+const globalStyles = readFileSync(resolve(__dirname, './FormPluginEditor.styles.scss'), 'utf8');
+
+/*
+ * Layout contract of the READ-ONLY legal reader — the surface behind the
+ * owner's 2026-08-18 before-state annotations H1/H2 (text inset), H4/I3 (the
+ * chapter-chip bar), reported broken twice before this file existed.
+ *
+ * Measured with Playwright at revision 3fb58d9 (the deployed Admin image),
+ * production bundle, REAL pre-dev DPA content (tenant 1, 4 chapters), at
+ * 390/820/1440 — BEFORE the fix:
+ *
+ *   - body text to its clipping frame (`editorContentScroll`):
+ *     left 0-1px, right 0-1px on EVERY read surface (onboarding wizard step,
+ *     DPA blocker, fullscreen reader dialog, legal-settings deck card). That
+ *     is the "text braucht padding min. 8px … an allen 4 Seiten!" defect: an
+ *     earlier owner call (2026-07-30) had deliberately removed the side inset.
+ *     The 2026-08-18 annotation reverses that call — on purpose, in writing.
+ *   - chapter-chip row: the last visible chip was hard-clipped mid-letter by
+ *     27-228px depending on surface and width ("Anlage 3" rendered as "A|"),
+ *     with no visual hint that the row scrolls.
+ *
+ * AFTER the fix the same measurements read: text inset 8px left and right
+ * (vertical 8px via `.readMode .editor`), and the clipped chip dissolves in a
+ * 32px edge fade that only shows while that side can still scroll.
+ *
+ * If any assertion here goes red, one of those two owner-visible defects is
+ * back. Do not delete a failing assertion — read the comment above it and the
+ * PR that introduced it first.
+ */
+describe('read-mode legal reader — text inset (before-state H1/H2, 2026-08-18)', () => {
+    it('gives the reading text an 8px side inset inside the read-mode card', () => {
+        // The inset lives on `.editorContentScroll` (the text viewport), NOT on
+        // `.editor`: the chapter bar is a sibling inside `.editor` and must
+        // keep spanning the full surface so its opaque sticky background masks
+        // the text scrolling underneath it.
+        const readMode = moduleStyles.match(/\.readMode\s*{[\s\S]*?\n}/)?.[0] ?? '';
+        expect(readMode).toMatch(/\.editorContentScroll\s*{[^}]*padding-inline:\s*8px;/);
+    });
+
+    it('keeps the 8px vertical padding of the read-mode text surface', () => {
+        // `.readMode .editor { padding: 8px 0 }` — the vertical half of the
+        // "8px on all four sides" annotation. The `0` is fine: the horizontal
+        // 8px comes from `.editorContentScroll` above.
+        const readMode = moduleStyles.match(/\.readMode\s*{[\s\S]*?\n}/)?.[0] ?? '';
+        expect(readMode).toMatch(/\.editor\s*{[^}]*padding:\s*8px 0;/);
+    });
+});
+
+describe('chapter-chip bar — control inset survives (#818, re-verified 2026-08-18)', () => {
+    // #818's 16px chip-bar inset was reported lost on the deployed environment;
+    // it was in fact deployed and live (measured navPadding "16px 16px 8px
+    // 16px" in the production bundle at 3fb58d9). These assertions keep it
+    // from ACTUALLY disappearing in a future refactor.
+    it('keeps the fluid reader sticky bar inset 16px left and right', () => {
+        expect(moduleStyles).toMatch(/padding:\s*16px 16px 8px;/);
+    });
+
+    it('keeps the deck-card chip bar inset 16px left and right', () => {
+        expect(moduleStyles).toMatch(/padding:\s*16px 16px 0;/);
+    });
+});
+
+describe('chapter-chip row — scrolls with a visible affordance (H4/I3, 2026-08-18)', () => {
+    it('keeps the chips on one scrollable line (Figma 1299-81676)', () => {
+        // Wrapping was measured and rejected: 11 chips would stack three rows
+        // into the sticky bottom bar at 390px and eat the reading space.
+        const row = globalStyles.match(/&-anchorNavRow\s*{[\s\S]*?\n {4}}/)?.[0] ?? '';
+        expect(row).toMatch(/flex-wrap:\s*nowrap;/);
+        expect(row).toMatch(/overflow-x:\s*auto;/);
+    });
+
+    it('fades the clipped edge instead of hard-cutting a chip mid-letter', () => {
+        // The BEFORE state showed "Anlage 3…" cut down to "A|" (27-228px of the
+        // last visible chip hidden) with no hint of scrollability. The fade is
+        // a mask, not an overlay, so it cannot tint the chips or cover the
+        // click targets; AnchorChips toggles it per side alongside the arrows.
+        expect(globalStyles).toMatch(/&--fadeEnd\s*{[^}]*mask-image:\s*linear-gradient\(to right,\s*#000 calc\(100% - 32px\), transparent\);/);
+        expect(globalStyles).toMatch(/&--fadeStart\s*{[^}]*mask-image:\s*linear-gradient\(to right,\s*transparent,\s*#000 32px\);/);
+        // Both sides scrollable -> both edges fade (single combined mask; two
+        // mask-image declarations would overwrite each other).
+        expect(globalStyles).toMatch(/&--fadeStart#{&}--fadeEnd/);
+    });
+});

--- a/src/components/FormPluginEditor/legalReader.styles.test.ts
+++ b/src/components/FormPluginEditor/legalReader.styles.test.ts
@@ -79,8 +79,12 @@ describe('chapter-chip row — scrolls with a visible affordance (H4/I3, 2026-08
         // last visible chip hidden) with no hint of scrollability. The fade is
         // a mask, not an overlay, so it cannot tint the chips or cover the
         // click targets; AnchorChips toggles it per side alongside the arrows.
-        expect(globalStyles).toMatch(/&--fadeEnd\s*{[^}]*mask-image:\s*linear-gradient\(to right,\s*#000 calc\(100% - 32px\), transparent\);/);
-        expect(globalStyles).toMatch(/&--fadeStart\s*{[^}]*mask-image:\s*linear-gradient\(to right,\s*transparent,\s*#000 32px\);/);
+        expect(globalStyles).toMatch(
+            /&--fadeEnd\s*{[^}]*mask-image:\s*linear-gradient\(to right,\s*#000000 calc\(100% - 32px\), transparent\);/,
+        );
+        expect(globalStyles).toMatch(
+            /&--fadeStart\s*{[^}]*mask-image:\s*linear-gradient\(to right,\s*transparent,\s*#000000 32px\);/,
+        );
         // Both sides scrollable -> both edges fade (single combined mask; two
         // mask-image declarations would overwrite each other).
         expect(globalStyles).toMatch(/&--fadeStart#{&}--fadeEnd/);

--- a/src/components/FormPluginEditor/useHeadingAnchorNav.ts
+++ b/src/components/FormPluginEditor/useHeadingAnchorNav.ts
@@ -89,6 +89,17 @@ export const useHeadingAnchorNav = (
         if (target && !editor.isEditable) {
             target.setAttribute('tabindex', '-1');
             target.focus?.({ preventScroll: true });
+            // Reading mode ALSO writes the anchor into the URL (owner report
+            // 2026-08-18, before-state F4/H4: „die anchor tags werden nicht
+            // gesetzt"): picking a chapter must be visible and shareable even
+            // when a short document has no scroll distance left to move.
+            // `replaceState` with the CURRENT history state: it fires no
+            // popstate/hashchange, so the BrowserRouter never re-navigates, and
+            // preserving `history.state` keeps react-router's location state
+            // intact. Never in edit mode — authoring must not rewrite the URL.
+            if (typeof window !== 'undefined' && typeof window.history?.replaceState === 'function') {
+                window.history.replaceState(window.history.state, '', `#${encodeURIComponent(anchorId)}`);
+            }
         }
         setActiveAnchorId(anchorId);
     };

--- a/src/components/FormPluginEditor/useHeadingAnchorNav.ts
+++ b/src/components/FormPluginEditor/useHeadingAnchorNav.ts
@@ -49,6 +49,33 @@ export const useHeadingAnchorNav = (
         };
     }, [editor, enabled, editable]);
 
+    // Arriving WITH a hash (the URL a chip click produces, shared or reloaded):
+    // jump to that chapter once the anchor list is in. Without this, the link
+    // the click writes would look shareable and not be — worse than no hash.
+    // A hash that matches no anchor (stale link after re-authoring, typo, or a
+    // foreign in-page anchor) is deliberately ignored: no throw, no scroll.
+    // Read-only only — an author's editor must not jump away from the caret.
+    const consumedInitialHash = useRef(false);
+    useEffect(() => {
+        if (!editor || !enabled || editable || consumedInitialHash.current) return;
+        if (!anchors.length || typeof window === 'undefined') return;
+        let requested = '';
+        try {
+            requested = decodeURIComponent(window.location.hash.slice(1));
+        } catch {
+            // Malformed percent-encoding in a hand-edited URL — treat as "no hash".
+        }
+        if (!requested) {
+            consumedInitialHash.current = true;
+            return;
+        }
+        consumedInitialHash.current = true;
+        if (anchors.some((anchor) => anchor.id === requested)) {
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            scrollToAnchor(requested);
+        }
+    }, [editor, enabled, editable, anchors]);
+
     // Read-only scroll spy: mark the anchor whose heading is currently at the
     // top of the (scrolled) editor content as active.
     useEffect(() => {


### PR DESCRIPTION
Refs: before-state doc `0 - Docs/plans/2026-08-18-tenant-onboarding-before-state.md`, findings **H1 / H2 / H4 / I3**. Reported twice; reported fixed once (#818); still wrong on the environment the owner uses.

## Why "we fixed it" and "it still looks wrong" were both true

We verified the deployed Admin image (`sha256:7aade2e0`, revision `3fb58d9`) **contains** both #818 (chip-bar inset) and #813 (display-only heading ids) — the demo merge lost nothing (the `M3RichTextEditor.tsx` / `AnchorChips.tsx` conflicts were import-style only). The measured production bundle at that revision shows the #818 inset live: chip-bar padding `16px 16px 8px 16px`.

**#818 was a scope miss, not a regression:** it padded the chapter-chip **bar**, while H1/H2 complain about the **body text**, which `.readMode .editor { padding: 8px 0 }` had deliberately set flush — an owner call of **2026-07-30** ("the reading measure gets those 16px back"). The owner's **2026-08-18** annotation explicitly reverses that: „text braucht padding min. 8px … an allen 4 Seiten!". This PR performs that reversal, on record.

## Measured (Playwright; Storybook + production `vite build`; real pre-dev DPA content, tenant 1; 390/820/1440)

| Metric | Before (3fb58d9) | After (this PR) |
|---|---|---|
| Body text → clipping frame, left/right | **0–1px** on every read surface (wizard step, DPA blocker, fullscreen reader, settings deck) | **8px** everywhere (8–9px incl. subpixel) |
| Vertical text padding (read mode) | 8px (kept) | 8px (kept, now tested) |
| Chip bar inset (#818) | 16px (was live, stays) | 16px (now style-contract-tested) |
| Last visible chip | hard-clipped mid-letter by **27–228px** („Anlage 3“ → „A|“), no scroll hint | same scroll row, but the cut chip **fades over 32px** per still-scrollable side, next to the existing arrows |
| Chip click → scroll+focus | worked (11/11 chips, verified before AND after — this part was never broken at this revision) | works (11/11) |
| Chip click → URL anchor | **never set** (no `location.hash` write existed) | `#<anchor>` written via `history.replaceState` |
| Arriving with `#anchor` | ignored | jumps to the chapter (scroll + focus + active chip); unknown/stale/malformed hash ignored without throwing |

No host double-pads: all four surfaces measured 0–1px before, so widening the shared `.readMode` rule is correct — the inset sits on `.editorContentScroll`, not `.editor`, so the sticky chapter bar keeps spanning the full surface (its opaque background must mask text scrolling beneath).

## Decisions on record

- **Reversal:** the 2026-07-30 edge-to-edge owner call is superseded by the newer, explicit 2026-08-18 annotation (H1/H2). Both are quoted in the SCSS comments so the next reader sees a decision, not an accident.
- **Scroll, not wrap:** wrapping 11 chips would stack ~3 rows into the sticky bottom bar at 390px and eat the reading space; Figma 1299-81676 specifies one scrollable row. The defect was the missing affordance — a hard mid-letter cut reads as a rendering bug — fixed with a per-side 32px mask fade toggled exactly like the arrows.
- **`replaceState`, no history entry per chapter:** stepping back through eleven chapters to leave a contract would be worse than losing back-button chapter steps. The current chapter is still shareable and restorable via the hash.
- **H4 "click does nothing":** not reproducible at `3fb58d9` in any deployed surface — Storybook dev, production bundle, story content AND real pre-dev content all navigate (numbers above). What measurably never happened was the anchor being *set*; that is fixed here. The remaining F4/H4 reports were annotated on the forwarded-signature surfaces that are not on `pre-dev` yet — they must be re-verified when those PRs land. For a short document with no scroll distance, feedback now exists: active chip + focus + URL hash (deck reader measured: `focusOnTarget=true` even with zero scroll).

## Tests (mutation-verified: each production change reverted → red)

- `legalReader.styles.test.ts` — style contract with the measured numbers (pattern: `globalSearchBar.styles.test.ts`): 8px read-mode inset, 8px vertical, both #818 16px insets, one-line scroll row, fade masks.
- `AnchorChips.overflow.test.tsx` — fade classes under the screenshot geometry (990/762px): end-only at start, both mid-scroll, none when everything fits.
- `M3RichTextEditor.anchors.test.tsx` (+4) — hash written in read mode, never in edit mode; arriving with `#hash` jumps and activates the chip; unknown hash = no throw, no jump.

Mutations probed: text inset removed, fade CSS removed, fade classes reverted, hash write removed, on-load jump disabled — 5/5 made the suite red.

Full runs: `tsc`, `eslint`, `stylelint`, `prettier` green; 467 tests green across FormPluginEditor, DpaLegalForm, DpaBlocker, TenantOnboarding, LegalSettings (Node 22.12-line; six known Node-26-only failures are unrelated, see #820).

## Deployment note

**This PR does not deploy anything.** Pre-Dev's Admin currently runs the demo-line image (`speed/reflux-progress-exp-16-aug` merge, `sha256:7aade2e0`). The fix reaches the owner's environment only via a new Admin image built from a line containing this branch — either merge to `pre-dev` + rebuild of the demo merge, or a direct demo-line rebuild. That is a separate decision.

## Reviewer test plan

- [ ] `npx vitest run src/components/FormPluginEditor/` — 12 files green
- [ ] Storybook `Pages/TenantOnboarding/Flow → OrganisationAndDpaLongText`: text no longer touches the reader edge (8px), last chip fades instead of hard-cutting, forward arrow present
- [ ] Click every chapter chip: document scrolls, heading gets focus, URL shows `#<chapter>`
- [ ] Reload with the `#<chapter>` URL: reader opens on that chapter, chip active
- [ ] Mobile 390×844 (`OrganisationAndDpaMobile` + blocker `MobileLongDpaText`): same four checks
- [ ] Fullscreen reader (blocker story `FullscreenReaderOverTheBlocker`): text inset 8px, chips fade, navigation works
- [ ] Settings deck (`Organisms/Legal/DataProcessingAgreementCard → ReadOnly`): text inset 8px; with a document too short to scroll, clicking the chip still sets focus + hash
- [ ] Edit mode: URL never changes while clicking chips

Before/after screenshots (same stems, 390/820/1440, incl. production-bundle run with the real pre-dev DPA): `~/ORISO/_e2e-artifacts/20260818-legal-reader-prio1/screenshots/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
