### PR TITLE
fix(branding): decode branding assets at the authenticated seam too (follow-up to #833)

### DIFF
--- a/src/api/tenant/getPublicTenantData.ts
+++ b/src/api/tenant/getPublicTenantData.ts
@@ -1,10 +1,8 @@
 import { fetchData, FETCH_METHODS, FETCH_ERRORS } from '../fetchData';
 import { baseTenantPublicEndpoint } from '../../appConfig';
 import getLocationVariables from '../../utils/getLocationVariables';
-import { decodeTenantAsset } from '../../utils/decodeTenantAsset';
+import { decodeTenantBrandingAssets } from '../../utils/decodeTenantAsset';
 import { AppConfigInterface } from '../../types/AppConfigInterface';
-
-const BRANDING_ASSETS = ['logo', 'favicon', 'associationLogo'] as const;
 
 /**
  * TenantService HTML-encodes every stored string, so a base64 branding asset
@@ -15,18 +13,7 @@ const BRANDING_ASSETS = ['logo', 'favicon', 'associationLogo'] as const;
  * it got missed: the admin's upload preview decoded, the public surfaces did not.
  */
 const decodeBrandingAssets = (result: any) => {
-    if (!result?.theming) {
-        return result;
-    }
-
-    const theming = { ...result.theming };
-    BRANDING_ASSETS.forEach((asset) => {
-        if (typeof theming[asset] === 'string') {
-            theming[asset] = decodeTenantAsset(theming[asset]);
-        }
-    });
-
-    return { ...result, theming };
+    return decodeTenantBrandingAssets(result);
 };
 
 /**

--- a/src/api/tenant/getTenantData.test.ts
+++ b/src/api/tenant/getTenantData.test.ts
@@ -69,3 +69,49 @@ describe('getTenantData', () => {
         });
     });
 });
+
+describe('getTenantData — branding assets survive the authenticated seam', () => {
+    /*
+     * `getPublicTenantData` decodes `theming.logo` / `favicon` /
+     * `associationLogo`; this module never did. That asymmetry made the tenant
+     * favicon override dead code: `<TenantFavicon tenantFavicon={data?.theming
+     * ?.favicon} />` is fed from HERE, TenantService stores `+` as `&#43;` and
+     * `=` as `&#61;`, and `getSafeFaviconUrl`'s HTML_ENTITY guard rejects any
+     * data URL still carrying them — so the tenant value was silently discarded
+     * and the platform default always won.
+     *
+     * Live evidence for the encoding is in `decodeTenantAsset.test.ts`: one real
+     * stored logo carried 3,284 x `&#43;`, the favicon 249 x `&#43;` plus `&#61;`.
+     */
+    const encodedIco = 'data:image/vnd.microsoft.icon;base64,AAABAAEAICA&#43;&#43;xEAA&#61;';
+    const decodedIco = 'data:image/vnd.microsoft.icon;base64,AAABAAEAICA++xEAA=';
+
+    it('decodes every branding asset, exactly like the public seam', async () => {
+        fetchMock.mockResolvedValue({
+            theming: { favicon: encodedIco, logo: 'a&#43;b', associationLogo: 'c&#61;d' },
+        });
+
+        const result = await getTenantData({ id: 1 } as never, false);
+
+        expect(result.theming.favicon).toBe(decodedIco);
+        expect(result.theming.logo).toBe('a+b');
+        expect(result.theming.associationLogo).toBe('c=d');
+    });
+
+    it('leaves a response without theming untouched', async () => {
+        fetchMock.mockResolvedValue({ impressum: null });
+
+        const result = await getTenantData({ id: 1 } as never, false);
+
+        expect(result.theming).toBeUndefined();
+        expect(result.impressum).toBe('');
+    });
+
+    it('does not invent branding keys that the response never carried', async () => {
+        fetchMock.mockResolvedValue({ theming: { favicon: encodedIco } });
+
+        const result = await getTenantData({ id: 1 } as never, false);
+
+        expect(Object.keys(result.theming)).toEqual(['favicon']);
+    });
+});

--- a/src/api/tenant/getTenantData.ts
+++ b/src/api/tenant/getTenantData.ts
@@ -3,6 +3,7 @@ import { tenantEndpoint } from '../../appConfig';
 import { TenantData } from '../../types/tenant';
 import { getAccessTokenForRequests } from '../auth/auth';
 import parseJwt from '../../utils/parseJWT';
+import { decodeTenantBrandingAssets } from '../../utils/decodeTenantAsset';
 
 /**
  * retrieve all needed tenant data
@@ -61,7 +62,11 @@ const getTenantData = (tenantData: TenantData, useMultiTenancyWithSingleDomain: 
             };
 
             // console.log('🔍 getTenantData: SUCCESS - Final result:', result);
-            return result;
+            // Same decode the public seam does. Without it the stored `&#43;` /
+            // `&#61;` survive into `theming.favicon`, `getSafeFaviconUrl`'s
+            // entity guard rejects the value, and the tenant override silently
+            // loses to the platform default.
+            return decodeTenantBrandingAssets(result);
         })
         .catch((error) => {
             // console.error('🔍 getTenantData: ERROR:', error);

--- a/src/utils/decodeTenantAsset.ts
+++ b/src/utils/decodeTenantAsset.ts
@@ -33,4 +33,36 @@ export const decodeTenantAsset = (value?: string | null): string | undefined => 
         .replace(/&amp;/g, '&');
 };
 
+/**
+ * The three stored strings that are URLs rather than markup. Every seam that
+ * hands tenant theming to the UI has to decode exactly these — see
+ * {@link decodeTenantBrandingAssets}.
+ */
+export const BRANDING_ASSETS = ['logo', 'favicon', 'associationLogo'] as const;
+
+/**
+ * Decode the branding assets of a tenant response, whichever endpoint produced
+ * it. Both the public and the authenticated seam need this: the public one
+ * feeds anonymous theming, the authenticated one feeds the tenant favicon
+ * override. Having it in one place is what keeps them from drifting apart
+ * again — they already did once, which silently killed the override.
+ *
+ * Returns the input unchanged when it carries no `theming`, and never invents
+ * keys the response did not have.
+ */
+export const decodeTenantBrandingAssets = <T extends { theming?: Record<string, unknown> }>(result: T): T => {
+    if (!result?.theming) {
+        return result;
+    }
+
+    const theming = { ...result.theming };
+    BRANDING_ASSETS.forEach((asset) => {
+        if (typeof theming[asset] === 'string') {
+            theming[asset] = decodeTenantAsset(theming[asset] as string);
+        }
+    });
+
+    return { ...result, theming };
+};
+
 export default decodeTenantAsset;


### PR DESCRIPTION
Follow-up to **#833** (`fix(branding): show the uploaded favicon in the admin tab for everyone`), which merged before this commit could be pushed to it. This is the second half of the same fix. See `0 - Docs/plans/2026-08-19-owner-problem-fixes-overview.md`.

## Problem

The tenant favicon override that #833 added **could never fire on the authenticated route**. No error, no log — just the platform default icon in the tab.

## Root cause

`<TenantFavicon tenantFavicon={data?.theming?.favicon} />` is fed from `useTenantData()` → `getTenantData`. That module — unlike `getPublicTenantData` — **never ran `decodeTenantAsset`**.

TenantService stores `+` as `&#43;` and `=` as `&#61;`. `getSafeFaviconUrl`'s HTML_ENTITY guard rejects any data URL still carrying them, and `resolveBrandingFavicon` then fell through to the platform default. Silently.

The two seams had already drifted apart once, which is exactly how this happened.

## Fix

The decode now lives in **one** place — `decodeTenantBrandingAssets`, beside `decodeTenantAsset` — and both callers use it. `getPublicTenantData` loses its private copy of the asset list, so the two seams cannot drift again.

## Tests

3 new test cases in `src/api/tenant/getTenantData.test.ts` (+46 lines). The decode assertion is **red without the production change**.

## Reviewer test plan

- [ ] Log in as a tenant admin whose tenant has an uploaded favicon — the browser tab shows the tenant icon, not the platform default.
- [ ] Store a favicon value containing `&#43;` / `&#61;` entities — it is decoded and accepted, not silently dropped.
- [ ] Anonymous route — `getPublicTenantData` still decodes the same asset list (it now shares the helper).
- [ ] Add a new branding asset to the list and confirm both seams pick it up from the single definition.
- [ ] **Mobile (390 px)**: no visual surface here, but confirm the authenticated shell still boots and the tab icon is set on a mobile browser.

## Scope note

Verified on Pre-Dev while writing this: the public payload for tenant 1 carries `data:image/vnd.microsoft.icon;base64,…` with **no entities**, so this is the **latent** half of the feature rather than the reported symptom. The reported symptom was the mount point and the five icon links, which #833 already fixed.

## Why a new PR and not a push to #833

#833 was already merged and its head branch deleted when this commit was ready. The branch has been re-pushed with this single commit on top of `pre-dev`; the diff is exactly the one commit.
