### PR TITLE
fix(card-deck): scroll the settings deck freely instead of snapping to card edges

### DIFF
--- a/src/components/CardDeck/styles.module.scss
+++ b/src/components/CardDeck/styles.module.scss
@@ -6,6 +6,11 @@
     flex-direction: column;
 }
 
+// Deliberately free of scroll snapping. A deck of settings cards is a document
+// the reader pans across, not a media carousel: snapping pulled the deck onto
+// the next card edge and made it impossible to rest between two cards and read
+// them side by side. `scroll-behavior: smooth` stays — it only smooths the
+// programmatic scrolls of the header arrows, never the reader's own drag.
 .deck {
     width: 100%;
     min-width: 0;
@@ -16,7 +21,6 @@
     overflow-y: hidden;
     overscroll-behavior-x: contain;
     scroll-behavior: smooth;
-    scroll-snap-type: x proximity;
     scrollbar-width: none;
     touch-action: pan-x pan-y;
 
@@ -55,7 +59,6 @@
     // toolbar silently doubles the card and pushes its siblings off-screen.
     max-width: min(var(--card-deck-item-width, 392px), var(--card-deck-item-max-width, var(--deck-item-cap)));
     flex: 0 0 min(var(--card-deck-item-width, 392px), var(--card-deck-item-max-width, var(--deck-item-cap)));
-    scroll-snap-align: start;
 
     > * {
         width: 100%;
@@ -70,7 +73,6 @@
     .deck {
         overflow: visible;
         padding: var(--card-deck-mobile-padding, 0);
-        scroll-snap-type: none;
     }
 
     .list {
@@ -106,7 +108,6 @@
         overflow: visible;
         padding: var(--card-deck-mobile-padding, 0);
         gap: var(--card-deck-mobile-gap, 24px);
-        scroll-snap-type: none;
     }
 
     .list {

--- a/src/components/CardDeck/styles.test.ts
+++ b/src/components/CardDeck/styles.test.ts
@@ -52,3 +52,33 @@ describe('CardDeck responsive contract', () => {
         expect(listRule).toMatch(/gap:\s*var\(--card-deck-gap,\s*var\(--admin-card-gap,\s*48px\)\)/);
     });
 });
+
+// A deck of settings cards is a document, not a media carousel: dragging it
+// sideways must come to rest where the reader let go instead of being tugged
+// onto the next card edge — which is what kept two cards from being read side
+// by side. Snapping was already off for the stacked and mobile variants, so the
+// desktop scroller was the only surface that still pulled.
+describe('CardDeck free horizontal scrolling', () => {
+    it('leaves the scroller and its cards free of snap points', () => {
+        const deckRule = cardDeckStyles.match(/\n\.deck\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+        const itemRule = cardDeckStyles.match(/\n\.item\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+
+        expect(deckRule).not.toMatch(/scroll-snap-type/);
+        expect(itemRule).not.toMatch(/scroll-snap-align/);
+    });
+
+    // Deliberately file-wide: a snap axis re-armed under any selector — a new
+    // variant, a breakpoint, a state class — brings the pull straight back.
+    it('never re-arms scroll snapping in a deck variant or breakpoint', () => {
+        expect(cardDeckStyles).not.toMatch(/scroll-snap/);
+    });
+
+    // Free must not become frozen: the cards still have to reach their full
+    // range under pointer, wheel and touch.
+    it('keeps the deck scrolling horizontally', () => {
+        const deckRule = cardDeckStyles.match(/\n\.deck\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+
+        expect(deckRule).toMatch(/overflow-x:\s*auto/);
+        expect(deckRule).toMatch(/touch-action:[^;]*pan-x/);
+    });
+});


### PR DESCRIPTION
## Problem

The settings card deck pulled a released drag onto the next card edge, so two cards
could never be held on screen together. Most visible on `settings/legal`. Measured on
pre-dev at 1440x900: released at scrollLeft 274, rested at 477 — a 203px pull.

## What changed

- `.deck` loses `scroll-snap-type: x proximity`; `.item` loses `scroll-snap-align: start`.
- The two now-dead `scroll-snap-type: none` overrides (`.stacked`, `<=767px`) go with them —
  with no base declaration they only restated the initial value.
- `src/components/CardDeck/styles.test.ts`: three assertions — no snap axis on the
  scroller, no snap target on the cards, no snap re-armed anywhere in the file, and a
  guard that the deck still scrolls (`overflow-x: auto`, `touch-action: pan-x`).

## Scope: the shared deck, not just legal settings

`CardDeck` is shared, so this was a deliberate call. Every consumer on `pre-dev` is a
settings surface, not a carousel — `Tenants/LegalSettings`, `Tenants/GeneralSettings`,
`Tenants/AppSettings/PermissionsSettings`, `pages/GlobalSettings`, `pages/Agency/Edit`
(4 decks), `pages/Tenants/Edit/General`, `pages/Tenants/Edit/AppSettings`. Snapping was
already off in the `.stacked` variant and the mobile breakpoint, so the desktop deck was
the odd one out rather than the norm. Scoping the fix to legal settings alone would have
left two identical-looking surfaces behaving differently.

Genuine carousels keep their snapping and are untouched: `ThemeBuilder`'s swatch picker
(`x mandatory` + `align: center`) and the product tour. `SectionCarousel` does not exist
on `pre-dev`.

`CardDeck/index.tsx` needs no change: the arrow buttons scroll by `cardStep` and the
position dots round `scrollLeft / cardStep`, both of which are snap-independent.

## Verification

TDD. Two of the three new assertions were red before the fix; the `overflow-x` guard is
a characterisation test against over-removal and passed both sides.

**Mutation test** — three mutants applied to the merged file, each caught, then restored:

| Mutant | Result |
| --- | --- |
| re-add `scroll-snap-type: x proximity` to `.deck` | 2 failed / 7 passed |
| re-add `scroll-snap-align: start` to `.item` | 2 failed / 7 passed |
| delete `overflow-x: auto` from `.deck` (over-removal) | 1 failed / 8 passed |
| restored | 16 passed |

**Real browser** (Chromium, Playwright). BEFORE re-arms the two declarations, AFTER is
as shipped; `released@` is where the gesture ended, `rested@` where the deck settled.

Storybook `Molecules/CardDeck`, compiled from this branch:

| Viewport | snap-type | snap-align | released@ | rested@ | drift |
| --- | --- | --- | --- | --- | --- |
| 390x844 BEFORE/AFTER | `x` -> `none` | `start` -> `none` | stacked, no horizontal scroller | | |
| 820x1180 BEFORE/AFTER | `x` -> `none` | `start` -> `none` | stacked, no horizontal scroller | | |
| 1440x900 BEFORE | `x` | `start` | 257 | 444 (card edge) | +187 |
| 1440x900 AFTER | `none` | `none` | 257 | 257 | 0 |

Live pre-dev, read-only, platform-admin session, 1440x900 — the diff's computed effect
applied client-side to the deployed page, nothing written back:

| Page | BEFORE released@ -> rested@ | AFTER released@ -> rested@ |
| --- | --- | --- |
| `theme-settings/legal` | 274 -> 477 (edge, +203) | 274 -> 274 (0) |
| `theme-settings/general` | 245 -> 420 (edge, +175) | 245 -> 245 (0) |
| `theme-settings/permissions` | 274 -> 477 (edge, +203) | 274 -> 274 (0) |

At 390x844 and 820x1180 the deployed deck already computes `scroll-snap-type: none` via
the mobile breakpoint and the `.stacked` variant, and screenshots are pixel-identical
BEFORE/AFTER — this change is desktop-only in effect. Deck still reaches its full scroll
range (`reachesEnd: true`); card spacing, position dots and header arrows unchanged.

`npm run test` 291 files / 2054 tests passed (Node 22.12.0 per `.nvmrc`). eslint clean,
prettier clean, stylelint unchanged vs baseline (0 errors, same 17 pre-existing warnings).

Closes #846
