### PR TITLE
fix(reader): retire the card radius with the card so it stops clipping the maximize control

### DIFF
--- a/src/components/FormPluginEditor/M3RichTextEditor.module.scss
+++ b/src/components/FormPluginEditor/M3RichTextEditor.module.scss
@@ -136,6 +136,14 @@ $m3-state-active: rgb(39 50 112 / 12%);
        sticky chapter bar below, which has to mask the text scrolling under it. */
     background: none;
     border: 0;
+
+    /* The radius framed the card, so it goes with the card. `.module`'s 28px
+       rounds an 800px surface that still paints a background and a shadow;
+       here there is nothing left to round — but `overflow: clip` kept obeying
+       it, and the arc sliced the maximize control sitting in that corner
+       (owner report 2026-08-19: "abgeschnitten … obere rechte Ecke"). Clipping
+       to a plain rectangle costs nothing visually and gives the control back. */
+    border-radius: 0;
     box-shadow: none;
 
     /* The rules that framed the removed box go with it. */

--- a/src/components/FormPluginEditor/legalReader.styles.test.ts
+++ b/src/components/FormPluginEditor/legalReader.styles.test.ts
@@ -129,3 +129,53 @@ describe('chapter-chip row — scrolls with a visible affordance (H4/I3, 2026-08
         expect(globalStyles).toMatch(/&--fadeStart#{&}--fadeEnd/);
     });
 });
+
+describe('boxless fluid reader — no vestigial corner radius (owner report 2026-08-19)', () => {
+    /*
+     * The owner reported the maximize control "abgeschnitten … in der oberen
+     * rechten Ecke" on the public onboarding reader.
+     *
+     * Measured live on predev.oriso.org (tenant-onboarding wizard, 1440x900,
+     * getComputedStyle) BEFORE the fix:
+     *
+     *   .maximizeToolBtn   28x28, border-radius 50%, rect top 235 / right 1328
+     *   .module.fluid.readMode  overflow "clip", border-radius "28px",
+     *                           rect top 235 / right 1328
+     *                           background rgba(0,0,0,0), border 0px none,
+     *                           box-shadow none
+     *
+     * The button's corner IS the container's corner, and a 28px arc through a
+     * 28px control slices it. The radius is a leftover: `.module` styles an
+     * 800px card, but the fluid reader explicitly gives up `background`,
+     * `border` and `box-shadow` ("The public reader is not a card … it IS the
+     * page", #594.17). Nothing visible is rounded any more — the radius only
+     * still clips. So the box's radius goes with the rest of the box, rather
+     * than the control being nudged away from a corner that no longer exists.
+     */
+    it('drops the card radius wherever it drops the card background', () => {
+        const fluid = moduleStyles.match(/\.module\.fluid:not\(\.inDialog\)\s*{[\s\S]*?\n}/)?.[0] ?? '';
+        expect(fluid).not.toBe('');
+        // The three rules that already retire the box …
+        expect(fluid).toMatch(/background:\s*none;/);
+        expect(fluid).toMatch(/border:\s*0;/);
+        expect(fluid).toMatch(/box-shadow:\s*none;/);
+        // … and the radius that framed it must retire with them.
+        expect(fluid).toMatch(/border-radius:\s*0;/);
+    });
+
+    it('keeps clipping the boxless reader so the chip row is not trapped', () => {
+        // `clip` (not `hidden`) stays: it must not become a scroll container,
+        // which would trap the sticky chapter bar. With a 0 radius it clips to
+        // a plain rectangle, so nothing eats the control any more.
+        const fluid = moduleStyles.match(/\.module\.fluid:not\(\.inDialog\)\s*{[\s\S]*?\n}/)?.[0] ?? '';
+        expect(fluid).toMatch(/overflow:\s*clip;/);
+    });
+
+    it('leaves the 800px deck card its rounded corners', () => {
+        // Only the boxless fluid reader loses the radius. The real card — the
+        // one that still paints a surface and a shadow — keeps it.
+        const base = moduleStyles.match(/^\.module\s*{[\s\S]*?\n}/m)?.[0] ?? '';
+        expect(base).toMatch(/border-radius:\s*28px;/);
+        expect(base).toMatch(/box-shadow:/);
+    });
+});


### PR DESCRIPTION
Bonus finding from the 2026-08-19 owner-problem session — reported by the owner as "an icon cut off in the top-right corner of the DPA reader", found to be worse than cosmetic. See `0 - Docs/plans/2026-08-19-owner-problem-fixes-overview.md`.

## Problem

In the boxless fluid DPA reader, the maximize control pinned to the top-right corner was visibly clipped. Measurement showed it was also **not fully clickable**.

## Root cause

`.module.fluid:not(.inDialog)` gave up the card it framed — `background`, `border` and `box-shadow` are all already `none` there ("The public reader is not a card … it IS the page", #594.17) — but **kept `.module`'s 28px corner radius**.

The radius rounded nothing visible any more. But `overflow: clip` still obeyed it, and `overflow: clip` also clips **hit testing**. The arc ran straight through the 28×28 maximize control whose corner *is* the container's corner.

Measured live on `predev.oriso.org` (public onboarding wizard, `getComputedStyle` plus an `elementFromPoint` probe grid over the control's 28×28 box), at viewport widths 390 / 820 / 1440:

| | control hittable |
|---|---|
| `border-radius: 28px` | **81–85 %** |
| `border-radius: 0` | **100 %** |

Container as measured: `overflow: clip`, `border-radius: 28px`, `background: rgba(0,0,0,0)`, `border: 0px none`, `box-shadow: none`.

So roughly a fifth of the control was not merely drawn short — it was not clickable.

## Fix

Set `border-radius: 0` where the box is already dropped. It clips to a plain rectangle instead, which costs nothing visually because there is no painted surface to round.

`overflow: clip` **stays**: it must not become a scroll container or it would trap the sticky chapter bar. The 800px deck card, which still paints a surface and a shadow, keeps its 28px corners.

## Tests

3 new test cases in `src/components/FormPluginEditor/legalReader.styles.test.ts` (new file, +50 lines) asserting that the fluid non-dialog reader has radius 0 while the deck card keeps 28px, and that `overflow: clip` is retained.

## Reviewer test plan

- [ ] Open the public DPA reader (onboarding wizard, anonymous). The maximize control is fully drawn, no arc through it.
- [ ] Click the **extreme top-right corner pixel** of the control — it activates. Before this change it did not.
- [ ] Scroll the reader — the sticky chapter bar still sticks (the `overflow: clip` guarantee is intact).
- [ ] Open the reader **inside a dialog** (`.inDialog`) — unchanged, still a card.
- [ ] The 800px deck card still shows 28px corners with its surface and shadow.
- [ ] **Mobile (390 px)**: control fully hittable; re-check at 820 and 1440.
