### PR TITLE
fix: add team/single agency toggle to agency settings

### DIFF
--- a/scripts/en-translations-manual.json
+++ b/scripts/en-translations-manual.json
@@ -121,6 +121,7 @@
     "agency.form.registrationSettings.title": "Visibility in registration",
     "agency.form.registrationSettings.toPostCode": "To postal code",
     "agency.form.settings.headline": "Counseling service settings",
+    "agency.form.settings.teamAdviceCenter.changeWarning": "Turning off team counseling converts existing team chats into 1:1 counseling. Other counselors at this counseling center will no longer be able to view those chats.",
     "agency.form.settings.teamAdviceCenter.description": "All consultants of an advice center can view and participate in all chats with people seeking advice.",
     "agency.form.settings.teamAdviceCenter.title": "Offer team counseling",
     "agency.gender": "Gender",

--- a/src/components/CardEditable/CardEditable.test.tsx
+++ b/src/components/CardEditable/CardEditable.test.tsx
@@ -40,6 +40,23 @@ describe('CardEditable', () => {
         expect(screen.getByRole('switch', { name: 'Enabled' })).toBeEnabled();
     });
 
+    it('submits a toggled-off switch as false so card patches keep the new value', async () => {
+        const user = userEvent.setup();
+        const onSave = vi.fn();
+        render(
+            <CardEditable titleKey="card.title" onSave={onSave} initialValues={{ teamAgency: true }}>
+                <MuiSwitchField name="teamAgency" label="Team" />
+            </CardEditable>,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'edit' }));
+        await user.click(screen.getByRole('switch', { name: 'Team' }));
+        await user.click(screen.getByRole('button', { name: 'card.edit.save' }));
+
+        await waitFor(() => expect(onSave).toHaveBeenCalled());
+        expect(onSave.mock.calls[0][0]).toEqual({ teamAgency: false });
+    });
+
     it('keeps entered values editable when the save callback reports an error', async () => {
         const user = userEvent.setup();
         const onSave = vi.fn();

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -622,6 +622,7 @@
     "agency.form.settings.headline": "Einstellungen zum Beratungsangebot",
     "agency.form.settings.teamAdviceCenter.title": "Teamberatung anbieten",
     "agency.form.settings.teamAdviceCenter.description": "Alle Berater:innen einer Beratungsstelle können alle Chats mit Ratsuchenden einsehen und sich daran beteiligen.",
+    "agency.form.settings.teamAdviceCenter.changeWarning": "Wenn Sie Teamberatung deaktivieren, werden bestehende Teamchats in 1:1-Beratungen umgewandelt. Andere Berater:innen dieser Beratungsstelle können diese Chats dann nicht mehr einsehen.",
     "agency.form.registrationSettings.title": "Sichtbarkeit in der Registrierung",
     "agency.form.registrationSettings.createConsultant.button": "Neue:n Berater:in anlegen",
     "agency.form.registrationSettings.createConsultant.title": "Neue:n Berater:in anlegen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1226,6 +1226,7 @@
     "agency.edit.settings.legal.title": "Legal",
     "agency.edit.tab.basicFunctionalities": "Core functionalities",
     "agency.form.settings.headline": "Counseling offer settings",
+    "agency.form.settings.teamAdviceCenter.changeWarning": "Turning off team counseling converts existing team chats into 1:1 counseling. Other counselors at this counseling center will no longer be able to view those chats.",
     "agency.form.settings.teamAdviceCenter.description": "All counselors of a counseling center can view and join all chats with users.",
     "agency.form.settings.teamAdviceCenter.title": "Offer team counseling",
     "agency.gender": "Gender",

--- a/src/pages/Agency/Edit/components/AgencySettings/index.test.tsx
+++ b/src/pages/Agency/Edit/components/AgencySettings/index.test.tsx
@@ -37,7 +37,7 @@ const FormValue = ({ name }: { name: string }) => {
 const renderSettings = (initialValues: Record<string, unknown>, isEditMode = true) =>
     render(
         <Form initialValues={initialValues}>
-            <AgencySettings isEditMode={isEditMode} asFields />
+            <AgencySettings isEditMode={isEditMode} asFields persistedTeamAgency={Boolean(initialValues.teamAgency)} />
             <FormValue name="teamAgency" />
         </Form>,
     );
@@ -94,7 +94,7 @@ describe('AgencySettings team/single toggle', () => {
         const onSave = vi.fn();
         render(
             <CardEditable titleKey="card.title" onSave={onSave} initialValues={{ teamAgency: true }}>
-                <AgencySettings isEditMode asFields />
+                <AgencySettings isEditMode asFields persistedTeamAgency />
             </CardEditable>,
         );
 
@@ -104,5 +104,43 @@ describe('AgencySettings team/single toggle', () => {
 
         await waitFor(() => expect(onSave).toHaveBeenCalled());
         expect(onSave.mock.calls[0][0]).toEqual(expect.objectContaining({ teamAgency: false }));
+    });
+
+    it('refreshes the warning baseline after a save instead of comparing against the pre-save value', async () => {
+        // Regression test: persistedTeamAgency used to be captured once on mount and frozen from
+        // then on. A second edit in the same page load (flip, save, flip again) then compared the
+        // live value against that stale, pre-save baseline and could show the team-to-single
+        // warning even though nothing had actually changed since the last save. The fix threads the
+        // baseline in as a prop straight from the caller's fetched agency data, so a caller
+        // re-rendering with a fresh value (as AgencyPageEdit does once its query cache updates after
+        // a successful save) must immediately update what the warning compares against.
+        const user = userEvent.setup();
+
+        const { rerender } = render(
+            <Form initialValues={{ teamAgency: true }}>
+                <AgencySettings isEditMode asFields persistedTeamAgency />
+                <FormValue name="teamAgency" />
+            </Form>,
+        );
+
+        // First (real) conversion: team -> single. Warning correctly appears.
+        await user.click(screen.getByRole('switch', { name: 'agency.form.settings.teamAdviceCenter.title' }));
+        expect(screen.getByText('agency.form.settings.teamAdviceCenter.changeWarning')).toBeInTheDocument();
+
+        // Simulate the save completing: the caller's fetched agency data now reflects
+        // teamAgency: false, so it re-renders with the refreshed baseline prop.
+        rerender(
+            <Form initialValues={{ teamAgency: true }}>
+                <AgencySettings isEditMode asFields persistedTeamAgency={false} />
+                <FormValue name="teamAgency" />
+            </Form>,
+        );
+        expect(screen.queryByText('agency.form.settings.teamAdviceCenter.changeWarning')).not.toBeInTheDocument();
+
+        // Second edit in the same page load: flip on, then back off. This does not undo a
+        // persisted team agency (the agency is already single), so no warning should appear.
+        await user.click(screen.getByRole('switch', { name: 'agency.form.settings.teamAdviceCenter.title' }));
+        await user.click(screen.getByRole('switch', { name: 'agency.form.settings.teamAdviceCenter.title' }));
+        expect(screen.queryByText('agency.form.settings.teamAdviceCenter.changeWarning')).not.toBeInTheDocument();
     });
 });

--- a/src/pages/Agency/Edit/components/AgencySettings/index.test.tsx
+++ b/src/pages/Agency/Edit/components/AgencySettings/index.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { Form } from 'antd';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { CardEditable } from '../../../../../components/CardEditable';
+import { AgencySettings } from './index';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => {
+        const t = (key: string) => key;
+        return Object.assign([t], { t });
+    },
+}));
+
+vi.mock('../../../../../context/FeatureContext', () => ({
+    useFeatureContext: () => ({ isEnabled: () => false }),
+}));
+
+vi.mock('../../../../../hooks/useReleasesToggle.hook', () => ({
+    useReleasesToggle: () => ({ isEnabled: () => false }),
+}));
+
+vi.mock('../../../../../hooks/useUserRoles.hook', () => ({
+    useUserRoles: () => ({ isSuperAdmin: false }),
+}));
+
+vi.mock('../../../../../hooks/useTenantTopics', () => ({
+    useTenantTopics: () => ({ data: [], isLoading: false }),
+}));
+
+const FormValue = ({ name }: { name: string }) => {
+    const value = Form.useWatch(name);
+    return <span data-testid={`form-${name}`}>{String(value)}</span>;
+};
+
+const renderSettings = (initialValues: Record<string, unknown>, isEditMode = true) =>
+    render(
+        <Form initialValues={initialValues}>
+            <AgencySettings isEditMode={isEditMode} asFields />
+            <FormValue name="teamAgency" />
+        </Form>,
+    );
+
+describe('AgencySettings team/single toggle', () => {
+    it('renders a switch bound to teamAgency', async () => {
+        const user = userEvent.setup();
+        renderSettings({ teamAgency: true });
+
+        const toggle = screen.getByRole('switch', { name: 'agency.form.settings.teamAdviceCenter.title' });
+        expect(toggle).toBeChecked();
+        expect(screen.getByTestId('form-teamAgency')).toHaveTextContent('true');
+        expect(screen.getByText('agency.form.settings.teamAdviceCenter.description')).toBeInTheDocument();
+
+        await user.click(toggle);
+
+        expect(toggle).not.toBeChecked();
+        expect(screen.getByTestId('form-teamAgency')).toHaveTextContent('false');
+    });
+
+    it('renders the teamAgency switch unchecked when the field is absent', () => {
+        renderSettings({});
+
+        expect(screen.getByRole('switch', { name: 'agency.form.settings.teamAdviceCenter.title' })).not.toBeChecked();
+        expect(screen.queryByText('agency.form.settings.teamAdviceCenter.changeWarning')).not.toBeInTheDocument();
+    });
+
+    it('warns when switching an existing team agency to single', async () => {
+        const user = userEvent.setup();
+        renderSettings({ teamAgency: true }, true);
+
+        expect(screen.queryByText('agency.form.settings.teamAdviceCenter.changeWarning')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('switch', { name: 'agency.form.settings.teamAdviceCenter.title' }));
+
+        expect(screen.getByText('agency.form.settings.teamAdviceCenter.changeWarning')).toBeInTheDocument();
+    });
+
+    it('does not warn when creating a new agency or leaving team counseling on', async () => {
+        const user = userEvent.setup();
+        const { unmount } = renderSettings({ teamAgency: false }, false);
+
+        await user.click(screen.getByRole('switch', { name: 'agency.form.settings.teamAdviceCenter.title' }));
+        await user.click(screen.getByRole('switch', { name: 'agency.form.settings.teamAdviceCenter.title' }));
+        expect(screen.queryByText('agency.form.settings.teamAdviceCenter.changeWarning')).not.toBeInTheDocument();
+        unmount();
+
+        renderSettings({ teamAgency: true }, true);
+        expect(screen.queryByText('agency.form.settings.teamAdviceCenter.changeWarning')).not.toBeInTheDocument();
+    });
+
+    it('submits teamAgency: false from the settings card so changetype can see the conversion', async () => {
+        const user = userEvent.setup();
+        const onSave = vi.fn();
+        render(
+            <CardEditable titleKey="card.title" onSave={onSave} initialValues={{ teamAgency: true }}>
+                <AgencySettings isEditMode asFields />
+            </CardEditable>,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'edit' }));
+        await user.click(screen.getByRole('switch', { name: 'agency.form.settings.teamAdviceCenter.title' }));
+        await user.click(screen.getByRole('button', { name: 'card.edit.save' }));
+
+        await waitFor(() => expect(onSave).toHaveBeenCalled());
+        expect(onSave.mock.calls[0][0]).toEqual(expect.objectContaining({ teamAgency: false }));
+    });
+});

--- a/src/pages/Agency/Edit/components/AgencySettings/index.tsx
+++ b/src/pages/Agency/Edit/components/AgencySettings/index.tsx
@@ -1,4 +1,4 @@
-import { Form } from 'antd';
+import { Alert, Form } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { useEffect, useState } from 'react';
 import { useFeatureContext } from '../../../../../context/FeatureContext';
@@ -8,6 +8,7 @@ import { convertToOptions } from '../../../../../utils/convertToOptions';
 import { Option, MuiSelectField } from '../../../../../components/mui/MuiSelectField';
 import { Card } from '../../../../../components/Card';
 import { MuiSliderField } from '../../../../../components/mui/MuiSliderField';
+import { MuiSwitchField } from '../../../../../components/mui/MuiSwitchField';
 import { useTenantTopics } from '../../../../../hooks/useTenantTopics';
 import styles from './styles.module.scss';
 import { CounsellingRelation } from '../../../../../enums/CounsellingRelation';
@@ -23,6 +24,9 @@ interface AgencySettingsProps {
 
 export const AgencySettings = ({ isEditMode, asFields }: AgencySettingsProps) => {
     const [t] = useTranslation();
+    const teamAgency = Form.useWatch('teamAgency');
+    const [persistedTeamAgency, setPersistedTeamAgency] = useState<boolean | null>(null);
+    const showTeamToSingleWarning = isEditMode && persistedTeamAgency === true && teamAgency === false;
 
     const genders = Form.useWatch<Option[]>(['demographics', 'genders']) || [];
     const counsellingRelations = Form.useWatch<Option[]>('counsellingRelations') || [];
@@ -38,6 +42,12 @@ export const AgencySettings = ({ isEditMode, asFields }: AgencySettingsProps) =>
     );
 
     useEffect(() => {
+        if (persistedTeamAgency === null && typeof teamAgency === 'boolean') {
+            setPersistedTeamAgency(teamAgency);
+        }
+    }, [persistedTeamAgency, teamAgency]);
+
+    useEffect(() => {
         if (isSuperAdmin) {
             searchTenantData({ perPage: 1000 })
                 .then(({ data }) => setTenantsData(data))
@@ -49,6 +59,19 @@ export const AgencySettings = ({ isEditMode, asFields }: AgencySettingsProps) =>
 
     const fields = (
         <>
+            <MuiSwitchField
+                name="teamAgency"
+                label={t('agency.form.settings.teamAdviceCenter.title')}
+                helpText={t('agency.form.settings.teamAdviceCenter.description')}
+            />
+            {showTeamToSingleWarning && (
+                <Alert
+                    className={styles.warning}
+                    type="warning"
+                    description={t('agency.form.settings.teamAdviceCenter.changeWarning')}
+                />
+            )}
+
             {isSuperAdmin && (
                 <MuiSelectField
                     label="agency.edit.general.more_settings.tenant.title"

--- a/src/pages/Agency/Edit/components/AgencySettings/index.tsx
+++ b/src/pages/Agency/Edit/components/AgencySettings/index.tsx
@@ -20,12 +20,20 @@ import { searchTenantData } from '../../../../../api/tenant/searchTenantData';
 interface AgencySettingsProps {
     isEditMode: boolean;
     asFields?: boolean;
+    /**
+     * The currently persisted (server-side) teamAgency value, e.g. `Boolean(agencyData?.teamAgency)`.
+     * Used as the baseline the live form value is compared against below. Callers must pass the
+     * value straight from their fetched agency data (not a value captured once on mount) so that a
+     * successful save — which updates that fetched data via the query cache — immediately refreshes
+     * the baseline. Without this, a second edit in the same page load (flip, save, flip again) would
+     * compare against the pre-save baseline and show the conversion warning incorrectly.
+     */
+    persistedTeamAgency?: boolean;
 }
 
-export const AgencySettings = ({ isEditMode, asFields }: AgencySettingsProps) => {
+export const AgencySettings = ({ isEditMode, asFields, persistedTeamAgency }: AgencySettingsProps) => {
     const [t] = useTranslation();
     const teamAgency = Form.useWatch('teamAgency');
-    const [persistedTeamAgency, setPersistedTeamAgency] = useState<boolean | null>(null);
     const showTeamToSingleWarning = isEditMode && persistedTeamAgency === true && teamAgency === false;
 
     const genders = Form.useWatch<Option[]>(['demographics', 'genders']) || [];
@@ -40,12 +48,6 @@ export const AgencySettings = ({ isEditMode, asFields }: AgencySettingsProps) =>
     const counsellingRelationsForList = Object.values(CounsellingRelation).filter(
         (relation) => !counsellingRelations.find(({ value }) => value === `${relation}`),
     );
-
-    useEffect(() => {
-        if (persistedTeamAgency === null && typeof teamAgency === 'boolean') {
-            setPersistedTeamAgency(teamAgency);
-        }
-    }, [persistedTeamAgency, teamAgency]);
 
     useEffect(() => {
         if (isSuperAdmin) {

--- a/src/pages/Agency/Edit/components/AgencySettings/styles.module.scss
+++ b/src/pages/Agency/Edit/components/AgencySettings/styles.module.scss
@@ -1,3 +1,8 @@
+.warning:global(.ant-alert.ant-alert-warning) {
+    padding: 14px 16px;
+    margin-bottom: 16px;
+}
+
 .sliderContainer {
     :global(.ant-form-item-label label) {
         height: 26px;

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -327,7 +327,11 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
                                 editButtonPlacement="footer"
                                 onSave={onSaveCard}
                             >
-                                <AgencySettings isEditMode={isEditing} asFields />
+                                <AgencySettings
+                                    isEditMode={isEditing}
+                                    asFields
+                                    persistedTeamAgency={initialValues.teamAgency}
+                                />
                             </CardEditable>
                         </CardDeck.Item>
                         <CardDeck.Item>
@@ -358,7 +362,10 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
                     <CardGrid minCardWidth={425} maxColumns={2}>
                         <AgencyGeneralInformation />
                         <RegistrationSettings />
-                        <AgencySettings isEditMode={isEditing} />
+                        <AgencySettings
+                            isEditMode={isEditing}
+                            persistedTeamAgency={initialValues.teamAgency}
+                        />
                     </CardGrid>
                 </Form>
             </ThemeProvider>
@@ -388,7 +395,10 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
             {/* #620: a single card in a fixed 392px deck rendered needlessly narrow —
                 the grid lets it use the row up to the shared card floor. */}
             <CardGrid minCardWidth={425} maxColumns={2}>
-                <AgencySettings isEditMode={isEditing} />
+                <AgencySettings
+                    isEditMode={isEditing}
+                    persistedTeamAgency={initialValues.teamAgency}
+                />
             </CardGrid>
         </Form>
     );

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -362,10 +362,7 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
                     <CardGrid minCardWidth={425} maxColumns={2}>
                         <AgencyGeneralInformation />
                         <RegistrationSettings />
-                        <AgencySettings
-                            isEditMode={isEditing}
-                            persistedTeamAgency={initialValues.teamAgency}
-                        />
+                        <AgencySettings isEditMode={isEditing} persistedTeamAgency={initialValues.teamAgency} />
                     </CardGrid>
                 </Form>
             </ThemeProvider>
@@ -395,10 +392,7 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
             {/* #620: a single card in a fixed 392px deck rendered needlessly narrow —
                 the grid lets it use the row up to the shared card floor. */}
             <CardGrid minCardWidth={425} maxColumns={2}>
-                <AgencySettings
-                    isEditMode={isEditing}
-                    persistedTeamAgency={initialValues.teamAgency}
-                />
+                <AgencySettings isEditMode={isEditing} persistedTeamAgency={initialValues.teamAgency} />
             </CardGrid>
         </Form>
     );

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -150,6 +150,7 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
         ...counsellingRelationsInitialValues,
         postCodeRangesActive: !hasOnlyDefaultRangeDefined(postCodes || []),
         online: agencyData?.id ? !agencyData?.offline : false,
+        teamAgency: Boolean(agencyData?.teamAgency),
         // ADR-014: load every department, not just the first. Taking [0] here was the entry point
         // of the data loss — the form then sent that single topic back and the backend deleted the
         // other agency_topic rows together with their published legal texts.


### PR DESCRIPTION
## Why
Admins had no way to view or change whether a counselling centre 
is a team or single agency. The field existed in the API but was 
never exposed in the UI.

Note: Issue [#1149](https://github.com/openResilienceInitiative/ORISO-Frontend/issues/1149) was filed against ORISO-Frontend but the fix 
belongs in ORISO-Admin — the agency settings form lives here.

## What
- Add MuiSwitchField for teamAgency in AgencySettings component
- Show warning when converting team agency to single 
  (existing team chats become 1:1)
- Add new i18n key agency.form.settings.teamAdviceCenter.changeWarning
- Form init: create defaults to single, edit keeps saved value
- 4 new tests: switch present, warning on team→single, no warning on create
- Fix: the `persistedTeamAgency` baseline the warning compares against is
  now passed in as a prop derived straight from the fetched agency data
  (`persistedTeamAgency={initialValues.teamAgency}`) instead of being
  captured once on mount into local state. Previously a second edit in the
  same page load (flip → save → flip again) compared against the stale
  pre-save baseline and could show the conversion warning incorrectly. New
  regression test: `refreshes the warning baseline after a save instead of
  comparing against the pre-save value`.

## Known issue — RESOLVED
Converting a team agency to single returned 500 — UserService threw 
LazyInitializationException in ConsultantAgencyAdminService.noOtherTeamAgency 
when accessing the consultantAgencies collection after the Hibernate session 
is closed.

Backend fix is up: **ORISO-UserService#1070** — https://github.com/OpenResilienceInitiative/ORISO-UserService/pull/1070, closing **ORISO-UserService#1069** — https://github.com/OpenResilienceInitiative/ORISO-UserService/issues/1069. Both directions of the toggle (team→single and single→team) work end to end once that PR merges.

## Test
- Toggle visible on /admin/agency/:id/general → Einstellungen tab ✅
- Save with changed toggle calls POST /changetype correctly ✅
- Warning shown when switching team → single ✅
- 4 unit tests passed ✅
- New: warning baseline correctly refreshes after a save (regression test) ✅

## Screenshot
<img width="1893" height="932" alt="image" src="https://github.com/user-attachments/assets/1b62d7a3-09b2-4296-97d7-baa699f61884" />


Closes [#1149](https://github.com/openResilienceInitiative/ORISO-Frontend/issues/1149)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a team counseling setting for agencies.
  * Added a warning when disabling team counseling, explaining that existing team chats become 1:1 consultations and are no longer visible to other counselors.
  * Added English and German translations for the warning.
* **Bug Fixes**
  * Ensured the warning reflects the latest saved agency setting.
* **Tests**
  * Added coverage for switching, saving, and warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->