### PR TITLE
feat(legal-editor): consent template chooser in the agency DPP function bar

### DIFF
--- a/src/components/FormPluginEditor/M3RichTextEditor.consentSlot.test.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.consentSlot.test.tsx
@@ -1,0 +1,94 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { M3RichTextEditor } from './M3RichTextEditor';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string, fallbackOrOptions?: unknown) => {
+            if (typeof fallbackOrOptions === 'string') return fallbackOrOptions;
+            return key;
+        },
+    }),
+}));
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })),
+    });
+    Element.prototype.scrollIntoView = vi.fn();
+});
+
+/**
+ * The lower function bar carries up to four split buttons (Figma 1261-48667 plus
+ * the consent template chooser of ADR-021 decision 4). `consentSlot` is the third
+ * of those to be filled from outside, and — like `topicSlot` — must be able to
+ * hold the bar open on its own.
+ */
+describe('M3RichTextEditor consentSlot', () => {
+    it('renders the consent slot in the lower function bar', async () => {
+        render(<M3RichTextEditor title="Datenschutz" consentSlot={<button type="button">Vorlage 2</button>} />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Vorlage 2' })).toBeInTheDocument();
+        });
+    });
+
+    it('orders the bar language → consent → topic → version', async () => {
+        render(
+            <M3RichTextEditor
+                title="Datenschutz"
+                languageSlot={<span data-testid="slot-language">DE</span>}
+                consentSlot={<span data-testid="slot-consent">Vorlage 2</span>}
+                topicSlot={<span data-testid="slot-topic">Sucht</span>}
+                versions={[{ id: 'v1', label: '1. Jul 2026', content: '<p>alt</p>' }]}
+            />,
+        );
+
+        const bar = await screen.findByTestId('m3-editor-function-bar');
+        const language = screen.getByTestId('slot-language');
+        const consent = screen.getByTestId('slot-consent');
+        const topic = screen.getByTestId('slot-topic');
+        const version = screen.getByTitle('legal.m3Editor.versionHistory');
+
+        // All four live in the same bar …
+        expect(bar).toContainElement(language);
+        expect(bar).toContainElement(consent);
+        expect(bar).toContainElement(topic);
+        expect(bar).toContainElement(version);
+
+        // … in the order the footer design specifies.
+        const order = Array.from(bar.children);
+        expect(order.indexOf(language)).toBeLessThan(order.indexOf(consent));
+        expect(order.indexOf(consent)).toBeLessThan(order.indexOf(topic));
+        expect(order.indexOf(topic)).toBeLessThan(
+            order.findIndex((child) => child === version || child.contains(version)),
+        );
+    });
+
+    it('keeps the bar when the consent slot is the only control in it', async () => {
+        // read-only + no versions removes the version control, a single language
+        // removes the language control, and no topicSlot is passed. Without the
+        // consent slot in the render guard the bar would disappear entirely.
+        render(
+            <M3RichTextEditor
+                title="Datenschutz"
+                readOnly
+                languages={[{ value: 'de', label: 'Deutsch' }]}
+                consentSlot={<span data-testid="slot-consent">Vorlage 2</span>}
+            />,
+        );
+
+        const bar = await screen.findByTestId('m3-editor-function-bar');
+        expect(bar).toContainElement(screen.getByTestId('slot-consent'));
+    });
+});

--- a/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.stories.tsx
@@ -2,8 +2,11 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 // eslint-disable-next-line import/no-unresolved -- SB10 subpath export, invisible to the eslint import resolver
 import { expect, userEvent, waitFor, within } from 'storybook/test';
+import Tune from '@mui/icons-material/Tune';
+import { TemplateSplitButton } from '../PlaceholderTemplate';
 import { EditorHintSnackbar } from './EditorHintSnackbar';
 import { M3RichTextEditor } from './M3RichTextEditor';
+import { SplitDropdown } from './SplitDropdown';
 
 // MUI Material 3 "Tip Tap Editor Module" (Figma Admin.ORISO 1:34903).
 const meta = {
@@ -352,5 +355,115 @@ export const VersionSelectReadOnly: Story = {
         readOnly: true,
         languages: [{ value: 'de', label: 'Deutsch' }],
         language: 'de',
+    },
+};
+
+const consentTemplates = [
+    { id: 1, name: 'Vorlage 1' },
+    { id: 2, name: 'Vorlage 2' },
+];
+
+/**
+ * The agency (Fachbereich) data-protection footer in full: language, consent
+ * template, topic and version — the four-control bar of the owner's decision of
+ * 2026-08-19. Framed at Mobile 390x844, where the bar has to scroll horizontally
+ * WITHOUT showing a scrollbar.
+ */
+const AgencyFooterEditor = (args: Parameters<typeof M3RichTextEditor>[0]) => {
+    const [value, setValue] = useState(args.value ?? '');
+    const [templateId, setTemplateId] = useState<number | string>(2);
+    return (
+        <M3RichTextEditor
+            {...args}
+            value={value}
+            onChange={setValue}
+            consentSlot={
+                <TemplateSplitButton
+                    activeTemplateId={templateId}
+                    disabled={args.readOnly}
+                    templates={consentTemplates}
+                    onSelectTemplate={setTemplateId}
+                />
+            }
+            topicSlot={
+                <SplitDropdown
+                    disabled={args.readOnly}
+                    icon={<Tune />}
+                    label="Sucht"
+                    title="Fachbereich wählen"
+                    menu={{
+                        selectable: true,
+                        selectedKeys: ['sucht'],
+                        items: [
+                            { key: 'sucht', label: 'Sucht' },
+                            { key: 'schulden', label: 'Schulden' },
+                        ],
+                    }}
+                />
+            }
+        />
+    );
+};
+
+export const AgencyFooterWithConsentTemplate: Story = {
+    render: (args) => <AgencyFooterEditor {...args} />,
+    args: {
+        title: 'Datenschutzerklärung',
+        value: '<h2>Datenschutzerklärung</h2><p>Aktueller Entwurf des Fachbereichs.</p>',
+        languages: [
+            { value: 'de', label: 'Deutsch' },
+            { value: 'en', label: 'Englisch' },
+        ],
+        language: 'de',
+        versions: dpaVersions,
+        versionLabel: 'Aktueller Entwurf',
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: 390, height: 844, overflow: 'hidden' }}>
+                <Story />
+            </div>
+        ),
+    ],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const bar = await waitFor(() => canvas.getByTestId('m3-editor-function-bar'));
+
+        // Left to right: language, consent template, topic, version.
+        const positions = ['Sprache wählen', 'Vorlagenmenü öffnen', 'Fachbereich wählen', 'Versionsverlauf'].map(
+            (name) => {
+                const control = canvas.getByRole('button', { name });
+                expect(bar).toContainElement(control);
+                return Array.from(bar.children).findIndex((child) => child.contains(control));
+            },
+        );
+        expect(positions).toEqual([...positions].sort((a, b) => a - b));
+
+        // The bar scrolls instead of wrapping, and never shows a scrollbar: the
+        // scroll track occupies no layout space at all.
+        expect(bar.scrollWidth).toBeGreaterThan(bar.clientWidth);
+        expect(bar.offsetHeight - bar.clientHeight).toBe(0);
+        expect(window.getComputedStyle(bar).flexWrap).toBe('nowrap');
+    },
+};
+
+// Read-only (no legal-text permission, or an archived version on screen): the
+// consent chooser stays VISIBLE and goes inert — hiding it would also hide that
+// this level offers templates at all.
+export const AgencyFooterReadOnly: Story = {
+    render: (args) => <AgencyFooterEditor {...args} />,
+    args: {
+        title: 'Datenschutzerklärung',
+        value: '<h2>Datenschutzerklärung</h2><p>Veröffentlichte Fassung.</p>',
+        readOnly: true,
+        languages: [{ value: 'de', label: 'Deutsch' }],
+        language: 'de',
+        versions: dpaVersions,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const chooser = await waitFor(() => canvas.getByRole('button', { name: 'Vorlagenmenü öffnen' }));
+        expect(chooser).toBeVisible();
+        expect(chooser).toBeDisabled();
     },
 };

--- a/src/components/FormPluginEditor/M3RichTextEditor.tsx
+++ b/src/components/FormPluginEditor/M3RichTextEditor.tsx
@@ -163,6 +163,18 @@ export type M3RichTextEditorProps = {
      */
     snackbarSlot?: React.ReactNode;
     /**
+     * Split button in the bottom function bar between language and topic — the
+     * chooser for a template the document's consent sentence is loaded from
+     * (ADR-021 decision 4: the consent text is a FIELD of the data-protection
+     * policy, so its template belongs to that policy's editor). Named for the
+     * role, not the one control that fills it today.
+     *
+     * Optional and additive: a host that passes nothing gets exactly the bar it
+     * had before. The consent chooser is wired on the AGENCY level only (owner
+     * decision 2026-08-19); the tenant/platform editor deliberately passes none.
+     */
+    consentSlot?: React.ReactNode;
+    /**
      * Second split button in the bottom function bar (between language and
      * version) — e.g. a topic/department picker (Figma 1261-48667 allows up
      * to three split button fields).
@@ -649,6 +661,7 @@ export const M3RichTextEditor = ({
     contentLanguage,
     hideHeader,
     languageSlot,
+    consentSlot,
     topicSlot,
     helpSlot,
     snackbarSlot,
@@ -1014,11 +1027,14 @@ export const M3RichTextEditor = ({
                 </div>
             )}
 
-            {/* Lower function bar (Figma 1261-48667): up to three split buttons —
-                language, topic/department (slot), version history. */}
-            {(languageControl || topicSlot || showVersionControl) && (
-                <div className={styles.functionBar}>
+            {/* Lower function bar (Figma 1261-48667): up to four split buttons —
+                language, consent template (slot), topic/department (slot),
+                version history. Every one of them can be the only occupant, so
+                each has to hold the bar open on its own. */}
+            {(languageControl || consentSlot || topicSlot || showVersionControl) && (
+                <div className={styles.functionBar} data-testid="m3-editor-function-bar">
                     {languageControl}
+                    {consentSlot}
                     {topicSlot}
                     {showVersionControl && (
                         <SplitDropdown

--- a/src/components/PlaceholderTemplate/LegalConsentTemplateEditor.tsx
+++ b/src/components/PlaceholderTemplate/LegalConsentTemplateEditor.tsx
@@ -38,6 +38,8 @@ export interface LegalConsentTemplateEditorProps {
      * archived version.
      */
     readOnly?: boolean;
+    /** The host draws the template chooser itself — see PlaceholderTemplateEditor. */
+    hideTemplateChooser?: boolean;
 }
 
 /**
@@ -57,6 +59,7 @@ export const LegalConsentTemplateEditor = ({
     addendum,
     languageLabel,
     readOnly = false,
+    hideTemplateChooser = false,
 }: LegalConsentTemplateEditorProps) => {
     const { t } = useTranslation();
     const sentenceId = useId();
@@ -79,6 +82,7 @@ export const LegalConsentTemplateEditor = ({
         <PlaceholderTemplateEditor
             activeTemplateId={activeTemplateId}
             fields={fields}
+            hideTemplateChooser={hideTemplateChooser}
             heading={t('placeholderTemplate.legal.heading', 'Einwilligung (Registrierung)')}
             preview={
                 <section

--- a/src/components/PlaceholderTemplate/PlaceholderTemplateEditor.tsx
+++ b/src/components/PlaceholderTemplate/PlaceholderTemplateEditor.tsx
@@ -48,6 +48,14 @@ export interface PlaceholderTemplateEditorProps<V extends Record<string, string>
      * hiding them would also hide what this level offers.
      */
     readOnly?: boolean;
+    /**
+     * The HOST already shows the template chooser somewhere else and this module
+     * must not draw a second one. Not a read-only variant and not a way to take
+     * the choice away: `readOnly` is what makes a chooser inert, this only says
+     * where it lives. Used by the department data-protection card, which lifts
+     * the chooser into the editor's function bar.
+     */
+    hideTemplateChooser?: boolean;
 }
 
 /**
@@ -70,18 +78,21 @@ export const PlaceholderTemplateEditor = <V extends Record<string, string>>({
     onManageTemplates,
     preview,
     readOnly = false,
+    hideTemplateChooser = false,
 }: PlaceholderTemplateEditorProps<V>) => (
     <section aria-label={heading} className={styles.editor}>
         <header className={styles.header}>
             <h3 className={styles.heading}>{heading}</h3>
-            <TemplateSplitButton
-                activeTemplateId={activeTemplateId}
-                disabled={readOnly}
-                templates={templates}
-                onCreateFromTemplate={onCreateFromTemplate}
-                onMainClick={onManageTemplates}
-                onSelectTemplate={onSelectTemplate}
-            />
+            {!hideTemplateChooser && (
+                <TemplateSplitButton
+                    activeTemplateId={activeTemplateId}
+                    disabled={readOnly}
+                    templates={templates}
+                    onCreateFromTemplate={onCreateFromTemplate}
+                    onMainClick={onManageTemplates}
+                    onSelectTemplate={onSelectTemplate}
+                />
+            )}
         </header>
         <div className={styles.formAndPreview}>
             <div className={styles.fields}>

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.consentTemplate.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/DepartmentDataProtectionCard.consentTemplate.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DepartmentDataProtectionCard } from './index';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        i18n: { language: 'de' },
+        t: (key: string, options?: unknown) => {
+            if (typeof options === 'string') return options;
+            if (options && typeof options === 'object') return `${key}:${Object.values(options).join(':')}`;
+            return key;
+        },
+    }),
+}));
+
+// TipTap is far too heavy for a wiring test; the stub renders the one slot this
+// test is about, so the assertions are about what the AGENCY card puts there.
+vi.mock('../../../../FormPluginEditor/M3RichTextEditor', () => ({
+    M3RichTextEditor: ({
+        consentSlot,
+        onViewVersionChange,
+        versions,
+    }: {
+        consentSlot?: React.ReactNode;
+        onViewVersionChange?: (versionId: string | null) => void;
+        versions?: { id: string }[];
+    }) => (
+        <div data-testid="editor">
+            <div data-testid="consent-slot">{consentSlot}</div>
+            {(versions ?? []).map((version) => (
+                <button key={version.id} type="button" onClick={() => onViewVersionChange?.(version.id)}>
+                    view {version.id}
+                </button>
+            ))}
+        </div>
+    ),
+}));
+
+const consentByLanguage = { de: 'Ich habe die {{legal_links}} gelesen.' };
+
+/** The chevron of the consent template split button — the mocked `t` yields the German fallback. */
+const chooser = () => screen.getByRole('button', { name: 'Vorlagenmenü öffnen' });
+
+const renderCard = (props: Partial<Parameters<typeof DepartmentDataProtectionCard>[0]> = {}) =>
+    render(
+        <DepartmentDataProtectionCard
+            departmentName="Sucht"
+            initialContentByLanguage={{ de: '<p>Text</p>' }}
+            languages={['de']}
+            consentByLanguage={consentByLanguage}
+            onSave={vi.fn()}
+            {...props}
+        />,
+    );
+
+/**
+ * ADR-021 decision 4 — the consent sentence is a FIELD of the department policy,
+ * so its template chooser belongs in that policy editor's function bar. The owner
+ * settled this for the AGENCY level only (2026-08-19); the tenant/platform editor
+ * is deliberately left alone (see LegalText.test.tsx).
+ */
+describe('DepartmentDataProtectionCard consent template chooser', () => {
+    it('puts a consent template split button into the editor function bar', async () => {
+        renderCard();
+
+        const slot = await screen.findByTestId('consent-slot');
+        expect(slot).toContainElement(chooser());
+        // Exactly one chooser on the surface — the consent module below the editor
+        // must not draw a second one driving the same field.
+        expect(screen.getAllByRole('button', { name: 'Vorlagenmenü öffnen' })).toHaveLength(1);
+    });
+
+    it('does not offer the chooser when the level carries no consent field', () => {
+        renderCard({ consentByLanguage: undefined });
+
+        expect(screen.getByTestId('consent-slot')).toBeEmptyDOMElement();
+    });
+
+    it('applies a picked template to the consent sentence of the active language', async () => {
+        const user = userEvent.setup();
+        const onSave = vi.fn();
+        renderCard({ onSave });
+
+        await user.click(chooser());
+        await user.click(await screen.findByText('legal.consent.template.platform.name'));
+
+        // The template's text lands in the consent field of the active language …
+        expect(await screen.findByDisplayValue('legal.consent.template.platform.text')).toBeInTheDocument();
+        // … and picking a template is an edit, not a save.
+        expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it('stays visible but inert for an admin without the legal-text permission', async () => {
+        renderCard({ readOnly: true });
+
+        const trigger = await screen.findByRole('button', { name: 'Vorlagenmenü öffnen' });
+        expect(trigger).toBeInTheDocument();
+        expect(trigger).toBeDisabled();
+    });
+
+    it('stays visible but inert while an archived version is on screen', async () => {
+        const user = userEvent.setup();
+        renderCard({
+            versions: [
+                {
+                    id: 1,
+                    kind: 'DPP',
+                    ownerLevel: 'DEPARTMENT',
+                    ownerId: 7,
+                    content: JSON.stringify({ de: '<p>alt</p>' }),
+                    consentText: JSON.stringify({ de: 'alter Satz {{legal_links}}' }),
+                    publishedAt: '2026-07-01T10:00:00Z',
+                },
+            ],
+        });
+
+        expect(await screen.findByRole('button', { name: 'Vorlagenmenü öffnen' })).toBeEnabled();
+
+        await user.click(screen.getByRole('button', { name: 'view 1' }));
+
+        expect(chooser()).toBeDisabled();
+    });
+});

--- a/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/DepartmentDataProtectionCard/index.tsx
@@ -3,6 +3,7 @@ import { Alert, Button, Tag } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { GdprIcon, ImprintIcon } from '../../../../CustomIcons/LegalIcons';
 import { M3RichTextEditor } from '../../../../FormPluginEditor/M3RichTextEditor';
+import { TemplateSplitButton } from '../../../../PlaceholderTemplate';
 import { LegalContentLanguageSelect } from '../LegalContentLanguageSelect';
 import { LegalConsentField } from '../LegalConsentField';
 import { PublishSourceWarningModal } from '../PublishSourceWarningModal';
@@ -10,6 +11,7 @@ import { TranslateOnPublishModal } from '../TranslateOnPublishModal';
 import { useLegalContentTranslation } from '../../hooks/useLegalContentTranslation';
 import { consentPublicationBlockers, MANDATORY_CONSENT_TOKEN } from '../../utils/consentTextValidation';
 import { toEditorVersions } from '../../utils/legalVersionOptions';
+import { useConsentTemplates } from '../../hooks/useConsentTemplates';
 import { useViewedLegalVersion } from '../../hooks/useViewedLegalVersion';
 import { LegalTextVersion } from '../../../../../types/legalVersion';
 import { TranslateRequest, TranslateResponse } from '../../../../../types/translation';
@@ -130,6 +132,8 @@ export const DepartmentDataProtectionCard = ({
     // decision 7 — the imprint is an information duty and never a consent gate).
     const consentEnabled = documentType === 'privacy' && consentByLanguage !== undefined;
     const [consentEdits, setConsentEdits] = useState<Record<string, string>>({});
+    const consentTemplates = useConsentTemplates();
+    const [consentTemplateId, setConsentTemplateId] = useState<number | string | undefined>(undefined);
     const [publishBlocked, setPublishBlocked] = useState(false);
     const consentMap = useMemo(
         () => ({ ...(consentByLanguage ?? {}), ...consentEdits }),
@@ -182,6 +186,9 @@ export const DepartmentDataProtectionCard = ({
     );
     // Keeps the consent sentence on the same version as the body shown above it.
     const { onViewVersionChange, viewedConsent, isViewingVersion } = useViewedLegalVersion(versions);
+    // Nothing about the consent sentence may be changed by a viewer without the
+    // legal-text permission, or while an archived version is on screen.
+    const consentLocked = readOnly || isViewingVersion;
 
     /**
      * Publishing is refused while an authored consent sentence lacks
@@ -196,6 +203,19 @@ export const DepartmentDataProtectionCard = ({
         }
         setPublishBlocked(false);
         requestPublish();
+    };
+
+    /**
+     * Loading a template REPLACES the sentence of the language currently being
+     * edited — the consent map is per language, so a template picked while
+     * reading German must not overwrite the French wording as well.
+     */
+    const applyConsentTemplate = (id: number | string) => {
+        const template = consentTemplates.find((entry) => entry.id === id);
+        if (!template || consentLocked) return;
+        setConsentTemplateId(id);
+        setPublishBlocked(false);
+        setConsentEdits((current) => ({ ...current, [activeLanguage]: template.values.text }));
     };
 
     return (
@@ -225,6 +245,21 @@ export const DepartmentDataProtectionCard = ({
                             onChange={setActiveLanguage}
                             sourceLanguage={sourceLanguage}
                             contentMap={contentMapWithEdits}
+                        />
+                    ) : undefined
+                }
+                /* The consent sentence is a FIELD of this policy (ADR-021 decision 4),
+                   so its template chooser belongs in this editor's function bar —
+                   agency level only, by the owner's decision of 2026-08-19. It stays
+                   visible but inert on read-only and archived surfaces: hiding it
+                   would also hide that this level offers templates at all. */
+                consentSlot={
+                    consentEnabled ? (
+                        <TemplateSplitButton
+                            activeTemplateId={consentTemplateId}
+                            disabled={consentLocked}
+                            templates={consentTemplates}
+                            onSelectTemplate={applyConsentTemplate}
                         />
                     ) : undefined
                 }
@@ -304,6 +339,7 @@ export const DepartmentDataProtectionCard = ({
                 It stays part of THIS card — one card, policy plus its consent field. */}
             {consentEnabled && (
                 <LegalConsentField
+                    hideTemplateChooser
                     inheritedFrom={
                         // The notice describes the CURRENT state. While an archived version is on
                         // screen it would answer a question nobody asked about the version being
@@ -315,7 +351,7 @@ export const DepartmentDataProtectionCard = ({
                             : undefined
                     }
                     language={activeLanguage}
-                    readOnly={readOnly || isViewingVersion}
+                    readOnly={consentLocked}
                     value={(viewedConsent ?? consentMap)[activeLanguage] ?? ''}
                     onChange={(next) => {
                         setPublishBlocked(false);

--- a/src/components/Tenants/LegalSettings/components/LegalConsentField/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalConsentField/index.tsx
@@ -1,15 +1,14 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Alert } from 'antd';
 import { useTranslation } from 'react-i18next';
-import { LegalConsentTemplateEditor, type LegalConsentTemplateValues } from '../../../../PlaceholderTemplate';
+import { LegalConsentTemplateEditor } from '../../../../PlaceholderTemplate';
+import { useConsentTemplates } from '../../hooks/useConsentTemplates';
 import {
     hasMandatoryConsentToken,
     isBlankConsentText,
     MANDATORY_CONSENT_TOKEN,
 } from '../../utils/consentTextValidation';
 import styles from './styles.module.scss';
-
-const PLATFORM_TEMPLATE_ID = 'platform';
 
 export interface LegalConsentFieldProps {
     /** The consent sentence of the language currently being edited. */
@@ -25,6 +24,13 @@ export interface LegalConsentFieldProps {
      * valid statement, so the card says which one it is showing).
      */
     inheritedFrom?: string;
+    /**
+     * The HOST already offers the template chooser — the department card lifts it
+     * into the editor's function bar (agency level, owner decision 2026-08-19), so
+     * this module must not draw a second, identical one. The choice itself is not
+     * taken away; only its location moves.
+     */
+    hideTemplateChooser?: boolean;
 }
 
 /**
@@ -41,20 +47,17 @@ export interface LegalConsentFieldProps {
  * - the cookie/authentication notice is appended by the platform and is not
  *   editable — shown in the preview so the admin sees the real sentence.
  */
-export const LegalConsentField = ({ value, language, onChange, readOnly, inheritedFrom }: LegalConsentFieldProps) => {
+export const LegalConsentField = ({
+    value,
+    language,
+    onChange,
+    readOnly,
+    inheritedFrom,
+    hideTemplateChooser,
+}: LegalConsentFieldProps) => {
     const { t } = useTranslation();
     const [activeTemplateId, setActiveTemplateId] = useState<number | string | undefined>(undefined);
-
-    const templates = useMemo(
-        () => [
-            {
-                id: PLATFORM_TEMPLATE_ID,
-                name: t('legal.consent.template.platform.name'),
-                values: { text: t('legal.consent.template.platform.text') } as LegalConsentTemplateValues,
-            },
-        ],
-        [t],
-    );
+    const templates = useConsentTemplates();
 
     // Only an authored sentence can violate the rule — an empty field means the
     // level above still applies, which is a valid state, not an error.
@@ -93,6 +96,7 @@ export const LegalConsentField = ({ value, language, onChange, readOnly, inherit
                         <span className={styles.addendumCaption}>{t('legal.consent.cookieNotice.caption')}</span>
                     </p>
                 }
+                hideTemplateChooser={hideTemplateChooser}
                 languageLabel={t(`language.${language}`, language.toUpperCase())}
                 readOnly={readOnly}
                 templates={templates}

--- a/src/components/Tenants/LegalSettings/components/LegalText/LegalText.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/LegalText/LegalText.test.tsx
@@ -73,6 +73,7 @@ vi.mock('../../../../FormPluginEditor/M3RichTextEditor', () => ({
         snackbarSlot,
         aboveEditorSlot,
         belowSlot,
+        ...rest
     }: {
         value?: string;
         onChange?: (html: string) => void;
@@ -83,8 +84,16 @@ vi.mock('../../../../FormPluginEditor/M3RichTextEditor', () => ({
         snackbarSlot?: React.ReactNode;
         aboveEditorSlot?: React.ReactNode;
         belowSlot?: React.ReactNode;
+        [prop: string]: unknown;
     }) => (
-        <div data-testid="m3-editor" data-value={value} data-readonly={readOnly ? 'true' : 'false'}>
+        <div
+            data-testid="m3-editor"
+            data-value={value}
+            data-readonly={readOnly ? 'true' : 'false'}
+            // Everything the tenant editor passes beyond the props modelled above.
+            // Read by the "consent chooser stays off this level" test below.
+            data-extra-props={Object.keys(rest).sort().join(',')}
+        >
             {helpSlot}
             {snackbarSlot}
             {aboveEditorSlot}
@@ -294,6 +303,30 @@ describe('LegalText (M3 editor)', () => {
         await vi.waitFor(() =>
             expect(screen.getByTestId('m3-editor')).toHaveAttribute('data-value', '<p>Impressum DE</p>'),
         );
+    });
+});
+
+describe('LegalText — consent template chooser (deliberately absent)', () => {
+    /**
+     * The owner settled the consent split button on the AGENCY level ONLY
+     * (2026-08-19). `M3RichTextEditor.consentSlot` exists for every host, but the
+     * tenant/platform editor must keep the footer it had. This asserts the
+     * restriction so it reads as a decision, not as an oversight — do not "finish"
+     * the job by wiring it here.
+     */
+    it('passes no consentSlot to the editor', () => {
+        render(
+            <LegalText
+                tenantId="1"
+                fieldName={['content', 'imprint']}
+                titleKey="imprint.title"
+                subTitle="imprint.subTitle"
+                placeHolderKey="settings.imprint.placeholder"
+            />,
+        );
+
+        const extraProps = screen.getByTestId('m3-editor').getAttribute('data-extra-props') ?? '';
+        expect(extraProps.split(',')).not.toContain('consentSlot');
     });
 });
 

--- a/src/components/Tenants/LegalSettings/hooks/useConsentTemplates.ts
+++ b/src/components/Tenants/LegalSettings/hooks/useConsentTemplates.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { LegalConsentTemplateValues, PlaceholderTemplateDefinition } from '../../../PlaceholderTemplate';
+
+/** The wording the platform ships; a level that picks it starts from that text. */
+export const PLATFORM_CONSENT_TEMPLATE_ID = 'platform';
+
+/**
+ * The consent-sentence templates on offer, in the one place that defines them.
+ *
+ * Two surfaces show the same chooser — the department card's editor function bar
+ * and the consent module's own header (ADR-021 decision 4) — and a template list
+ * that differed between them would let the same pick produce two sentences.
+ */
+export const useConsentTemplates = (): PlaceholderTemplateDefinition<LegalConsentTemplateValues>[] => {
+    const { t } = useTranslation();
+
+    return useMemo(
+        () => [
+            {
+                id: PLATFORM_CONSENT_TEMPLATE_ID,
+                name: t('legal.consent.template.platform.name'),
+                values: { text: t('legal.consent.template.platform.text') } as LegalConsentTemplateValues,
+            },
+        ],
+        [t],
+    );
+};


### PR DESCRIPTION
## Problem

The department data-protection editor's lower function bar carried three controls: language, topic, version. The consent sentence had no template chooser there, even though the consent sentence is a **field of that policy** (ADR-021 decision 4) — so its chooser belongs in the same bar. The footer now reads **language, consent template, topic, version**.

## Root cause

Not a defect so much as a missing slot: `M3RichTextEditor`'s function bar had no extension point between the language control and `topicSlot`, so the consent module drew its own chooser elsewhere in the form.

## Fix

- **`M3RichTextEditor`**: new optional `consentSlot`, rendered between the language control and `topicSlot`, and added to the bar's render guard so it can hold the bar open on its own. Purely additive — hosts that pass nothing get exactly the bar they had.
- **`DepartmentDataProtectionCard`** fills the slot with the **existing `TemplateSplitButton`** (no second split button was built) and owns the picked template; applying one replaces only the active language's sentence.
- The chooser is **visible but disabled** on read-only surfaces and while an archived version is on screen, per the admin "disable, never hide" rule.
- `useConsentTemplates` holds the template list once, so the two surfaces that can show the chooser cannot drift apart.
- `hideTemplateChooser` keeps the consent module from drawing a second, identical chooser now that the card lifted it into the function bar.

### Scope decision carried over from the commit

The **tenant/platform level was deliberately left out at the owner's request (2026-08-19)**. `LegalText.test.tsx` asserts it passes no `consentSlot`, so nobody "completes" this later by mistake. If you think that test is wrong, that is an owner decision, not a review nit.

## Tests

- All five `M3RichTextEditor` guard suites plus the new `consentSlot` suite: **59 tests**.
- `LegalSettings` and `PlaceholderTemplate` suites: **168 tests**.
- `eslint --max-warnings=0` and `prettier` on the touched files.
- **axe** (wcag2a / 2aa / 21a / 21aa / 22aa) on both new stories at 390x844: **0 violations**.

## Reviewer test plan

- [ ] Storybook → `M3RichTextEditor` → the new consent-slot stories: the function bar reads language, consent template, topic, version in that order.
- [ ] Open a Fachbereich data-protection card; pick a consent template from the split button. Only the **active language's** sentence changes; the others are untouched.
- [ ] Switch the card to read-only: the chooser is still **visible but disabled**, not hidden.
- [ ] Open an **archived version**: same — visible, disabled.
- [ ] Confirm only **one** template chooser is on screen (the consent module must not draw a second one).
- [ ] Open the **tenant/platform** legal text: there is deliberately **no** consent chooser in its function bar.
- [ ] **Mobile 390x844**: the four controls wrap sanely and the bar stays operable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consent-template selection to department legal text editing.
  * Templates can be applied to the active language without immediately saving changes.
  * Added support for hiding the template chooser when needed.
  * Added read-only and archived-state behavior that disables template selection.

* **Tests**
  * Added coverage for consent controls, template selection, visibility, ordering, and read-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->