### PR TITLE
fix(agency): lay out the create flow in the responsive CardGrid

### DIFF
--- a/src/components/CardGrid/index.tsx
+++ b/src/components/CardGrid/index.tsx
@@ -27,6 +27,7 @@ export interface CardGridProps {
  */
 export const CardGrid = ({ children, minCardWidth = 400, maxColumns = 3, className }: CardGridProps) => (
     <div
+        data-admin-card-grid
         className={classNames(styles.cardGrid, className)}
         style={
             {

--- a/src/pages/Agency/Edit/AgencyCreateRaster.stories.tsx
+++ b/src/pages/Agency/Edit/AgencyCreateRaster.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { http, HttpResponse } from 'msw';
+import { Form } from 'antd';
+import { ThemeProvider } from '@mui/material/styles';
+import { orisoMuiTheme } from '../../../theme/orisoMuiTheme';
+import { CardGrid } from '../../../components/CardGrid';
+import { AgencyGeneralInformation } from './components/GeneralInformation';
+import { RegistrationSettings } from './components/RegistrationSettings';
+import { AgencySettings } from './components/AgencySettings';
+
+/**
+ * #620: the agency create flow composes its three cards in the responsive
+ * CardGrid (shared row width, wrap below the floor) instead of the fixed
+ * 392px CardDeck. This story renders the real create composition so the
+ * raster can be reviewed at desktop/tablet/mobile without a backend.
+ */
+const topics = [
+    { id: 1, name: 'Allgemeine Sozialberatung', status: 'ACTIVE' },
+    { id: 2, name: '[U25] Suizidprävention', status: 'ACTIVE' },
+];
+
+const consultants = {
+    total: 1,
+    embedded: [
+        {
+            embedded: {
+                id: 'c1',
+                firstname: 'Erika',
+                lastname: 'Beispiel',
+                email: 'erika@example.org',
+                absent: false,
+                agencies: [],
+            },
+        },
+    ],
+};
+
+const meta: Meta<typeof CardGrid> = {
+    title: 'Organisms/Agency/CreateFlowRaster',
+    component: CardGrid,
+    parameters: {
+        msw: {
+            handlers: [
+                http.get('*/service/topic*', () => HttpResponse.json(topics)),
+                http.get('*/service/users/consultants/search*', () => HttpResponse.json(consultants)),
+                http.get('*/service/agencyadmin/agencies*', () => HttpResponse.json({ embedded: [], total: 0 })),
+            ],
+        },
+    },
+    decorators: [
+        (Story) => (
+            <ThemeProvider theme={orisoMuiTheme}>
+                <Form layout="vertical" size="large" labelAlign="left" labelWrap>
+                    <Story />
+                </Form>
+            </ThemeProvider>
+        ),
+    ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CardGrid>;
+
+export const Default: Story = {
+    render: () => (
+        <CardGrid minCardWidth={425} maxColumns={2}>
+            <AgencyGeneralInformation />
+            <RegistrationSettings />
+            <AgencySettings isEditMode={false} />
+        </CardGrid>
+    ),
+};

--- a/src/pages/Agency/Edit/index.test.tsx
+++ b/src/pages/Agency/Edit/index.test.tsx
@@ -271,9 +271,11 @@ describe('AgencyPageEdit create flow', () => {
         // the text twice (the <label>, plus the aria-hidden notched-outline
         // <legend>), so a plain text query matches both.
         expect(await screen.findByLabelText('Trägerzuordnung *')).toBeInTheDocument();
-        // Create flow: general+registration share one deck item; settings is the second.
-        expect(container.querySelector('[data-admin-card-deck]')).toBeInTheDocument();
-        expect(container.querySelectorAll('[data-admin-card-deck-item]')).toHaveLength(2);
+        // #620: create flow lays its three cards out in the responsive CardGrid —
+        // cards share the row width and wrap/stack below the floor. The fixed-width
+        // horizontal CardDeck must be gone from the create surface.
+        expect(container.querySelector('[data-admin-card-grid]')).toBeInTheDocument();
+        expect(container.querySelector('[data-admin-card-deck]')).not.toBeInTheDocument();
         expect(mocks.searchTenantData).toHaveBeenCalledWith({ perPage: 1000 });
     });
 

--- a/src/pages/Agency/Edit/index.tsx
+++ b/src/pages/Agency/Edit/index.tsx
@@ -11,6 +11,7 @@ import { normalizeTopicIds } from '../../../api/agency/normalizeTopicIds';
 import routePathNames from '../../../appConfig';
 import { Page } from '../../../components/Page';
 import { CardDeck } from '../../../components/CardDeck';
+import { CardGrid } from '../../../components/CardGrid';
 import { DashboardEmptyState } from '../../../components/DashboardEmptyState/DashboardEmptyState';
 import { useFeatureContext } from '../../../context/FeatureContext';
 import { FeatureFlag } from '../../../enums/FeatureFlag';
@@ -345,19 +346,15 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
                     onFinish={onSubmit}
                 >
                     <h3 className={styles.backHeadline}>{t(`agency.edit.settings.general.title`)}</h3>
-                    <CardDeck
-                        ariaLabel={t(`agency.edit.settings.general.title`)}
-                        previousLabel={t('agency.cardDeck.previous')}
-                        nextLabel={t('agency.cardDeck.next')}
-                    >
-                        <CardDeck.Item>
-                            <AgencyGeneralInformation />
-                            <RegistrationSettings />
-                        </CardDeck.Item>
-                        <CardDeck.Item>
-                            <AgencySettings isEditMode={isEditing} />
-                        </CardDeck.Item>
-                    </CardDeck>
+                    {/* #620: the create flow shares the row width responsively (CardGrid)
+                        instead of the fixed-width horizontal CardDeck — cards split 50/50
+                        while two fit and stack below the floor, so FieldGrid can reach
+                        its multi-column layout inside each card. */}
+                    <CardGrid minCardWidth={425} maxColumns={2}>
+                        <AgencyGeneralInformation />
+                        <RegistrationSettings />
+                        <AgencySettings isEditMode={isEditing} />
+                    </CardGrid>
                 </Form>
             </ThemeProvider>
         );
@@ -383,15 +380,11 @@ export const AgencyPageEdit = ({ section = 'general' }: AgencyPageEditProps) => 
             onFinish={onSubmit}
         >
             <h3 className={styles.backHeadline}>{t('agency.edit.settings.functionalities.title')}</h3>
-            <CardDeck
-                ariaLabel={t('agency.edit.settings.functionalities.title')}
-                previousLabel={t('agency.cardDeck.previous')}
-                nextLabel={t('agency.cardDeck.next')}
-            >
-                <CardDeck.Item>
-                    <AgencySettings isEditMode={isEditing} />
-                </CardDeck.Item>
-            </CardDeck>
+            {/* #620: a single card in a fixed 392px deck rendered needlessly narrow —
+                the grid lets it use the row up to the shared card floor. */}
+            <CardGrid minCardWidth={425} maxColumns={2}>
+                <AgencySettings isEditMode={isEditing} />
+            </CardGrid>
         </Form>
     );
 


### PR DESCRIPTION
Closes OpenResilienceInitiative/ORISO-Admin#620
Refs OpenResilienceInitiative/ORISO-Admin#848

## Problem

The agency create flow (`/admin/agency/add`) and the legacy functionalities create view composed their cards in the fixed-width horizontal `CardDeck` (392px per card): on desktop the cards did not split the row and every field collapsed into one narrow column; on iPad the width was wrong. Träger create was already migrated by #632.

## What changed

- Agency create: the three cards (General information, Registration visibility, Counselling settings) now sit in `CardGrid` (`minCardWidth 425`, `maxColumns 2`) — 50/50 while two fit, stacked below the floor
- Legacy functionalities create: single card moves from the 392px deck into the grid
- `CardGrid` carries a `data-admin-card-grid` marker (mirrors the deck marker) for tests
- New story `Organisms/Agency/CreateFlowRaster` renders the real create composition with MSW data
- Page test asserts grid-not-deck on the create surface

## Verification

- `npx vitest run src/pages/Agency src/components/CardGrid src/components/CardDeck` → 14 files, 93 tests green
- eslint + prettier clean on the changed files
- Story checked live at 1440×900 (two 692px cards per row, third wraps), 820×1180 (one 788px card, fields in 2 columns), 390×844 (single column, no horizontal scroll)

## How should I test this?

- [ ] Open `/admin/agency/add` at ~1920/1440 width → General information + Visibility share the row 50/50 at equal height; Counselling settings wraps below; address fields flow in two columns
- [ ] Resize to iPad (~820) → cards stack full-width, fields keep two columns; no horizontal page scroll
- [ ] Resize to mobile (~390) → everything stacks single-column
- [ ] Edit an existing agency → the horizontal card deck there is unchanged
- [ ] Storybook: `Organisms/Agency/CreateFlowRaster` renders the same raster
