### PR TITLE
fix(branding): store an uploaded .ico as an image data URL

### DIFF
--- a/src/components/FormFileUploaderField/index.test.tsx
+++ b/src/components/FormFileUploaderField/index.test.tsx
@@ -2,6 +2,7 @@ import { Form } from 'antd';
 import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { FormFileUploaderField } from './index';
+import { getSafeFaviconUrl } from '../../utils/getSafeFaviconUrl';
 
 /**
  * The uploader lives inside CardEditable, which disables its <Form> while the card
@@ -86,6 +87,28 @@ describe('FormFileUploaderField', () => {
 
             pickFile(input, 'favicon.ico', type);
             await vi.waitFor(() => expect(changes.length).toBeGreaterThan(0));
+        });
+
+        /**
+         * Accepting the file is only half the job: the value the uploader stores is
+         * what later becomes `link[rel=icon][href]`, and `getSafeFaviconUrl` only
+         * admits `data:image/*`. A host that reports no MIME type for `.ico` made
+         * FileReader label the payload `application/octet-stream`, so the upload
+         * looked successful while the tab kept the built-in favicon.
+         */
+        it.each([
+            ['Chrome', 'image/vnd.microsoft.icon'],
+            ['Firefox', 'image/x-icon'],
+            ['a host with no mapping for the extension', ''],
+        ])('stores an .ico from %s as a value the favicon gatekeeper accepts', async (_host, type) => {
+            const { changes, input } = renderField({ formDisabled: false, allowIcon: true });
+
+            pickFile(input, 'favicon.ico', type);
+            await vi.waitFor(() => expect(changes.length).toBeGreaterThan(0));
+
+            const stored = changes[0].logo as string;
+            expect(stored).toMatch(/^data:image\//);
+            expect(getSafeFaviconUrl(stored)).toBe(stored);
         });
 
         it('still rejects an .ico file on a field that does not allow icons', async () => {

--- a/src/components/FormFileUploaderField/index.tsx
+++ b/src/components/FormFileUploaderField/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { UploadFileProps } from '../../types/uploadFiles';
 import decodeHTML from '../../utils/decodeHTML';
 import getBase64 from '../../utils/getBase64';
+import { normalizeIconDataUrl } from '../../utils/normalizeIconDataUrl';
 import styles from './styles.module.scss';
 
 interface FormFileUploaderFieldProps {
@@ -66,7 +67,10 @@ const FormFileUploaderLocal = ({ onChange, value, allowIcon, disabled }: FormRic
             return false;
         }
 
-        getBase64(file, onChange);
+        // The stored value is what later becomes `link[rel=icon][href]`, so an
+        // .ico whose MIME type the host could not map has to be relabelled here
+        // rather than admitted by loosening `getSafeFaviconUrl`.
+        getBase64(file, (result) => onChange(normalizeIconDataUrl(result, file.name)));
         return false;
     };
 

--- a/src/utils/normalizeIconDataUrl.test.ts
+++ b/src/utils/normalizeIconDataUrl.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeIconDataUrl } from './normalizeIconDataUrl';
+import { getSafeFaviconUrl } from './getSafeFaviconUrl';
+
+const ICO_PAYLOAD = 'AAABAAEAICAAAAEAIACoEAAAFgAAACgAAAA=';
+
+describe('normalizeIconDataUrl', () => {
+    it('gives an .ico with no MIME mapping a usable image media type', () => {
+        // `beforeUpload` accepts a file whose `type` is '' on its `.ico`
+        // extension; FileReader then labels the data URL application/octet-stream.
+        const stored = normalizeIconDataUrl(`data:application/octet-stream;base64,${ICO_PAYLOAD}`, 'favicon.ico');
+
+        expect(stored).toBe(`data:image/x-icon;base64,${ICO_PAYLOAD}`);
+    });
+
+    it('produces a value the favicon gatekeeper accepts', () => {
+        const stored = normalizeIconDataUrl(`data:application/octet-stream;base64,${ICO_PAYLOAD}`, 'favicon.ico');
+
+        expect(getSafeFaviconUrl(stored)).toBe(stored);
+    });
+
+    it.each([
+        `data:image/vnd.microsoft.icon;base64,${ICO_PAYLOAD}`,
+        `data:image/x-icon;base64,${ICO_PAYLOAD}`,
+        'data:image/png;base64,iVBORw0KGgo=',
+    ])('leaves a value that already declares an image type alone (%s)', (value) => {
+        expect(normalizeIconDataUrl(value, 'favicon.ico')).toBe(value);
+    });
+
+    it('does not relabel a non-icon file that happens to lack a MIME type', () => {
+        const stored = `data:application/octet-stream;base64,${ICO_PAYLOAD}`;
+
+        expect(normalizeIconDataUrl(stored, 'logo.bin')).toBe(stored);
+    });
+
+    it('is empty-safe', () => {
+        expect(normalizeIconDataUrl(undefined, 'favicon.ico')).toBeUndefined();
+        expect(normalizeIconDataUrl('', 'favicon.ico')).toBe('');
+    });
+});

--- a/src/utils/normalizeIconDataUrl.ts
+++ b/src/utils/normalizeIconDataUrl.ts
@@ -1,0 +1,35 @@
+const DATA_URL_MEDIA_TYPE = /^data:([^;,]*)/i;
+const IMAGE_MEDIA_TYPE = /^image\//i;
+
+/**
+ * The media type a browser reports for a picked `.ico` file varies: Chrome says
+ * `image/vnd.microsoft.icon`, Firefox `image/x-icon`, and a host with no mapping
+ * for the extension reports an empty string. `FormFileUploaderField` accepts the
+ * third case on the file extension (see `isAcceptedFile`), but `FileReader`
+ * labels a type-less blob `application/octet-stream`, so the stored value is
+ *
+ *   data:application/octet-stream;base64,AAABAAEA…
+ *
+ * which is not an image data URL. `getSafeFaviconUrl` refuses it — correctly,
+ * it must not admit arbitrary media types — so the upload appeared to work while
+ * the browser tab kept the built-in favicon, and the card's own preview `<img>`
+ * stayed blank.
+ *
+ * Relabelling at the upload seam keeps the stored value honest for every later
+ * consumer instead of loosening the gatekeeper. Only a file that is an `.ico`
+ * by name and carries no image media type is touched.
+ */
+export const normalizeIconDataUrl = (dataUrl?: string, fileName?: string): string | undefined => {
+    if (!dataUrl || !/\.ico$/i.test(fileName ?? '')) {
+        return dataUrl;
+    }
+
+    const mediaType = DATA_URL_MEDIA_TYPE.exec(dataUrl)?.[1];
+    if (mediaType === undefined || IMAGE_MEDIA_TYPE.test(mediaType)) {
+        return dataUrl;
+    }
+
+    return dataUrl.replace(DATA_URL_MEDIA_TYPE, 'data:image/x-icon');
+};
+
+export default normalizeIconDataUrl;


### PR DESCRIPTION
Owner-reported problem 4 of four, **admin-upload half**. Sibling PRs: ORISO-Frontend `fix/public-tenant-favicon-p4` (anonymous visitors) and ORISO-Admin `fix/platform-default-favicon` follow-up (decode at the authenticated seam). See `0 - Docs/plans/2026-08-19-owner-problem-fixes-overview.md`.

## Problem

The owner uploaded a tenant favicon. The upload card reported success, but the browser tab kept the built-in placeholder and the card's own preview stayed blank.

## Root cause

The favicon card accepts an `.ico` on its **file extension** when the host reports no MIME type for it (`isAcceptedFile`, #782). `FileReader` then labels the payload `application/octet-stream`, so the value that reaches the tenant record is:

```
data:application/octet-stream;base64,AAABAAEA…
```

`getSafeFaviconUrl` refuses that — **correctly**. It must not admit arbitrary media types into `link[rel=icon][href]`. So the upload looked successful and the value stored was one the renderer was right to reject.

The existing ICO tests only asserted that the file was **accepted**, never what was **stored**. That is how this stayed hidden.

## Fix

Relabel at the upload seam instead of loosening the gatekeeper. A new `normalizeIconDataUrl` utility: an `.ico` that carries no image media type is stored as `data:image/x-icon`. Values that already declare an image type, and non-`.ico` files, are untouched.

The gatekeeper `getSafeFaviconUrl` is not weakened — this is the narrow fix, not the broad one.

## Tests

4 new test cases: `src/utils/normalizeIconDataUrl.test.ts` (new, +40 lines) and `src/components/FormFileUploaderField/index.test.tsx` (+23). The existing ICO tests were upgraded to check the **stored value** against `getSafeFaviconUrl`, which is the assertion that was missing.

## Reviewer test plan

- [ ] Upload a real `.ico` from a host that reports no MIME type for it — the stored value starts `data:image/x-icon;base64,` and the card preview renders.
- [ ] Upload a `.ico` that the host *does* type as `image/vnd.microsoft.icon` — the value is passed through untouched, not double-relabelled.
- [ ] Upload a PNG — untouched, still stored with its own image type.
- [ ] Upload a non-image file — still rejected by the existing accept rules.
- [ ] Reload the panel — the stored favicon survives the round trip and appears in the browser tab.
- [ ] **Mobile (390 px)**: the upload card, its preview and the error state all fit without horizontal scroll.

## Scope note

On Pre-Dev the tenant 1 record already carries `data:image/vnd.microsoft.icon;base64,…` correctly, so **this branch is defence in depth rather than the reported cause**. The reported cause is covered by the Frontend PR (anonymous mount point + five icon links) and by the authenticated-seam decode follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `.ico` file uploads so they are correctly recognized and accepted as favicon images.
  - Prevented valid icon data from being rejected when browsers provide missing or non-image MIME types.
  - Preserved existing image formats and handling for non-icon files.
- **Tests**
  - Added coverage for browser-specific MIME types, empty values, unsupported files, and existing image data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->