### PR TITLE
fix(login): centre the password-reset link and use the M3 filled submit button

### DIFF
--- a/src/pages/Login/LoginForm.test.tsx
+++ b/src/pages/Login/LoginForm.test.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import less from 'less';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LoginForm from './LoginForm';
+import m3ButtonStyles from '../../components/M3Button/styles.module.scss';
 import { FETCH_ERRORS } from '../../api/fetchData';
 import { ADMIN_PORTAL_ACCESS_DENIED } from '../../hooks/useLoginMutation.hook';
 import { TwoFactorType } from '../../enums/TwoFactorType';
@@ -34,6 +38,28 @@ const translations: Record<string, string> = {
 
 const t = (key: string) => translations[key] || key;
 let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+const STYLES_ROOT = resolve(__dirname, '../../styles');
+
+/** Compile the real login stylesheet (its LESS variables included) to CSS. */
+const compileLoginFormCss = async () => {
+    const entry = readFileSync(resolve(STYLES_ROOT, 'components/loginForm.less'), 'utf8');
+    const { css } = await less.render(`@import 'variables/index.less';\n${entry}`, {
+        paths: [STYLES_ROOT, resolve(STYLES_ROOT, 'components')],
+        filename: resolve(STYLES_ROOT, 'components/loginForm.less'),
+        javascriptEnabled: true,
+    });
+
+    return css;
+};
+
+const applyCompiledLoginFormStyles = (css: string) => {
+    const styleElement = document.createElement('style');
+    styleElement.textContent = css;
+    document.head.appendChild(styleElement);
+
+    return () => styleElement.remove();
+};
 
 vi.mock('react-i18next', () => ({
     useTranslation: () => Object.assign([t], { t, i18n: { language: 'en' } }),
@@ -110,6 +136,72 @@ describe('LoginForm', () => {
         render(<LoginForm />);
 
         expect(screen.getByRole('link', { name: 'Forgot password?' })).toHaveAttribute('href', '/admin/password-reset');
+    });
+
+    /*
+     * Owner review of predev.oriso.org/admin, "Muss zentrierter sein": the
+     * password-reset link was the only child of the sign-in form that did not
+     * share the axis of the fields and the submit button — it hugged the inline
+     * start ~100px left of the form centre.
+     *
+     * jsdom has no layout engine, so this compiles the stylesheet the app really
+     * ships (variables + styles/components/loginForm.less) and applies it to the
+     * really rendered form: the assertion then runs through the actual cascade,
+     * which is what decides the link's horizontal placement. A shrink-to-fit box
+     * only centres when it is block-level AND both inline margins resolve to
+     * `auto` — `auto` on an inline-level box is inert, which is exactly the
+     * shipped bug — so both halves of that mechanism are asserted.
+     */
+    it('centres the password-reset link on the axis the fields and the submit button share', async () => {
+        const removeStylesheet = applyCompiledLoginFormStyles(await compileLoginFormCss());
+
+        try {
+            render(<LoginForm />);
+            const link = screen.getByRole('link', { name: 'Forgot password?' });
+            const style = window.getComputedStyle(link);
+
+            expect(['inline', 'inline-block']).not.toContain(style.display);
+            expect(style.marginLeft).toBe('auto');
+            expect(style.marginRight).toBe('auto');
+        } finally {
+            removeStylesheet();
+        }
+    });
+
+    /*
+     * Owner review, "Scheint keine Color Token Secondary zu haben": the sign-in
+     * action was a raw MUI `<Button variant="contained">` whose colour came from
+     * the hardcoded `#273270` in theme/orisoMuiTheme.ts — the legacy antd navy
+     * that theme/antdM3Theme.ts retired everywhere else — and which therefore
+     * also inherited MUI's own resting elevation and its untokenised disabled
+     * grey. The public surface's own primary submit (TenantOnboarding /
+     * OrganisationDpaStep) is the shared M3 filled button; the sign-in action
+     * has to be the same control, so its colour comes from --m3-primary /
+     * --m3-on-primary and it is flat at rest.
+     */
+    it('renders sign in as the shared M3 filled button, not a raw MUI contained button', () => {
+        render(<LoginForm />);
+
+        const signInButton = screen.getByRole('button', { name: 'Sign in' });
+
+        expect(signInButton).toHaveClass(m3ButtonStyles.filled);
+        expect(signInButton.className).not.toMatch(/MuiButton-contained/);
+    });
+
+    it('keeps the full-width submit block and the busy state on the shared button', async () => {
+        mocks.login.mockImplementation(() => undefined);
+        render(<LoginForm />);
+        const user = await fillRequiredFields();
+
+        const signInButton = screen.getByRole('button', { name: 'Sign in' });
+        expect(signInButton).toHaveClass(m3ButtonStyles.block);
+
+        await user.click(signInButton);
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Sign in' })).toHaveAttribute('aria-busy', 'true');
+        });
+        expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
     });
 
     it('keeps sign in disabled until username and password are entered', async () => {

--- a/src/pages/Login/LoginForm.tsx
+++ b/src/pages/Login/LoginForm.tsx
@@ -4,12 +4,11 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
 import InputAdornment from '@mui/material/InputAdornment';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import LockOutlined from '@mui/icons-material/LockOutlined';
 import VerifiedUserOutlined from '@mui/icons-material/VerifiedUserOutlined';
+import { M3Button } from '../../components/M3Button';
 import { MuiFormField, MuiPasswordFormField } from '../../components/mui/MuiFormField';
 import { orisoMuiTheme } from '../../theme/orisoMuiTheme';
 import routePathNames from '../../appConfig';
@@ -114,17 +113,25 @@ const LoginForm = () => {
                             const { username, password } = getFieldsValue();
                             const formIsComplete = !!username && !!password;
                             return (
-                                <Button
+                                // The public surface's shared primary action — the same
+                                // control the tenant-admin onboarding submits with (see
+                                // TenantOnboarding/OrganisationDpaStep). It carries the
+                                // M3 filled treatment (--m3-primary / --m3-on-primary,
+                                // flat at rest, state-layer hover, visible focus ring)
+                                // instead of MUI's default contained button, whose
+                                // colour came from the hardcoded #273270 in
+                                // theme/orisoMuiTheme.ts and whose resting elevation
+                                // made it read as a stuck hover state.
+                                <M3Button
                                     type="submit"
-                                    variant="contained"
-                                    fullWidth
-                                    size="large"
-                                    disabled={!formIsComplete || postLoading}
-                                    startIcon={postLoading ? <CircularProgress size={18} color="inherit" /> : undefined}
-                                    sx={{ mt: 2, borderRadius: '100px', textTransform: 'none' }}
+                                    variant="filled"
+                                    block
+                                    className="loginSubmit"
+                                    disabled={!formIsComplete}
+                                    loading={postLoading}
                                 >
                                     {t('message.form.login.loginBtn')}
-                                </Button>
+                                </M3Button>
                             );
                         }}
                     </Form.Item>

--- a/src/styles/components/loginForm.less
+++ b/src/styles/components/loginForm.less
@@ -59,17 +59,45 @@
         max-width: 290px;
     }
 
+    /*
+     * The password-reset link is the only shrink-to-fit child of a form whose
+     * fields and submit button are full-width blocks, so left-aligned it sat
+     * ~100px left of the axis everything else shares (owner review of
+     * predev.oriso.org/admin: "Muss zentrierter sein"). A block-level box with
+     * auto inline margins puts it on that axis while keeping the hit target the
+     * size of the label — `text-align: center` on a full-width anchor would make
+     * the whole 320px row clickable.
+     *
+     * Its colour is the primary token, not the legacy `@primary-color` navy
+     * (#273270): that literal is the retired antd `colorPrimary` (see
+     * theme/antdM3Theme.ts) and it is what made the link read as off-palette
+     * next to the M3 submit button below it.
+     */
+
     .forgotPW {
-        display: inline-block;
+        display: block;
+        width: fit-content;
         padding: 0;
         margin-top: @spacing-m;
-        color: @primary-color;
+        margin-right: auto;
+        margin-left: auto;
+        color: var(--m3-primary, #a5000a);
         text-decoration: underline;
 
         span {
-            color: @primary-color;
+            color: var(--m3-primary, #a5000a);
             text-decoration: underline;
         }
+    }
+
+    /*
+     * The submit action is the shared M3 filled button (components/M3Button),
+     * which owns its own height, shape and colour tokens — only the gap to the
+     * link above it belongs to this form.
+     */
+
+    .loginSubmit {
+        margin-top: @spacing-sm;
     }
 
     .passwordResetForm .MuiTextField-root {


### PR DESCRIPTION
## Problem

Owner review of the Pre-Dev sign-in form: the `Forgot password?` link sits ~100px left of the axis the fields and the submit button share, and the submit button is an off-palette navy pill that reads as a stuck state layer rather than a solid M3 filled button.

## Root cause

The submit action was a raw MUI `<Button variant="contained">`. `theme/orisoMuiTheme.ts` gives MUI a single hardcoded `palette.primary.main = '#273270'` — the legacy antd `colorPrimary` that `theme/antdM3Theme.ts` retired everywhere else — so MUI derived the whole control from that literal: `--variant-containedBg: #273270`, elevation-2 **at rest** (raised to elevation-4 on hover, 6 on focus, 8 on active), no focus ring at all, and `rgba(0,0,0,.12)` / `rgba(0,0,0,.26)` when disabled. Nothing in the markup is a gradient — `background-image: none`, no `::before`/`::after`, no children — the "lighter middle section" is the white label plus that resting drop shadow on a button that already looks hovered. The same `#273270` literal also coloured the link.

## What changed

- `.forgotPW` is a block-level box with auto inline margins → on the form axis, hit target still the size of the label.
- Submit is the shared `M3Button variant="filled" block` — the same control `TenantOnboarding/OrganisationDpaStep` submits with. Colour from `--m3-primary` / `--m3-on-primary`, flat at rest, `color-mix` hover state layer, 2px `:focus-visible` ring, `loading` replaces the manual `CircularProgress` `startIcon`.
- The link takes `--m3-primary` too, so link and button stay on one palette.

## Verification

Real Chromium, `/admin/login`, 390x844 · 820x1180 · 1440x900, light and dark (the admin defines no `prefers-color-scheme` rules, so both render identically — measurements are byte-identical across schemes).

| measurement | before | after |
| --- | --- | --- |
| link centre − form centre | −119.57 / −100.82 / −100.82 px | **−0.01 px** at all three widths |
| resting background | `rgb(39,50,112)` (`#273270`, no token) | `rgb(165,0,10)` = resolved `--m3-primary` |
| resting box-shadow | MUI elevation-2 (3 stacked shadows) | `none` |
| hover | `rgb(27,35,78)` (MUI darken) | `color-mix(--m3-primary 90%, #000)` |
| `:focus-visible` outline | `0px none` (shadow only) | `2px solid rgb(165,0,10)` |
| height | 42.25px | 40px (M3) |

Screenshots (page + tight strips for disabled / resting / hover / focus, all three widths, no credential ever visible — the password field stays masked and the run aborts if `type !== "password"`) are attached below.

### Mutation test

Both hunks reverted individually against the new tests:

- revert `styles/components/loginForm.less` → `centres the password-reset link on the axis the fields and the submit button share` fails with `expected [ 'inline', 'inline-block' ] to not include 'inline-block'`; 12 other tests stay green.
- revert `pages/Login/LoginForm.tsx` → `renders sign in as the shared M3 filled button…` and `keeps the full-width submit block and the busy state…` fail on the missing `_filled_` / `_block_` class; 11 other tests stay green.
- both restored → 18/18 green in `src/pages/Login/`.

The centring test compiles the stylesheet the app really ships (`less.render` over `variables/index.less` + `loginForm.less`), applies it to the really rendered form and asserts through the actual cascade — not a regex over the source line.

### Commands

- `npx vitest run src/pages/Login/` → 18 passed
- `npx tsc --noEmit` → clean
- `npx eslint …` → clean · `npx prettier --check …` → clean · `npx stylelint …` → 0 errors
- `npm run test` (full) → the only failures are pre-existing: `src/pages/users/Edit/index.test.tsx` fails identically with this branch's files reverted to `origin/pre-dev`, and `src/pages/Links`, `DocumentMasterDataCard` time out non-deterministically under parallel load and pass in isolation.

## Follow-up, not in this PR

`M3Button`'s disabled state is `opacity: .38` on the fill, so a disabled **filled** button is a washed-out pink pill instead of M3's neutral `on-surface` 12%/38% treatment. That is existing shared-component behaviour (it already ships on the onboarding steps), and the sign-in form opens in exactly that state — but changing it repaints every disabled `M3Button` in the admin, so it wants its own decision rather than a drive-by edit here.
