### PR TITLE
fix(m3button): give disabled its M3 neutral container instead of fading the brand

### DIFF
--- a/src/components/M3Button/M3Button.stories.tsx
+++ b/src/components/M3Button/M3Button.stories.tsx
@@ -36,7 +36,40 @@ export const Outlined: Story = {
 export const Filled: Story = { args: { variant: 'filled', icon: <UploadIcon />, children: 'Upload' } };
 export const Tonal: Story = { args: { variant: 'tonal', children: 'Batch Mode' } };
 export const Disabled: Story = { args: { variant: 'filled', disabled: true, children: 'Upload' } };
+export const DisabledText: Story = { args: { variant: 'text', disabled: true, children: 'Next' } };
+export const DisabledOutlined: Story = {
+    args: { variant: 'outlined', disabled: true, icon: <PlusIcon />, children: 'additional postal code' },
+};
+export const DisabledTonal: Story = { args: { variant: 'tonal', disabled: true, children: 'Batch Mode' } };
 export const Loading: Story = { args: { variant: 'outlined', loading: true, children: 'Save' } };
+
+/**
+ * Every variant disabled, side by side — the view that makes a regression
+ * obvious. M3 disables a filled or tonal button by neutralising its container
+ * (`on-surface` 12%) and dropping the label to 38%; the brand colour must not
+ * survive. A blanket `opacity` on the control instead produces a faded pink
+ * pill, which is exactly what the admin sign-in form showed once its submit
+ * button moved to `M3Button` (PR #839) — the login page's initial state IS the
+ * disabled state.
+ */
+export const AllVariantsDisabled: StoryObj = {
+    render: () => (
+        <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'center' }}>
+            <M3Button variant="text" disabled>
+                Back
+            </M3Button>
+            <M3Button variant="outlined" disabled icon={<PlusIcon />}>
+                additional postal code
+            </M3Button>
+            <M3Button variant="filled" disabled icon={<UploadIcon />}>
+                Upload
+            </M3Button>
+            <M3Button variant="tonal" disabled>
+                Batch Mode
+            </M3Button>
+        </div>
+    ),
+};
 
 export const AllVariants: StoryObj = {
     render: () => (

--- a/src/components/M3Button/m3Button.styles.test.ts
+++ b/src/components/M3Button/m3Button.styles.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const moduleStyles = readFileSync(resolve(__dirname, './styles.module.scss'), 'utf8');
+
+/*
+ * Disabled contract of the shared M3 button.
+ *
+ * Before this file existed the rule was a single blanket
+ * `.button:disabled { opacity: 0.38 }`. That fades the WHOLE control,
+ * container included, so a disabled `filled` button rendered as the primary
+ * red at 38% — a washed-out pink pill — and `tonal` as a washed-out slate.
+ *
+ * Material 3 specifies the opposite: a disabled filled or tonal button is a
+ * NEUTRAL container, `on-surface` at 12%, with its label at `on-surface` 38%.
+ * The brand colour must not survive into the disabled state at all.
+ *
+ * This became owner-visible on the admin sign-in form: PR #839 moved
+ * `src/pages/Login/LoginForm.tsx` from a raw MUI `<Button variant="contained">`
+ * to `<M3Button variant="filled" block>`, and the login page's INITIAL state is
+ * the disabled state — so the faded pink pill was the first thing anyone saw.
+ * `src/pages/TenantOnboarding/AccountStep.tsx` ships the same treatment via
+ * `disabled={busy}`.
+ *
+ * If an assertion here goes red, that pill is back. Read this comment and the
+ * PR that introduced the assertion before deleting it.
+ */
+describe('M3Button — disabled treatment (M3 neutral container, not faded brand)', () => {
+    it('does not fade the whole control with a blanket opacity', () => {
+        const blockRule = moduleStyles.match(/\.button:disabled\s*\{[^}]*\}/)?.[0] ?? '';
+        expect(blockRule).not.toMatch(/opacity/);
+    });
+
+    it('keeps the not-allowed cursor on every disabled variant', () => {
+        const blockRule = moduleStyles.match(/\.button:disabled\s*\{[^}]*\}/)?.[0] ?? '';
+        expect(blockRule).toMatch(/cursor:\s*not-allowed/);
+    });
+
+    it('gives a disabled filled button a neutral 12% container and a 38% label', () => {
+        const rule = moduleStyles.match(/\.filled:disabled\s*\{[^}]*\}/)?.[0] ?? '';
+        expect(rule).toMatch(/--m3-on-surface/);
+        expect(rule).toMatch(/12%/);
+        expect(rule).toMatch(/38%/);
+        // The brand colour must not survive into the disabled state.
+        expect(rule).not.toMatch(/--m3-primary/);
+    });
+
+    it('gives a disabled tonal button the same neutral treatment', () => {
+        const rule = moduleStyles.match(/\.tonal:disabled\s*\{[^}]*\}/)?.[0] ?? '';
+        expect(rule).toMatch(/--m3-on-surface/);
+        expect(rule).toMatch(/12%/);
+        expect(rule).toMatch(/38%/);
+        expect(rule).not.toMatch(/--m3-secondary-container/);
+    });
+
+    it('fades only the label on text and outlined — they have no filled container to neutralise', () => {
+        const textRule = moduleStyles.match(/\.text:disabled\s*\{[^}]*\}/)?.[0] ?? '';
+        expect(textRule).toMatch(/38%/);
+        expect(textRule).not.toMatch(/background:/);
+
+        const outlinedRule = moduleStyles.match(/\.outlined:disabled\s*\{[^}]*\}/)?.[0] ?? '';
+        expect(outlinedRule).toMatch(/38%/);
+        // M3 dims the outline too, at 12%.
+        expect(outlinedRule).toMatch(/12%/);
+    });
+});

--- a/src/components/M3Button/styles.module.scss
+++ b/src/components/M3Button/styles.module.scss
@@ -23,9 +23,14 @@
     outline-offset: 2px;
 }
 
+/* Disabled is per-variant, NOT a blanket opacity on the control.
+   Fading the whole button keeps the brand colour and merely dilutes it — a
+   disabled `filled` then reads as a pale pink pill. M3 wants the opposite: the
+   container goes neutral (`on-surface` 12%) and only the label carries the 38%
+   emphasis drop. See `m3Button.styles.test.ts` for why this is pinned. */
+
 .button:disabled {
     cursor: not-allowed;
-    opacity: 0.38;
 }
 
 .block {
@@ -57,6 +62,10 @@
     background: color-mix(in srgb, var(--m3-primary, #a5000a) 8%, transparent);
 }
 
+.text:disabled {
+    color: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 38%, transparent);
+}
+
 /* outlined — "+ additional postal code", "Link OTP App". */
 .outlined {
     border: 1px solid var(--m3-outline-variant, #c4c7c8);
@@ -65,6 +74,11 @@
 
 .outlined:not(:disabled):hover {
     background: var(--m3-state-layer-on-surface, rgb(27 27 28 / 8%));
+}
+
+.outlined:disabled {
+    border-color: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 12%, transparent);
+    color: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 38%, transparent);
 }
 
 /* filled — primary call to action ("Upload", "Send invitation"). */
@@ -77,6 +91,11 @@
     background: color-mix(in srgb, var(--m3-primary, #a5000a) 90%, #000000);
 }
 
+.filled:disabled {
+    background: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 12%, transparent);
+    color: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 38%, transparent);
+}
+
 /* tonal — secondary emphasis. */
 .tonal {
     background: var(--m3-secondary-container, #646d78);
@@ -85,4 +104,9 @@
 
 .tonal:not(:disabled):hover {
     background: color-mix(in srgb, var(--m3-secondary-container, #646d78) 90%, #000000);
+}
+
+.tonal:disabled {
+    background: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 12%, transparent);
+    color: color-mix(in srgb, var(--m3-on-surface, #1b1b1c) 38%, transparent);
 }


### PR DESCRIPTION
## Problem

`src/components/M3Button/styles.module.scss` implemented disabled as one blanket rule:

```scss
.button:disabled {
    cursor: not-allowed;
    opacity: 0.38;
}
```

Fading the whole control keeps the brand colour and merely dilutes it. A disabled `filled` button therefore rendered as the primary red at 38% — a washed-out pink pill — and `tonal` as a washed-out slate.

Material 3 specifies the opposite for filled and tonal: the container goes **neutral** (`on-surface` at 12%) and only the **label** carries the 38% emphasis drop. The brand colour must not survive into the disabled state at all.

## Why it surfaced now

It has shipped for a while on the tenant-onboarding steps (`src/pages/TenantOnboarding/AccountStep.tsx` passes `disabled={busy}`), where it is a transient state nobody stares at.

#839 moved `src/pages/Login/LoginForm.tsx` from a raw MUI `<Button variant="contained">` to `<M3Button variant="filled" block>` — and **the login page's initial state is exactly the disabled state**. So the faded pink pill became the first thing anyone sees when opening the admin panel.

#839 is correct and is not the cause; it made an existing defect visible.

## Fix

Per-variant treatment using the tokens already in `src/app.css`, written in the `color-mix` idiom the file already uses for its hover states:

| variant | container | label | outline |
|---|---|---|---|
| `text` | none | `on-surface` 38% | — |
| `outlined` | none | `on-surface` 38% | `on-surface` 12% |
| `filled` | `on-surface` 12% | `on-surface` 38% | — |
| `tonal` | `on-surface` 12% | `on-surface` 38% | — |

`cursor: not-allowed` stays on `.button:disabled`, and the `disabled || loading` wiring in `src/components/M3Button/index.tsx` is untouched. No new colour value, no one-off component.

## Evidence

Real browser, computed styles against the compiled stylesheet with the real `app.css` token values:

| button | background | label | opacity | cursor |
|---|---|---|---|---|
| text (disabled) | `rgba(0,0,0,0)` | `on-surface / 0.38` | 1 | not-allowed |
| outlined (disabled) | `rgba(0,0,0,0)`, outline `/ 0.12` | `on-surface / 0.38` | 1 | not-allowed |
| filled (disabled) | `on-surface / 0.12` | `on-surface / 0.38` | 1 | not-allowed |
| tonal (disabled) | `on-surface / 0.12` | `on-surface / 0.38` | 1 | not-allowed |
| filled (enabled, control) | `rgb(165, 0, 10)` = `--m3-primary` | `#fff` | 1 | pointer |

No brand colour in any disabled state; `opacity` is back to `1` everywhere; the enabled appearance is unchanged.

### Mutation test

| mutation | result |
|---|---|
| restore the blanket `opacity: 0.38` | first assertion red |
| point `.filled:disabled` back at `--m3-primary` | filled assertion red |
| restore both hunks | 5/5 green |

### Other checks

Node 22.12.0 (`.nvmrc`): `tsc --noEmit` clean · `eslint --max-warnings=0` clean · `prettier --check` clean · `stylelint` 0 errors (6 pre-existing warnings, unchanged) · M3Button-consumer suites (`cards`, `ConsultantPicker`, `TwoFactorSetup`, `pages/Login`) 6 files / 29 tests green.

### Verification limits, stated plainly

Storybook renders in this environment but its stories could not be measured through the automated browser: MSW fails to register its service worker there, so every story shows the addon's error panel instead of the component. The numbers above therefore come from the **compiled stylesheet applied to the real markup in a real browser**, not from the Storybook canvas. The story-level component suite (#699) is not on this base, so no automated a11y-addon run happened either — the disabled contrast values (38% label on a 12% container) match the M3 disabled spec, but a reviewer opening Storybook should confirm the addon is quiet.

## Stories

Every variant now has a disabled story (`DisabledText`, `DisabledOutlined`, `DisabledTonal` alongside the existing `Disabled`), plus `AllVariantsDisabled` — one row showing all four, so this regression is obvious at a glance next time.

## Reviewer test plan

- [ ] Open `atoms-m3button--all-variants-disabled` in Storybook: all four read as neutral grey, none pink or slate
- [ ] Check the a11y addon is quiet on the new disabled stories
- [ ] Admin sign-in page with empty fields: the submit button is a neutral grey pill, not faded pink
- [ ] Type into both fields: the button becomes the red filled button
- [ ] Tenant onboarding, account step: the button during `busy` is neutral grey
- [ ] 390x844, 820x1180, 1440x900 — no disabled `M3Button` elsewhere in the admin regressed
