### PR TITLE
fix(dpa-forward): stop blaming the address, and stop minting a second link

### DIFF
--- a/src/api/tenantOnboarding/dpaForward.test.ts
+++ b/src/api/tenantOnboarding/dpaForward.test.ts
@@ -74,33 +74,46 @@ describe('createHttpDpaForwardClient', () => {
         );
     });
 
-    it('502: keeps the created link and reports the mail failure instead of failing outright', async () => {
-        mocks.fetchData
-            .mockRejectedValueOnce(new Response(null, { status: 502 }))
-            .mockResolvedValueOnce({ ...RESPONSE, signUrl: 'https://app.example.org/dpa-sign/retry' });
+    it('reports the mail failure from the first response without minting a second link', async () => {
+        // Every forward call mints a NEW link, and only five may be outstanding
+        // at once. The old 502 fallback made a second call to obtain a link, so
+        // one failed send cost two of the five. The flag now rides in the first
+        // response and there is no second call to make.
+        mocks.fetchData.mockResolvedValueOnce({ ...RESPONSE, mailSent: false });
 
         const outcome = await createHttpDpaForwardClient().forward('tok', { recipientEmail: 'legal@example.org' });
 
         expect(outcome.mailFailed).toBe(true);
-        expect(outcome.link.signUrl).toBe('https://app.example.org/dpa-sign/retry');
-        // The fallback call must not try to send the mail again.
-        expect(mocks.fetchData).toHaveBeenLastCalledWith(expect.objectContaining({ bodyData: JSON.stringify({}) }));
+        expect(outcome.link.signUrl).toBe(RESPONSE.signUrl);
+        expect(mocks.fetchData).toHaveBeenCalledTimes(1);
     });
 
-    it('502 whose link-only fallback also fails stays a technical error', async () => {
-        mocks.fetchData
-            .mockRejectedValueOnce(new Response(null, { status: 502 }))
-            .mockRejectedValueOnce(new Response(null, { status: 500 }));
+    it('treats a server that omits mailSent as "not sent" rather than a silent success', async () => {
+        // Failing towards "show the link" is safe; the opposite default would
+        // claim a delivery that never happened and hide the link.
+        mocks.fetchData.mockResolvedValueOnce({ ...RESPONSE });
 
-        await expect(
-            createHttpDpaForwardClient().forward('tok', { recipientEmail: 'legal@example.org' }),
-        ).rejects.toMatchObject({ kind: 'TECHNICAL' });
+        const outcome = await createHttpDpaForwardClient().forward('tok', { recipientEmail: 'legal@example.org' });
+
+        expect(outcome.mailFailed).toBe(true);
+    });
+
+    it('never reports a mail failure for a link-only call', async () => {
+        // No recipient means no mail was asked for, so there is nothing to fail.
+        mocks.fetchData.mockResolvedValueOnce({ ...RESPONSE });
+
+        const outcome = await createHttpDpaForwardClient().forward('tok');
+
+        expect(outcome.mailFailed).toBe(false);
     });
 
     it.each([
-        [400, 'INVALID_EMAIL'],
+        // 400 is TECHNICAL on purpose: it used to claim the address was
+        // invalid for any server-side rejection (owner report 2026-08-19).
+        [400, 'TECHNICAL'],
         [404, 'UNKNOWN_TOKEN'],
         [409, 'NO_DPA_PUBLISHED'],
+        [429, 'TOO_MANY_LINKS'],
         [500, 'TECHNICAL'],
     ] as const)('maps %i to DpaForwardError(%s)', async (status, kind) => {
         mocks.fetchData.mockRejectedValue(new Response(null, { status }));

--- a/src/api/tenantOnboarding/dpaForward.ts
+++ b/src/api/tenantOnboarding/dpaForward.ts
@@ -51,12 +51,12 @@ export interface DpaForwardOutcome {
 
 /** Why a forward call failed in a way the dialog must phrase specifically. */
 export type DpaForwardFailureKind =
-    /** 400 — `recipientEmail` is not a valid address (inline field error). */
-    | 'INVALID_EMAIL'
     /** 404 — unknown invite token. */
     | 'UNKNOWN_TOKEN'
     /** 409 — the platform operator has published no DPA, nothing to forward. */
     | 'NO_DPA_PUBLISHED'
+    /** 429 — this onboarding already holds the maximum of outstanding sign links. */
+    | 'TOO_MANY_LINKS'
     /** Anything else — retryable/technical. */
     | 'TECHNICAL';
 
@@ -116,13 +116,19 @@ const toForwardError = async (error: unknown): Promise<unknown> => {
     if (!(error instanceof Response)) {
         return error;
     }
+    // 400 deliberately has NO mapping of its own. It used to become
+    // INVALID_EMAIL, which told the user their address was wrong for any
+    // server-side rejection — the owner hit exactly that with a valid address
+    // while the real cause was a missing APP_BASE_URL two services away. The
+    // body is empty, so a 400 cannot be discriminated here anyway, and the
+    // dialog already blocks malformed addresses client-side via { type: 'email' }.
     switch (error.status) {
-        case 400:
-            return new DpaForwardError('INVALID_EMAIL');
         case 404:
             return new DpaForwardError('UNKNOWN_TOKEN');
         case 409:
             return new DpaForwardError('NO_DPA_PUBLISHED');
+        case 429:
+            return new DpaForwardError('TOO_MANY_LINKS');
         case 410:
             return toLinkDeath(error);
         default:
@@ -160,7 +166,7 @@ export const createHttpDpaForwardClient = (): DpaForwardClient => {
             skipAuth: true,
             responseHandling: [...PUBLIC_RESPONSE_HANDLING, FETCH_SUCCESS.CONTENT],
             bodyData: JSON.stringify(request),
-        }) as Promise<{ signUrl: string; expiresAt?: string | null }>;
+        }) as Promise<{ signUrl: string; expiresAt?: string | null; mailSent?: boolean }>;
 
     const toLink = (dto: { signUrl: string; expiresAt?: string | null }): DpaForwardLink => ({
         signUrl: resolveDpaForwardSignLink(dto.signUrl),
@@ -169,21 +175,22 @@ export const createHttpDpaForwardClient = (): DpaForwardClient => {
 
     return {
         forward: async (inviteToken, request = {}) => {
-            try {
-                return { link: toLink(await call(inviteToken, request)), mailFailed: false };
-            } catch (error) {
-                // 502: the mail could not be sent BUT THE LINK EXISTS. The
-                // response carries no body, so a link-only repeat call fetches
-                // one to display — sharing it manually is the whole fallback.
-                if (error instanceof Response && error.status === 502) {
-                    try {
-                        return { link: toLink(await call(inviteToken, {})), mailFailed: true };
-                    } catch (retryError) {
-                        throw await toForwardError(retryError);
-                    }
-                }
+            // The backend answers 200 with the link even when the mail could not
+            // be delivered, flagging it as `mailSent: false`. The old 502 branch
+            // fetched a link with a SECOND call — and every call mints a new
+            // link, so a failed send cost two of the five allowed outstanding
+            // links instead of none. The flag now travels in the first response.
+            //
+            // An older server omits `mailSent`. Reading that as "not sent" only
+            // ever shows the copyable link; the opposite default would claim a
+            // success that never happened and hide the link the user needs.
+            const dto = await call(inviteToken, request).catch(async (error: unknown) => {
                 throw await toForwardError(error);
-            }
+            });
+            return {
+                link: toLink(dto),
+                mailFailed: !!request.recipientEmail && dto.mailSent !== true,
+            };
         },
     };
 };

--- a/src/components/DpaForwardDialog/DpaForwardDialog.tsx
+++ b/src/components/DpaForwardDialog/DpaForwardDialog.tsx
@@ -51,9 +51,9 @@ type LinkState = { kind: 'loading' } | { kind: 'ready'; link: DpaForwardLink } |
 
 /** i18n key for a typed backend failure. */
 const FAILURE_MESSAGE: Record<DpaForwardFailureKind, string> = {
-    INVALID_EMAIL: 'tenantOnboarding.validation.email',
     UNKNOWN_TOKEN: 'dpaForward.dialog.errorUnknownToken',
     NO_DPA_PUBLISHED: 'dpaForward.dialog.errorNoDpaPublished',
+    TOO_MANY_LINKS: 'dpaForward.dialog.errorTooManyLinks',
     TECHNICAL: 'dpaForward.dialog.linkError',
 };
 

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -125,6 +125,7 @@
     "dpaForward.dialog.sendFailed": "Die E-Mail konnte nicht versendet werden. Bitte versuchen Sie es erneut.",
     "dpaForward.dialog.errorUnknownToken": "Dieser Einladungslink ist nicht mehr gültig. Bitte fordern Sie beim Plattformbetreiber einen neuen an.",
     "dpaForward.dialog.errorNoDpaPublished": "Der Plattformbetreiber hat noch keinen Auftragsverarbeitungsvertrag veröffentlicht. Es gibt derzeit nichts zum Weiterleiten — bitte wenden Sie sich an den Plattformbetreiber.",
+    "dpaForward.dialog.errorTooManyLinks": "Für diese Registrierung sind bereits zu viele offene Signaturlinks vorhanden. Bitte warten Sie, bis einer davon verwendet wurde oder abgelaufen ist, und versuchen Sie es dann erneut.",
     "dpaForward.dialog.mailFailedLinkReady": "Die E-Mail konnte nicht versendet werden. Der Signaturlink oben wurde trotzdem erstellt und ist gültig — teilen Sie ihn einfach direkt.",
     "dpaForward.dialog.previewLabel": "Vorschau der E-Mail",
     "dpaForward.dialog.confirm": "Weiterleitung abschließen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -130,6 +130,7 @@
     "dpaForward.dialog.sendFailed": "The e-mail could not be sent. Please try again.",
     "dpaForward.dialog.errorUnknownToken": "This invitation link is no longer valid. Please request a new one from the platform operator.",
     "dpaForward.dialog.errorNoDpaPublished": "The platform operator has not published a data processing agreement yet. There is nothing to forward at the moment — please contact the platform operator.",
+    "dpaForward.dialog.errorTooManyLinks": "This registration already has too many outstanding signing links. Please wait until one of them has been used or has expired, then try again.",
     "dpaForward.dialog.mailFailedLinkReady": "The e-mail could not be sent. The signing link above was created anyway and is valid — simply share it directly.",
     "dpaForward.dialog.previewLabel": "Preview of the e-mail",
     "dpaForward.dialog.confirm": "Complete forwarding",


### PR DESCRIPTION
Owner-reported problem 2 of four, **UI half**. Backend counterpart: ORISO-UserService `fix/dpa-forward-public-endpoint-p2`. Infrastructure counterpart: ORISO-Helm `fix/tenantservice-app-base-url`. See `0 - Docs/plans/2026-08-19-owner-problem-fixes-overview.md`.

## Problem

The owner forwarded the DPA to a perfectly valid e-mail address and the panel answered:

> „Bitte geben Sie eine gültige E-Mail-Adresse ein."
> ("Please enter a valid e-mail address.")

The address was never the problem.

## Root cause

Measured, not guessed. The full chain, live on Pre-Dev:

1. `APP_BASE_URL` was not configured for TenantService, so `TenantDpaFacade:89` emitted a **path-only** sign link (`/dpa-sign/<token>`).
2. `DpaForwardEmailService.parseUri` requires an absolute URI and rejected it with **400**. Live stack trace in the UserService log, two occurrences matching the owner's attempts.
3. This panel mapped **any** 400 to `INVALID_EMAIL` — so a missing config two services away surfaced as a complaint about the recipient's address.

Two further defects in the same client:

- **429 was unmapped.** TenantService caps an onboarding at five outstanding sign links (14-day TTL) and says so clearly. That answer reached the user as a generic technical error.
- **The 502 fallback minted a second link.** Every forward call mints a NEW link. On a failed send the fallback made a SECOND call to obtain one, so a failed send cost **two** of the five allowed links instead of none. Measured consequence: tenant 34 shows five PENDING rows with zero mails delivered, throttled until 2026-09-01. Tenants 29 and 12323 are also at 5; tenants 32 and 25 at 4.

## Fix

1. **400 no longer maps to `INVALID_EMAIL`.** The 400 body is empty, so it cannot be discriminated client-side anyway, and the dialog already blocks malformed addresses with `{ type: 'email' }`. 400 now falls through to `TECHNICAL`.
2. **429 becomes its own kind `TOO_MANY_LINKS`** with its own message, so the wait is phrased as a wait.
3. **The 502 fallback is deleted.** The backend now returns 200 with the link plus `mailSent`, so the flag rides in the first response — no second call, no double mint. A server that omits the field is read as "not sent": that only ever shows the copyable link, whereas the opposite default would claim a delivery that never happened and hide the link the user needs.

`mailFailed` is gated on an actual recipient, so a link-only call cannot report a failure for a mail nobody asked for.

Locales `de` and `en` both extended, key parity kept.

## Tests

3 files / **44 passing**, 3 new test cases in `src/api/tenantOnboarding/dpaForward.test.ts`. Against the previous production file the four new assertions **fail**, so they do constrain the behaviour they describe.

## Reviewer test plan

- [ ] Force a 400 from the forward endpoint — the dialog shows a technical error, **not** an e-mail complaint.
- [ ] Force a 429 — the dialog shows the `TOO_MANY_LINKS` message (a wait, not an outage).
- [ ] Force a mail-send failure with the backend branch deployed — the dialog shows the copyable sign link and reports the mail as not sent.
- [ ] Confirm no second forward call is issued on failure (check the network panel: exactly one POST).
- [ ] Type a malformed address — the client-side `{ type: 'email' }` rule still blocks it before any request.
- [ ] Link-only call (no recipient) — no mail-failure message appears.
- [ ] **Mobile (390 px)**: the error / link-ready state fits, the sign link is selectable and the copy control is reachable.
- [ ] Switch `de` / `en` — both new strings resolve.

## Note

This PR is the UI half only. Without the UserService and Helm counterparts the underlying 400 still occurs — it will simply be reported honestly as a technical error instead of blaming the address.
