### PR TITLE
fix(icons): clear the catalog drift that is failing CI on pre-dev itself

### DIFF
--- a/src/components/IconCatalog/iconCatalog.generated.json
+++ b/src/components/IconCatalog/iconCatalog.generated.json
@@ -1866,8 +1866,8 @@
         "fileName": "mail_filled_24px.svg",
         "sourcePath": "src/resources/img/svg/oriso/mail_filled_24px.svg",
         "exportNames": [],
-        "usageFiles": ["src/pages/Links/InviteComposer.tsx"],
-        "usage": "app-used"
+        "usageFiles": [],
+        "usage": "catalogued-only"
     },
     {
         "id": "ui-icon:oriso:nearby-conv-type:200",


### PR DESCRIPTION
## Problem

**`pre-dev` is red on its own `CI - Main`**, and has been since the icon-catalog drift gate landed with #712.

Verified failing on two consecutive merge commits on `pre-dev`:

| Commit | Workflow | Result |
|---|---|---|
| `92234a21` | CI - Main | failure |
| `5b7776a2` | CI - Main | failure |

Both fail on the same step:

```
::error file=src/components/IconCatalog/iconCatalog.generated.json::
The committed icon catalog is stale. Run 'npm run generate:icon-catalog' and commit the diff.
```

Because every feature branch inherits `pre-dev`, this fails **every** Admin PR's build until it is fixed — it is currently blocking #835 and would block any new PR opened today.

## Actual behaviour

The committed catalog and the source it describes disagree:

```
iconCatalog.generated.json   mail_filled_24px.svg -> "usage": "app-used",
                             "usageFiles": ["src/pages/Links/InviteComposer.tsx"]

InviteComposer.tsx:23        import { ReactComponent as SendIcon }
                               from '../../resources/img/svg/oriso/send_400_24px.svg';
```

`InviteComposer` imports the **send** glyph. The catalog claims it imports the **filled mail** glyph.

The stale entry dates back to `360b71e chore(storybook): add generated icon catalog page`. The component moved to the send glyph afterwards (`707b096`, `9f1e11f`, `f2e4d0f`) and the generated file was never re-run. Nothing noticed, because until #712 there was no gate — the drift was invisible, not new.

## Expected behaviour

The generated catalog matches the source it is generated from, and `pre-dev` builds green.

## Evidence

Regenerated with the repo's own script on the pinned Node (`.nvmrc` → 22.12.0):

```
$ npm run generate:icon-catalog
Generated 234 icon catalog entries (139 app-used).
```

Resulting diff is two lines — the one stale entry becomes `catalogued-only`:

```diff
         "fileName": "mail_filled_24px.svg",
-        "usageFiles": ["src/pages/Links/InviteComposer.tsx"],
-        "usage": "app-used"
+        "usageFiles": [],
+        "usage": "catalogued-only"
```

`send_400_24px.svg` stays `app-used`, which is what the import actually says.

## The cause behind the cause

`pre-dev` shipped red for hours because **it has no required status checks** — its ruleset declares only `deletion`, and the `pull_request` rule is scoped to `~DEFAULT_BRANCH` and `dev`. A red merge lands exactly like a green one, and `mergeStateStatus: CLEAN` means "no conflict", never "checks passed".

This PR fixes the symptom. Turning on required checks for `pre-dev` is the fix for the cause, and is a settings change rather than engineering work.

## Reviewer test plan

- [ ] Confirm `pre-dev` is currently red: `gh run list --branch pre-dev --limit 4 --repo OpenResilienceInitiative/ORISO-Admin`
- [ ] Confirm the mismatch independently: `grep -n send_400_24px src/pages/Links/InviteComposer.tsx`
- [ ] Check out this branch and run `npm run generate:icon-catalog` — it should produce no further diff
- [ ] Confirm this PR's own build is green
- [ ] After merge, confirm the next `CI - Main` on `pre-dev` is green
