### PR TITLE
fix(login): keep the public stage headline in the UI language

### DIFF
--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -16,7 +16,6 @@ import { useAppConfigContext } from '../../context/useAppConfig';
 export interface LoginSurfaceProps {
     /** Platform logo from Theme settings → Appearance (#594.14). */
     logo?: string | null;
-    claim?: string | null;
 }
 
 /**
@@ -28,9 +27,9 @@ export interface LoginSurfaceProps {
  * route renders — #594 asks for the login and the onboarding page to be
  * comparable side by side, and a story that rebuilds the markup would drift.
  */
-export const LoginSurface = ({ logo, claim }: LoginSurfaceProps) => (
+export const LoginSurface = ({ logo }: LoginSurfaceProps) => (
     <PublicPageLayoutWrapper className="login flex-col flex" footerVariant="stage">
-        <Stage logo={logo} claim={claim} />
+        <Stage logo={logo} />
         <Row align="middle" style={{ flex: '1 0 auto' }}>
             <Col xs={{ span: 22, offset: 1 }} md={{ span: 6, offset: 3 }} xl={{ span: 4, offset: 6 }}>
                 <LoginForm />
@@ -52,7 +51,6 @@ export const Login = () => {
     const tokenExpiry = getTokenExpiryFromLocalStorage();
     const { data: tenantData } = usePublicTenantData();
     const logo = tenantData?.theming?.logo;
-    const claim = tenantData?.content?.claim;
     const { hasRole, isTechnicalAccount } = useUserRoles();
     const accessTokenValidInMs = tokenExpiry.accessTokenValidUntilTime - currentTime;
 
@@ -114,5 +112,5 @@ export const Login = () => {
         settings.mainTenantSubdomainForSingleDomainMultitenancy,
     ]);
 
-    return redirectUrl ? <Navigate to={redirectUrl} /> : <LoginSurface logo={logo} claim={claim} />;
+    return redirectUrl ? <Navigate to={redirectUrl} /> : <LoginSurface logo={logo} />;
 };

--- a/src/pages/Login/LoginStageLanguage.test.tsx
+++ b/src/pages/Login/LoginStageLanguage.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Login } from './Login';
+
+/**
+ * Regression cover for the login-stage language flip (#594 follow-up).
+ *
+ * Measured on Pre-Dev: `GET /service/tenant/public/online-beratung` answers
+ * `content.claim = "Lets make this project running."` — a single, already
+ * language-RESOLVED string. TenantService flattens the stored multilingual map
+ * server-side (`TenantConverter#getTranslatedStringFromMap`) picking the
+ * language from a `lang` cookie and silently falling back to `de`, so the
+ * client cannot tell which language it received.
+ *
+ * The stage rendered `{claim || t('slogan')}`: the localized headline painted
+ * first and was then REPLACED when the (serial) settings → tenant request chain
+ * resolved. That is both a visible content jump and — because the resolved
+ * claim carries no language — a headline in a different language than the rest
+ * of the surface, which is what the owner saw (German form + footer, English
+ * headline, language menu still on DE).
+ *
+ * The headline of an operator surface must therefore stay the localized product
+ * name and must not change when tenant content arrives.
+ */
+
+const tenantData = vi.hoisted(() => ({ current: undefined as unknown }));
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string) => (key === 'slogan' ? 'Beratung & Hilfe - Verwaltung' : key),
+        i18n: { language: 'de' },
+    }),
+}));
+
+vi.mock('./LoginForm', () => ({
+    default: () => <div data-testid="login-form" />,
+}));
+
+vi.mock('../../components/Layout/PublicPageLayoutWrapper', () => ({
+    default: ({ children, className }: React.PropsWithChildren<{ className?: string }>) => (
+        <main className={className}>{children}</main>
+    ),
+}));
+
+vi.mock('../../api/auth/auth', () => ({
+    bootstrapAuthSession: () =>
+        new Promise(() => {
+            // Keep the bootstrap pending so the component stays on the login route.
+        }),
+    getAccessTokenForRequests: () => '',
+}));
+
+vi.mock('../../api/auth/accessSessionLocalStorage', () => ({
+    getTokenExpiryFromLocalStorage: () => ({
+        accessTokenValidUntilTime: 0,
+        refreshTokenValidUntilTime: 0,
+    }),
+}));
+
+vi.mock('../../hooks/useUserRoles.hook', () => ({
+    useUserRoles: () => ({ hasRole: () => false, isTechnicalAccount: false }),
+}));
+
+vi.mock('../../hooks/usePublicTenantData.hook', () => ({
+    usePublicTenantData: () => ({ data: tenantData.current }),
+}));
+
+vi.mock('../../context/useAppConfig', () => ({
+    useAppConfigContext: () => ({
+        settings: { mainTenantSubdomainForSingleDomainMultitenancy: '' },
+    }),
+}));
+
+/** The exact payload Pre-Dev serves for tenant 1 (`caritas-berlin`). */
+const PRE_DEV_TENANT = {
+    theming: { logo: null },
+    content: { claim: 'Lets make this project running.' },
+};
+
+const renderLogin = () =>
+    render(
+        <MemoryRouter>
+            <Login />
+        </MemoryRouter>,
+    );
+
+const headline = () => document.querySelector('.stage__headline h1')?.textContent;
+
+describe('Login stage language', () => {
+    beforeEach(() => {
+        tenantData.current = undefined;
+    });
+
+    it('keeps the localized headline once tenant content resolves', () => {
+        const { rerender } = renderLogin();
+
+        expect(headline()).toBe('Beratung & Hilfe - Verwaltung');
+
+        // The settings → tenant request chain resolves and tenant content lands.
+        tenantData.current = PRE_DEV_TENANT;
+        rerender(
+            <MemoryRouter>
+                <Login />
+            </MemoryRouter>,
+        );
+
+        expect(headline()).toBe('Beratung & Hilfe - Verwaltung');
+    });
+
+    it('never shows the language-resolved tenant claim on the operator surface', () => {
+        tenantData.current = PRE_DEV_TENANT;
+
+        renderLogin();
+
+        expect(screen.queryByText('Lets make this project running.')).toBeNull();
+    });
+});

--- a/src/pages/Login/Stage.tsx
+++ b/src/pages/Login/Stage.tsx
@@ -13,10 +13,9 @@ export interface StageProps {
      * (`theming.logo` on the public tenant data — the exact source the app
      * layer reads, see `Tenants/GeneralSettings/components/LogoAndFavicon`).
      * When it is not configured — or the URL fails to load — the panel simply
-     * shows the claim; there is no stand-in artwork any more (#594.14).
+     * shows the headline; there is no stand-in artwork any more (#594.14).
      */
     logo?: string | null;
-    claim?: string | null;
 }
 
 /**
@@ -25,13 +24,24 @@ export interface StageProps {
  * Its surface is the shared `--m3-on-background` token, i.e. literally the
  * desktop sidebar's colour (#594.13a) — see styles/components/stage.less.
  *
+ * Language: the headline pair is the localized ADMIN product name and nothing
+ * else. It deliberately does NOT show the tenant's public claim
+ * (`content.claim`). TenantService resolves that field server-side out of a
+ * multilingual map — picking the language from a `lang` cookie the admin does
+ * not set and silently falling back to `de`
+ * (`TenantConverter#getTranslatedStringFromMap`) — so the value that arrives
+ * here carries no language of its own. Rendering it replaced the localized
+ * headline once the (serial) settings → tenant request chain resolved, which
+ * both flipped this operator surface into whatever language the claim happened
+ * to be written in and produced a visible content jump on every cold load.
+ *
  * Branding (#594.14): it used to fall back to a hardcoded Lottie animation
  * (`resources/animations/admin_panel.json`) whenever no tenant logo was set,
  * which is what put a stand-in animation next to an uploaded test asset on the
  * onboarding page. The panel now shows exactly one thing — the logo configured
  * in Theme settings → Appearance — and nothing when none is configured.
  */
-const Stage = ({ className, hasAnimation, isReady = true, logo, claim }: StageProps) => {
+const Stage = ({ className, hasAnimation, isReady = true, logo }: StageProps) => {
     const { t } = useTranslation();
     const [logoFailed, setLogoFailed] = useState(false);
     const showTenantLogo = Boolean(logo) && !logoFailed;
@@ -44,7 +54,7 @@ const Stage = ({ className, hasAnimation, isReady = true, logo, claim }: StagePr
                 </div>
             )}
             <div className="stage__headline">
-                <Title level={1}>{claim || t('slogan')}</Title>
+                <Title level={1}>{t('slogan')}</Title>
                 <Title level={3}>{t('subSlogan')}</Title>
             </div>
             <Spinner className={clsx('stage__spinner', !hasAnimation && 'hidden')} />

--- a/src/pages/PasswordReset/PasswordResetPageLayout.tsx
+++ b/src/pages/PasswordReset/PasswordResetPageLayout.tsx
@@ -48,7 +48,7 @@ export const PasswordResetPageLayout = ({ children, variant = 'login' }: Passwor
             {/* The Admin panel's branding fade plays once on EVERY public page
                 (#594.3). It is fixed-position and settles off-canvas below xl,
                 so it never covers a long form after its intro. */}
-            <Stage logo={tenantData?.theming?.logo} claim={tenantData?.content?.claim} />
+            <Stage logo={tenantData?.theming?.logo} />
             <Row align={isLongForm || isWizard ? 'top' : 'middle'} style={{ flex: '1 0 auto' }}>
                 <Col
                     xs={{ span: 20, offset: 2 }}


### PR DESCRIPTION
## Problem

The sign-in stage rendered `{claim || t('slogan')}`. The localized headline painted first and was then **replaced** by the tenant's public claim once the serial `/service/settings` → `/service/tenant/public/…` chain resolved — a visible content jump, and a headline in a different language than the rest of the surface.

Measured on Pre-Dev: `GET /service/tenant/public/online-beratung` returns `content.claim = "Lets make this project running."`. TenantService resolves that field server-side from a multilingual map, picking the language from a `lang` cookie the admin never sets (it stores `oriso-admin.language`) and silently falling back to `de` — `TenantConverter#getTranslatedStringFromMap`. The string that reaches the admin therefore carries **no language of its own**, so the client cannot tell whether it matches the active UI language.

## What changed

- `Stage` renders the localized `t('slogan')`/`t('subSlogan')` only; the tenant claim no longer overrides it.
- Dropped the now-dead `claim` plumbing from `Login`/`LoginSurface` and `PasswordResetPageLayout`.
- The tenant logo is unaffected — that branding is language-neutral.
- New regression test `LoginStageLanguage.test.tsx` asserts the headline is unchanged before/after tenant content resolves, using the exact Pre-Dev payload.

## Verification

- `npx vitest run src/pages/Login/ src/pages/PasswordReset/` → 40/40 pass.
- `npx tsc --noEmit`, `eslint --max-warnings=0`, `prettier --check` on changed files → clean.
- Full suite: 2049 passed; the 4 failures in `src/pages/Links/*` reproduce unchanged on clean `origin/pre-dev` (pre-existing).
- Live against Pre-Dev data via dev proxy: API still serves the claim, DOM never contains it; DE → "Beratung & Hilfe - Verwaltung" / "Online. Anonym. Sicher.", EN → "Counseling & Help - Administration" / "Online. Anonymous. Secure.".

### Mutation test

Re-introduced the defect (`{claim || t('slogan')}` plus the `claim` prop and its `Login` plumbing) and re-ran the new test:

```
× keeps the localized headline once tenant content resolves
    AssertionError: expected 'Lets make this project running.' to be 'Beratung & Hilfe - Verwaltung'
× never shows the language-resolved tenant claim on the operator surface
    AssertionError: expected <h1 …(1)></h1> to be null
Tests  2 failed (2)
```

Both tests are killed by the mutation and pass on the fix.

## Out of scope — handed over, not fixed here

1. **Data (do not fix on Pre-Dev):** tenant `id=1` (`caritas-berlin`, subdomain `online-beratung`), column `tenant.content_claim`, value `{"de": "Lets make this project running."}` — English test content stored in the German slot.
2. **TenantService:** the public claim is flattened server-side with a silent `de` fallback, so no client can detect a language mismatch.
3. **Admin claim editor:** `Tenants/GeneralSettings/components/NameAndSlogan` binds `['content','claim','de']` — hardcoded German, so a non-German claim cannot be authored at all.