### PR TITLE
fix(editor): headline-scale document headings + trailing-paragraph caret rescue

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -30,6 +30,20 @@ initialize({
     serviceWorker: { url: new URL('mockServiceWorker.js', window.location.href).href },
 });
 
+// Registration can fail wholesale in embedded/sandboxed browsers that refuse
+// service workers. Stories that declare no `parameters.msw.handlers` never
+// talk to the worker, so a failed registration must degrade to "no mocking"
+// instead of replacing EVERY story with the MSW error page.
+const tolerantMswLoader: typeof mswLoader = async (context) => {
+    try {
+        return await mswLoader(context);
+    } catch (error) {
+        if (context.parameters?.msw) throw error;
+        console.warn('[storybook] MSW worker unavailable, story runs unmocked:', error);
+        return {};
+    }
+};
+
 const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
 });
@@ -64,7 +78,7 @@ const preview: Preview = {
             storySort: { order: ['Atoms', 'Molecules', 'Organisms', '*'] },
         },
     },
-    loaders: [mswLoader],
+    loaders: [tolerantMswLoader],
     decorators: [
         (Story) => (
             <QueryClientProvider client={queryClient}>

--- a/src/components/FormPluginEditor/M3RichTextEditor.module.scss
+++ b/src/components/FormPluginEditor/M3RichTextEditor.module.scss
@@ -198,26 +198,10 @@ $m3-state-active: rgb(39 50 112 / 12%);
         height: auto;
     }
 
-    // The display-size heading scale is made for the 800px deck card. In a
-    // sign-in-sized column it swallows the surface, so the fluid reader keeps
-    // the compact headline scale at every width.
-    .editor {
-        :global(.ProseMirror h1) {
-            font-size: 32px;
-            letter-spacing: 0;
-            line-height: 40px;
-        }
-
-        :global(.ProseMirror h2) {
-            font-size: 26px;
-            line-height: 34px;
-        }
-
-        :global(.ProseMirror h3) {
-            font-size: 22px;
-            line-height: 30px;
-        }
-    }
+    // No heading override here any more: since the owner's 2026-08-19 call
+    // the base scale IS the compact M3 headline scale at every width, so the
+    // fluid reader simply inherits it (headingScale.styles.test.ts pins one
+    // uniform scale across all surfaces).
 }
 
 // Fluid READ mode (owner demo 2026-08-19, reversing #594.3 for reading): with
@@ -1009,25 +993,31 @@ $m3-state-active: rgb(39 50 112 / 12%);
         cursor: pointer;
     }
 
-    // Heading scale (Figma 1280-73020): M3 display sizes on desktop, headline
-    // sizes on mobile — body text follows body-large / body-medium.
+    // Heading scale: M3 HEADLINE roles at every width — body text follows
+    // body-large / body-medium. Figma 1280-73020 put the M3 DISPLAY sizes
+    // (57/45/36, the hero/marketing role) on the desktop editor; the owner
+    // overrode that on 2026-08-19 ("die Header sind ... eindeutig oft zu
+    // groß ... das muss nicht so riesig sein"): running document text keeps
+    // the document relationship (h1 = 2x body, not 3.5x), which is exactly
+    // the scale the mobile breakpoint used all along. Contract-tested in
+    // headingScale.styles.test.ts — do not re-grow one surface only.
     :global(.ProseMirror h1) {
-        font-size: 57px;
+        font-size: 32px;
         font-weight: 400;
-        letter-spacing: -0.25px;
-        line-height: 64px;
+        letter-spacing: 0;
+        line-height: 40px;
     }
 
     :global(.ProseMirror h2) {
-        font-size: 45px;
+        font-size: 28px;
         font-weight: 400;
-        line-height: 52px;
+        line-height: 36px;
     }
 
     :global(.ProseMirror h3) {
-        font-size: 36px;
+        font-size: 24px;
         font-weight: 400;
-        line-height: 44px;
+        line-height: 32px;
     }
 
     :global(.ProseMirror p) {
@@ -1037,22 +1027,6 @@ $m3-state-active: rgb(39 50 112 / 12%);
     }
 
     @media (max-width: 599px) {
-        :global(.ProseMirror h1) {
-            font-size: 32px;
-            letter-spacing: 0;
-            line-height: 40px;
-        }
-
-        :global(.ProseMirror h2) {
-            font-size: 28px;
-            line-height: 36px;
-        }
-
-        :global(.ProseMirror h3) {
-            font-size: 24px;
-            line-height: 32px;
-        }
-
         :global(.ProseMirror p) {
             font-size: 14px;
             letter-spacing: 0.25px;

--- a/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
@@ -113,6 +113,67 @@ export const AnchorRowNarrowOverflow: Story = {
     ],
 };
 
+// The owner's caret trap (2026-08-19): a document that ends with a heading
+// left ~184px of empty editor surface in which EVERY click put the caret into
+// the heading — typing produced giant heading text. Contract under test
+// (Word's click-and-type): clicking the empty space below a final heading
+// creates a body paragraph and the caret lands in it (trailingParagraph.ts).
+// This play function runs against the real browser layout — jsdom has none.
+export const CaretBelowHeadingLandsInBodyText: Story = {
+    render: (args) => <ControlledEditor {...args} />,
+    args: {
+        title: 'Datenschutz',
+        value: '<h1>Datenschutzerklärung</h1>',
+        languages: [{ value: 'de', label: 'Deutsch' }],
+        language: 'de',
+    },
+    play: async ({ canvasElement }) => {
+        const editorNode = await waitFor(() => {
+            const node = canvasElement.querySelector<HTMLElement>('.ProseMirror');
+            expect(node).not.toBeNull();
+            return node!;
+        });
+
+        // The guarantee paragraph must exist below the final heading.
+        await waitFor(() => expect(editorNode.querySelector('h1 + p')).not.toBeNull());
+
+        // Click into the dead space between the heading's bottom and the
+        // editor surface's bottom (its min-height keeps that area open).
+        // `caretRangeFromPoint` is the browser's OWN hit-testing — the same
+        // resolution a native click performs. Before the fix it resolved
+        // every point in this area into the heading (measured 2026-08-19).
+        const heading = editorNode.querySelector('h1')!;
+        const headingRect = heading.getBoundingClientRect();
+        const surfaceRect = editorNode.getBoundingClientRect();
+        const clientX = surfaceRect.left + 24;
+        const clientY = headingRect.bottom + (surfaceRect.bottom - headingRect.bottom) / 2;
+        const caretRange = document.caretRangeFromPoint(clientX, clientY);
+        expect(caretRange).not.toBeNull();
+
+        editorNode.focus();
+        const selection = document.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(caretRange!);
+
+        // The caret must sit in a body paragraph AFTER the heading, never in
+        // the heading itself.
+        await waitFor(() => {
+            const anchor = document.getSelection()?.anchorNode;
+            expect(anchor).toBeTruthy();
+            const block = anchor instanceof Element ? anchor : anchor?.parentElement;
+            expect(block?.closest('p')).toBeTruthy();
+            expect(block?.closest('h1')).toBeFalsy();
+        });
+
+        // Typing there produces body text and leaves the heading untouched.
+        document.execCommand('insertText', false, 'Absatztext.');
+        await waitFor(() => {
+            expect(editorNode.querySelector('h1 + p')?.textContent).toBe('Absatztext.');
+            expect(editorNode.querySelector('h1')?.textContent).toBe('Datenschutzerklärung');
+        });
+    },
+};
+
 const ResponsiveHintEditor = (args: Parameters<typeof M3RichTextEditor>[0]) => {
     const [visible, setVisible] = useState(true);
     return (

--- a/src/components/FormPluginEditor/M3RichTextEditor.trailingParagraph.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.trailingParagraph.test.tsx
@@ -1,0 +1,41 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { M3RichTextEditor } from './M3RichTextEditor';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}));
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })),
+    });
+    Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe('M3RichTextEditor — trailing-paragraph guarantee is wired into the editor', () => {
+    it('a doc-changing edit on a heading-final document emits HTML that ends in a paragraph', async () => {
+        const onChange = vi.fn();
+        // Heading-final document (the owner's caret trap). The chip "x" is an
+        // ordinary doc-changing transaction through the REAL component
+        // pipeline — after it, the guarantee paragraph must exist.
+        const { container } = render(<M3RichTextEditor value='<h2 id="intro">Intro</h2>' onChange={onChange} />);
+        await waitFor(() => expect(container.querySelectorAll('[data-anchor-chip]')).toHaveLength(1));
+
+        fireEvent.click(container.querySelector('[data-anchor-chip="intro"] .RichEditor-anchorChipRemove')!);
+
+        await waitFor(() => expect(onChange).toHaveBeenCalled());
+        const lastHtml = onChange.mock.calls[onChange.mock.calls.length - 1][0] as string;
+        expect(lastHtml).toMatch(/<p><\/p>$/);
+    });
+});

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -54,6 +54,7 @@ import {
 } from '../CustomIcons/EditorIcons';
 import { createImageDropPasteHandlers, useEditorImageUpload } from './useEditorImageUpload';
 import { ensureHeadingAnchorIds, HeadingAnchors } from './headingAnchors';
+import { TrailingParagraph } from './trailingParagraph';
 import { HeadingMenu } from './HeadingMenu';
 import { SplitDropdown } from './SplitDropdown';
 import AnchorChips from './AnchorChips';
@@ -723,6 +724,10 @@ export const M3RichTextEditor = ({
             Superscript,
             TextAlign.configure({ types: ['heading', 'paragraph'] }),
             Placeholder.configure({ placeholder }),
+            // Word contract: empty space below a final heading belongs to a
+            // body paragraph — created on demand, never in the read-only
+            // reader (see trailingParagraph.ts).
+            TrailingParagraph,
             ...(anchorsEnabled ? [HeadingAnchors] : []),
         ],
         content: editorContent,

--- a/src/components/FormPluginEditor/headingScale.styles.test.ts
+++ b/src/components/FormPluginEditor/headingScale.styles.test.ts
@@ -1,0 +1,80 @@
+import { resolve } from 'node:path';
+import { compile } from 'sass';
+import { describe, expect, it } from 'vitest';
+
+/*
+ * Type-role contract of the legal-document editor headings (owner decision
+ * 2026-08-19, voice note): "die Header sind ... eindeutig oft zu groß ...
+ * das muss nicht so riesig sein".
+ *
+ * The Figma reference (1280-73020) put M3 DISPLAY sizes (57/45/36) on the
+ * desktop editor — the hero/marketing role. Above 16px body text that is a
+ * 3.5:1 ratio, a display relationship, not a document one. The owner's call
+ * deliberately overrides that Figma scale: running document text uses the M3
+ * HEADLINE roles (32/28/24) at every width — exactly what the mobile
+ * breakpoint already used before this contract existed.
+ *
+ * These assertions run against the COMPILED stylesheet, so they hold no
+ * matter how the SCSS nesting is reorganised. If one goes red, the editor
+ * (or the read-only DPA/onboarding reader, which shares this stylesheet)
+ * has left the headline scale — read this comment before "fixing" the test.
+ */
+
+const compiled = compile(resolve(__dirname, './M3RichTextEditor.module.scss')).css;
+
+/** Every declaration block in the compiled CSS whose selector targets `.ProseMirror <tag>`. */
+const headingBlocks = (tag: 'h1' | 'h2' | 'h3'): string[] => {
+    // Compiled css-modules output keeps the `:global(...)` wrapper; match any
+    // selector that ends in the heading tag within a `.ProseMirror` scope.
+    const rule = new RegExp(String.raw`[^{}]*\.ProseMirror ${tag}\)?[^{}a-z0-9-]*\{([^}]*)\}`, 'g');
+    return [...compiled.matchAll(rule)].map(([, block]) => block);
+};
+
+const declarations = (block: string, property: string): string[] =>
+    [...block.matchAll(new RegExp(`(?:^|[;\\s])${property}\\s*:\\s*([^;]+);`, 'g'))].map(([, value]) => value.trim());
+
+const M3_HEADLINE = {
+    h1: { fontSize: '32px', lineHeight: '40px' },
+    h2: { fontSize: '28px', lineHeight: '36px' },
+    h3: { fontSize: '24px', lineHeight: '32px' },
+} as const;
+
+describe('editor heading scale — M3 headline roles at every width (owner call 2026-08-19)', () => {
+    (['h1', 'h2', 'h3'] as const).forEach((tag) => {
+        it(`resolves every ${tag} rule to headline size ${M3_HEADLINE[tag].fontSize}/${M3_HEADLINE[tag].lineHeight}`, () => {
+            const blocks = headingBlocks(tag);
+            expect(blocks.length).toBeGreaterThan(0);
+
+            const fontSizes = blocks.flatMap((block) => declarations(block, 'font-size'));
+            const lineHeights = blocks.flatMap((block) => declarations(block, 'line-height'));
+
+            // The scale must hold in EVERY scope (desktop card, mobile
+            // breakpoint, fluid reader) — a single diverging override brings
+            // the "riesig" state back on one surface only.
+            expect(fontSizes.length).toBeGreaterThan(0);
+            fontSizes.forEach((value) => expect(value).toBe(M3_HEADLINE[tag].fontSize));
+            lineHeights.forEach((value) => expect(value).toBe(M3_HEADLINE[tag].lineHeight));
+        });
+    });
+
+    it('banishes the M3 display sizes (57/45/36) from every heading rule', () => {
+        (['h1', 'h2', 'h3'] as const).forEach((tag) => {
+            const fontSizes = headingBlocks(tag).flatMap((block) => declarations(block, 'font-size'));
+            fontSizes.forEach((value) => {
+                expect(['57px', '45px', '36px']).not.toContain(value);
+            });
+        });
+    });
+
+    it('keeps headline tracking at 0 — no display-large negative letter-spacing on h1', () => {
+        headingBlocks('h1').forEach((block) => {
+            declarations(block, 'letter-spacing').forEach((value) => expect(value).toBe('0'));
+        });
+    });
+
+    it('keeps the document body/heading relationship: h1 at 2x body-large (32/16), not 3.5x', () => {
+        const h1Sizes = headingBlocks('h1').flatMap((block) => declarations(block, 'font-size'));
+        expect(h1Sizes.length).toBeGreaterThan(0);
+        h1Sizes.forEach((value) => expect(parseFloat(value)).toBeLessThanOrEqual(2 * 16));
+    });
+});

--- a/src/components/FormPluginEditor/trailingParagraph.test.ts
+++ b/src/components/FormPluginEditor/trailingParagraph.test.ts
@@ -1,0 +1,142 @@
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TrailingParagraph } from './trailingParagraph';
+
+/*
+ * The trailing-paragraph guarantee (owner report 2026-08-19): a document that
+ * ends with a heading has no node below it that can hold the caret, so every
+ * click into the editor's remaining empty surface (min-height 248px — measured
+ * 184px ≈ 7 blank lines under a lone H1) put the caret INTO the heading and
+ * typing produced giant heading text. The normal document-editor contract
+ * (Word): empty space below a heading belongs to a body paragraph — if none
+ * exists, one is created.
+ */
+
+let editors: Editor[] = [];
+
+const createEditor = (content: string, editable = true): Editor => {
+    const editor = new Editor({
+        element: document.createElement('div'),
+        extensions: [StarterKit, TrailingParagraph],
+        content,
+        editable,
+    });
+    editors.push(editor);
+    return editor;
+};
+
+afterEach(() => {
+    editors.forEach((editor) => editor.destroy());
+    editors = [];
+});
+
+describe('TrailingParagraph — guarantee while editing', () => {
+    it('appends an empty paragraph when an edit leaves a heading as the last node', () => {
+        const editor = createEditor('<h1>Datenschutzerklärung</h1>');
+
+        // Simulate the owner's flow: type inside the heading (any doc-changing
+        // transaction) — the guarantee must hold from the first edit on.
+        editor.chain().focus('end').insertContent('!').run();
+
+        expect(editor.state.doc.lastChild?.type.name).toBe('paragraph');
+        expect(editor.getHTML()).toMatch(/<h1>Datenschutzerklärung!<\/h1><p><\/p>$/);
+    });
+
+    it('leaves a document that already ends in a paragraph untouched', () => {
+        const editor = createEditor('<h1>Titel</h1><p>Fließtext.</p>');
+
+        editor.chain().focus('end').insertContent(' Mehr.').run();
+
+        expect(editor.state.doc.childCount).toBe(2);
+        expect(editor.getHTML()).toBe('<h1>Titel</h1><p>Fließtext. Mehr.</p>');
+    });
+
+    it('does not stack up guarantee paragraphs on repeated edits', () => {
+        const editor = createEditor('<h1>Titel</h1>');
+
+        editor.chain().focus('end').insertContent('a').run();
+        editor.chain().focus('end').insertContent('b').run();
+
+        const paragraphs = editor.state.doc.content.content.filter((node) => node.type.name === 'paragraph');
+        expect(paragraphs).toHaveLength(1);
+    });
+
+    it('covers other non-paragraph endings too (blockquote)', () => {
+        const editor = createEditor('<p>Intro</p><blockquote><p>Zitat</p></blockquote>');
+
+        editor.chain().focus('end').insertContent('!').run();
+
+        expect(editor.state.doc.lastChild?.type.name).toBe('paragraph');
+    });
+});
+
+describe('TrailingParagraph — read-only reader stays non-mutating', () => {
+    it('never appends to a read-only document', () => {
+        const editor = createEditor('<h1>Datenschutzerklärung</h1>', false);
+
+        // The reader never edits, but plugins must not react even to
+        // programmatic transactions (anchor stamping, version swaps).
+        editor.view.dispatch(editor.state.tr.insertText('!', editor.state.doc.content.size - 1));
+
+        expect(editor.state.doc.lastChild?.type.name).toBe('heading');
+    });
+});
+
+describe('TrailingParagraph — dead-space click on a pristine heading-final document', () => {
+    // Before ANY edit (a legacy legal text saved as `...</h1>`), the
+    // appendTransaction guarantee has not run yet. The click into the dead
+    // space below the heading is the moment the paragraph must be created —
+    // that click IS the user's edit intent, so onChange firing then is right.
+    const clickAt = (editor: Editor, clientY: number): boolean =>
+        editor.view.someProp('handleClick', (handle) =>
+            handle(editor.view, editor.state.doc.content.size - 1, new MouseEvent('click', { clientY })),
+        ) ?? false;
+
+    const mockLastBlockBottom = (editor: Editor, bottom: number) => {
+        const lastBlock = editor.view.dom.lastElementChild as HTMLElement;
+        vi.spyOn(lastBlock, 'getBoundingClientRect').mockReturnValue({
+            bottom,
+            top: 0,
+            left: 0,
+            right: 100,
+            width: 100,
+            height: bottom,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        } as DOMRect);
+    };
+
+    it('creates the paragraph and puts the caret into it', () => {
+        const editor = createEditor('<h1>Datenschutzerklärung</h1>');
+        mockLastBlockBottom(editor, 100);
+
+        const handled = clickAt(editor, 150);
+
+        expect(handled).toBe(true);
+        expect(editor.state.doc.lastChild?.type.name).toBe('paragraph');
+        // Caret sits inside the new empty paragraph, so typing produces body text.
+        expect(editor.state.selection.$from.parent.type.name).toBe('paragraph');
+    });
+
+    it('does nothing for clicks ON the heading itself', () => {
+        const editor = createEditor('<h1>Datenschutzerklärung</h1>');
+        mockLastBlockBottom(editor, 100);
+
+        const handled = clickAt(editor, 50);
+
+        expect(handled).toBe(false);
+        expect(editor.state.doc.lastChild?.type.name).toBe('heading');
+    });
+
+    it('does nothing in the read-only reader', () => {
+        const editor = createEditor('<h1>Datenschutzerklärung</h1>', false);
+        mockLastBlockBottom(editor, 100);
+
+        const handled = clickAt(editor, 150);
+
+        expect(handled).toBe(false);
+        expect(editor.state.doc.lastChild?.type.name).toBe('heading');
+    });
+});

--- a/src/components/FormPluginEditor/trailingParagraph.ts
+++ b/src/components/FormPluginEditor/trailingParagraph.ts
@@ -1,0 +1,81 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import type { EditorView } from '@tiptap/pm/view';
+
+/*
+ * Trailing-paragraph guarantee (owner report 2026-08-19).
+ *
+ * A document that ends with a heading has no node below it that can hold the
+ * caret. The editor surface keeps a min-height (248px), so under a lone H1
+ * there were ~184px of empty surface — and EVERY click in it resolved to the
+ * nearest position, the heading's end: typing then produced giant heading
+ * text, and the author had to backspace onto the heading line to escape
+ * ("sehr sehr schwer da irgendwie headlines zu bauen").
+ *
+ * The normal document-editor contract (Word's click-and-type): empty space
+ * below a heading belongs to a following body paragraph; if none exists, it
+ * is created. StarterKit's Gapcursor does not cover this — it only applies
+ * after non-text blocks (hr, image), never after textblocks like headings.
+ *
+ * Two guards, same pattern as `headingAnchors.ts`:
+ *  - `appendTransaction` keeps the guarantee during editing (any doc-changing
+ *    transaction on an editable editor). It deliberately does NOT run at
+ *    creation time: normalising a freshly LOADED document would emit a
+ *    phantom onChange draft before the user touched anything.
+ *  - `handleClick` covers exactly that pristine case (a legacy legal text
+ *    saved as `...</h1>`): the first click into the dead space below the last
+ *    block creates the paragraph and puts the caret into it — the click IS
+ *    the user's edit intent, so the resulting onChange is genuine.
+ *
+ * The read-only reader (DPA blocker, onboarding wizard) must never mutate the
+ * stored document, so both paths check `editor.isEditable`.
+ */
+
+const needsTrailingParagraph = (doc: ProseMirrorNode): boolean =>
+    doc.lastChild !== null && doc.lastChild.type.name !== 'paragraph';
+
+const clickedBelowLastBlock = (view: EditorView, event: MouseEvent): boolean => {
+    const lastBlock = view.dom.lastElementChild;
+    if (!lastBlock) return false;
+    return event.clientY > lastBlock.getBoundingClientRect().bottom;
+};
+
+export const TrailingParagraph = Extension.create({
+    name: 'trailingParagraph',
+
+    addProseMirrorPlugins() {
+        const { editor } = this;
+        return [
+            new Plugin({
+                key: new PluginKey('trailingParagraph'),
+                appendTransaction: (transactions, _oldState, newState) => {
+                    if (!transactions.some((transaction) => transaction.docChanged)) return null;
+                    if (!editor.isEditable) return null;
+                    if (!needsTrailingParagraph(newState.doc)) return null;
+                    const { paragraph } = newState.schema.nodes;
+                    if (!paragraph) return null;
+                    return newState.tr.insert(newState.doc.content.size, paragraph.create());
+                },
+                props: {
+                    handleClick: (view, _pos, event) => {
+                        if (!editor.isEditable) return false;
+                        if (!needsTrailingParagraph(view.state.doc)) return false;
+                        if (!clickedBelowLastBlock(view, event)) return false;
+                        const { paragraph } = view.state.schema.nodes;
+                        if (!paragraph) return false;
+                        const tr = view.state.tr.insert(view.state.doc.content.size, paragraph.create());
+                        // Caret into the new empty paragraph: typing produces
+                        // body text, exactly what the click below the heading
+                        // asked for.
+                        tr.setSelection(TextSelection.create(tr.doc, tr.doc.content.size - 1));
+                        view.dispatch(tr.scrollIntoView());
+                        return true;
+                    },
+                },
+            }),
+        ];
+    },
+});
+
+export default TrailingParagraph;


### PR DESCRIPTION
Closes #852

**Problem.** The legal-document editor rendered desktop headings at the M3 *display* roles (H1 57 / H2 45 / H3 36 over 16px body — a 3.5:1 hero relationship), and a document ending in a heading trapped the caret: ~184px of empty `min-height` surface below a lone H1 in which every click resolved into the heading, so typing produced giant heading text.

**What changed**
- Heading scale → M3 *headline* roles (H1 32/40, H2 28/36, H3 24/32) at every width (owner call 2026-08-19, deliberately overriding Figma 1280-73020's display scale); the fluid reader's now-redundant compact override removed — one uniform scale, contract-tested against the **compiled** stylesheet (`headingScale.styles.test.ts`).
- New `TrailingParagraph` extension (Word click-and-type contract): `appendTransaction` keeps a trailing body paragraph while editing; `handleClick` creates it on the first click into the dead space of a pristine heading-final document; both paths `isEditable`-guarded, so the read-only reader (DPA blocker, onboarding wizard) never mutates stored HTML. Documents already ending in `</p>` round-trip byte-identically (asserted).
- Storybook play function (`CaretBelowHeadingLandsInBodyText`) drives real browser hit-testing (`caretRangeFromPoint`) into the dead space and asserts the caret lands in a paragraph and typing produces body text.
- `.storybook/preview.tsx`: MSW loader degrades to unmocked stories when service-worker registration is unavailable (stories declaring `msw` handlers still fail loudly).

**Mutation testing** (all killed): M1 extension unwired → play function + wiring test red (verified in real Chrome); M2 docChanged guard inverted, M3 clientY comparison inverted, M4/M5 isEditable guards removed, M6 needsTrailingParagraph forced false, M7 caret not moved → 1–4 unit tests red each. Scale: S1 h2 45px, S2 h1 −0.25px tracking, S3 h1 lh 64px, S4 h3 22px divergence, S5 h1 36px → 1–3 tests red each.

**Verification**
- `npm test`: 301 files / 2155 tests green (incl. 15 new)
- `npx eslint … --max-warnings=0`, stylelint, prettier, `tsc --noEmit`, `typecheck:storybook`, `npm run build`: green
- Real Chrome at 390×844 / 820×1180 / 1440×900: heading sizes read as document text, anchor/chapter chip bar incl. edge fade + arrows unchanged (editor, read-only editor, DpaLegalReader), caret lands in body paragraph below the heading, typed text renders as body text; measured computed styles h1 32/40 tracking 0, p 16/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)