### PR TITLE
fix(legal): head the consent editor with an icon and say what the screen does

### DIFF
--- a/src/components/PlaceholderTemplate/LegalConsentTemplateEditor.tsx
+++ b/src/components/PlaceholderTemplate/LegalConsentTemplateEditor.tsx
@@ -1,5 +1,6 @@
 import { useId, useMemo, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import FactCheckOutlinedIcon from '@mui/icons-material/FactCheckOutlined';
 import { M3Checkbox } from '../M3Checkbox';
 import {
     PlaceholderTemplateEditor,
@@ -13,6 +14,14 @@ import styles from './PlaceholderTemplateEditor.module.scss';
 export interface LegalConsentTemplateValues extends Record<string, string> {
     text: string;
 }
+
+/**
+ * Head symbol of the consent sentence: a document with a tick — the policy the
+ * sentence belongs to, plus the checkbox the help-seeker confirms it with. An
+ * alias, not a wrapper, so the full-page editor head and the dialog hero icon
+ * use one symbol instead of drifting apart. Decorative everywhere it is used.
+ */
+export const LegalConsentHeadIcon = FactCheckOutlinedIcon;
 
 export interface LegalConsentTemplateEditorProps {
     values: LegalConsentTemplateValues;
@@ -80,6 +89,7 @@ export const LegalConsentTemplateEditor = ({
             activeTemplateId={activeTemplateId}
             fields={fields}
             heading={t('placeholderTemplate.legal.heading', 'Einwilligung (Registrierung)')}
+            icon={<LegalConsentHeadIcon />}
             preview={
                 <section
                     aria-label={t('placeholderTemplate.legal.previewLabel', 'Vorschau der Einwilligung')}

--- a/src/components/PlaceholderTemplate/PlaceholderTemplateDialog.module.scss
+++ b/src/components/PlaceholderTemplate/PlaceholderTemplateDialog.module.scss
@@ -17,6 +17,14 @@
     white-space: nowrap;
 }
 
+/* The dialog head already carries the hero icon above the centered title
+   (Modal anatomy). The editor's own head icon would repeat it, off-center and
+   next to the split button — it is decorative, so it simply goes away here. */
+
+.body :global(section > header > [data-head-icon]) {
+    display: none;
+}
+
 /* With the heading hidden, the template split button alone forms the header
    row — keep it on the right edge like in the full-page variant. */
 

--- a/src/components/PlaceholderTemplate/PlaceholderTemplateDialog.stories.tsx
+++ b/src/components/PlaceholderTemplate/PlaceholderTemplateDialog.stories.tsx
@@ -2,7 +2,11 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { PlaceholderTemplateDialog } from './PlaceholderTemplateDialog';
 import { InviteEmailTemplateEditor, type InviteEmailTemplateValues } from './InviteEmailTemplateEditor';
-import { LegalConsentTemplateEditor, type LegalConsentTemplateValues } from './LegalConsentTemplateEditor';
+import {
+    LegalConsentHeadIcon,
+    LegalConsentTemplateEditor,
+    type LegalConsentTemplateValues,
+} from './LegalConsentTemplateEditor';
 import type { PlaceholderTemplateDefinition } from './PlaceholderTemplateEditor';
 
 const meta = {
@@ -97,6 +101,7 @@ const LegalDialogDemo = () => {
     return (
         <PlaceholderTemplateDialog
             titleKey="placeholderTemplate.dialog.legalTitle"
+            icon={<LegalConsentHeadIcon />}
             descriptionKey="placeholderTemplate.dialog.legalDescription"
             onSave={() => undefined}
             onClose={() => undefined}

--- a/src/components/PlaceholderTemplate/PlaceholderTemplateDialog.test.tsx
+++ b/src/components/PlaceholderTemplate/PlaceholderTemplateDialog.test.tsx
@@ -40,6 +40,18 @@ describe('PlaceholderTemplateDialog', () => {
         expect(screen.getByRole('button', { name: 'cancel' })).toBeInTheDocument();
     });
 
+    // M3 basic-dialog anatomy: icon → title → description. The shell only
+    // forwards it; which symbol a dialog carries is the variant's call.
+    it('shows the hero icon in the head when the caller supplies one', () => {
+        renderDialog({ icon: <svg data-testid="hero-icon" /> });
+        expect(screen.getByTestId('hero-icon')).toBeInTheDocument();
+    });
+
+    it('keeps the head iconless when no icon is passed', () => {
+        renderDialog();
+        expect(screen.queryByTestId('hero-icon')).toBeNull();
+    });
+
     it('wires save and cancel to the callbacks', () => {
         const { onSave, onClose } = renderDialog();
         fireEvent.click(screen.getByRole('button', { name: 'save' }));

--- a/src/components/PlaceholderTemplate/PlaceholderTemplateDialog.tsx
+++ b/src/components/PlaceholderTemplate/PlaceholderTemplateDialog.tsx
@@ -5,6 +5,13 @@ import styles from './PlaceholderTemplateDialog.module.scss';
 export interface PlaceholderTemplateDialogProps {
     /** i18n key of the centered dialog title (house M3 anatomy). */
     titleKey: string;
+    /**
+     * Hero icon centered above the title (M3 basic-dialog anatomy: icon →
+     * title → description). Passed per variant, since the invite e-mail and
+     * the consent sentence are not the same subject. Decorative — the Modal
+     * renders it `aria-hidden`.
+     */
+    icon?: ReactNode;
     /** One sentence under the title saying what the dialog is for. */
     descriptionKey?: string;
     /**
@@ -45,6 +52,7 @@ export interface PlaceholderTemplateDialogProps {
  */
 export const PlaceholderTemplateDialog = ({
     titleKey,
+    icon,
     descriptionKey,
     children,
     onSave,
@@ -57,6 +65,7 @@ export const PlaceholderTemplateDialog = ({
 }: PlaceholderTemplateDialogProps) => (
     <Modal
         titleKey={titleKey}
+        icon={icon}
         descriptionKey={descriptionKey}
         footer={footer}
         okLabelKey="save"

--- a/src/components/PlaceholderTemplate/PlaceholderTemplateEditor.module.scss
+++ b/src/components/PlaceholderTemplate/PlaceholderTemplateEditor.module.scss
@@ -12,8 +12,28 @@
     gap: 12px;
 }
 
+/* Decorative head icon (M3 anatomy icon → title). Sized by font-size as well
+   as by width/height, the same way Modal's hero icon is: the icon sets clip
+   themselves against a rect expressed in `em`, so sizing only the box can crop
+   the artboard. */
+
+.headIcon {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    color: var(--m3-secondary, #4c555f);
+    font-size: 24px;
+
+    svg {
+        width: 1em;
+        height: 1em;
+    }
+}
+
 .heading {
-    margin: 0;
+    /* Absorbs the free space so the head reads icon → title on the left and
+       keeps the template split button on the right edge. */
+    margin: 0 auto 0 0;
     color: var(--m3-on-surface, #1d1b20);
     font-size: 18px;
     font-weight: 600;

--- a/src/components/PlaceholderTemplate/PlaceholderTemplateEditor.test.tsx
+++ b/src/components/PlaceholderTemplate/PlaceholderTemplateEditor.test.tsx
@@ -129,6 +129,14 @@ describe('InviteEmailTemplateEditor', () => {
         expect(bodyField).toContainElement(pickers[0]);
     });
 
+    // The head icon is a variant decision, not a frame decision: the shared
+    // editor is reused here, so hardcoding a symbol in it would stamp the
+    // consent icon onto the invitation e-mail too.
+    it('keeps the invite head iconless — the shared frame does not pick a symbol', () => {
+        const { container } = render(<InviteHarness />);
+        expect(container.querySelector('[data-head-icon]')).toBeNull();
+    });
+
     it('loads the picked template into the fields via the split button', async () => {
         const user = userEvent.setup();
         render(<InviteHarness />);
@@ -162,6 +170,16 @@ describe('LegalConsentTemplateEditor', () => {
         expect(within(preview).getByRole('checkbox')).toBeInTheDocument();
         expect(within(preview).getByText(/Beratungsstelle Mainz-Neustadt/)).toBeInTheDocument();
         expect(within(preview).queryByText('{{Beratungsstelle}}')).not.toBeInTheDocument();
+    });
+
+    it('heads the module with a decorative icon that never becomes its name', () => {
+        const { container } = render(<LegalHarness />);
+
+        const headIcon = container.querySelector('[data-head-icon]');
+        expect(headIcon).toBeInTheDocument();
+        expect(headIcon).toHaveAttribute('aria-hidden', 'true');
+        // The accessible name stays the heading on the <section aria-label>.
+        expect(screen.getByRole('region', { name: 'Einwilligung (Registrierung)' })).toBeInTheDocument();
     });
 
     it('updates the consent preview live while typing', () => {

--- a/src/components/PlaceholderTemplate/PlaceholderTemplateEditor.tsx
+++ b/src/components/PlaceholderTemplate/PlaceholderTemplateEditor.tsx
@@ -24,6 +24,13 @@ export interface PlaceholderTemplateFieldConfig<V extends Record<string, string>
 export interface PlaceholderTemplateEditorProps<V extends Record<string, string>> {
     /** Module heading (visible; also groups the editor for screen readers). */
     heading: string;
+    /**
+     * Decorative head icon, M3 anatomy icon → title. Optional and supplied by
+     * the variant: this frame is shared with the invite e-mail, so it must not
+     * decide that both carry the same symbol. Purely decorative — it is
+     * `aria-hidden`, the `<section aria-label>` stays the accessible name.
+     */
+    icon?: ReactNode;
     fields: PlaceholderTemplateFieldConfig<V>[];
     /** Tokens every field's picker offers. */
     tokens: PlaceholderTokenDef[];
@@ -59,6 +66,7 @@ export interface PlaceholderTemplateEditorProps<V extends Record<string, string>
  */
 export const PlaceholderTemplateEditor = <V extends Record<string, string>>({
     heading,
+    icon,
     fields,
     tokens,
     values,
@@ -73,6 +81,11 @@ export const PlaceholderTemplateEditor = <V extends Record<string, string>>({
 }: PlaceholderTemplateEditorProps<V>) => (
     <section aria-label={heading} className={styles.editor}>
         <header className={styles.header}>
+            {icon && (
+                <span aria-hidden className={styles.headIcon} data-head-icon>
+                    {icon}
+                </span>
+            )}
             <h3 className={styles.heading}>{heading}</h3>
             <TemplateSplitButton
                 activeTemplateId={activeTemplateId}

--- a/src/components/PlaceholderTemplate/index.ts
+++ b/src/components/PlaceholderTemplate/index.ts
@@ -22,5 +22,9 @@ export {
 } from './PlaceholderTemplateEditor';
 export { EmailKitPreview, type EmailKitPreviewProps } from './EmailKitPreview';
 export { InviteEmailTemplateEditor, type InviteEmailTemplateValues } from './InviteEmailTemplateEditor';
-export { LegalConsentTemplateEditor, type LegalConsentTemplateValues } from './LegalConsentTemplateEditor';
+export {
+    LegalConsentHeadIcon,
+    LegalConsentTemplateEditor,
+    type LegalConsentTemplateValues,
+} from './LegalConsentTemplateEditor';
 export { PlaceholderTemplateDialog, type PlaceholderTemplateDialogProps } from './PlaceholderTemplateDialog';

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1856,7 +1856,7 @@
     "placeholderTemplate.dialog.inviteTitle": "Einladungs-E-Mail",
     "placeholderTemplate.dialog.inviteDescription": "Vorlage wählen, Platzhalter einfügen und die E-Mail live in der Vorschau prüfen.",
     "placeholderTemplate.dialog.legalTitle": "Einwilligungstext",
-    "placeholderTemplate.dialog.legalDescription": "Vorlage wählen und den Einwilligungssatz mit Platzhaltern anpassen.",
+    "placeholderTemplate.dialog.legalDescription": "Hier legen Sie den Satz fest, den der Ratsuchende bei der Registrierung mit einem Häkchen bestätigt. Er gehört zur Datenschutzerklärung — mit dem Veröffentlichen entsteht eine neue Fassung, auch wenn der übrige Text gleich bleibt.",
     "placeholderTemplate.preview.failed": "Die Vorschau konnte nicht erzeugt werden.",
     "placeholderTemplate.preview.retry": "Erneut versuchen",
     "placeholderTemplate.token.inviteLink": "Einladungslink",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1856,7 +1856,7 @@
     "placeholderTemplate.dialog.inviteTitle": "Invitation e-mail",
     "placeholderTemplate.dialog.inviteDescription": "Pick a template, insert placeholders and check the e-mail live in the preview.",
     "placeholderTemplate.dialog.legalTitle": "Consent text",
-    "placeholderTemplate.dialog.legalDescription": "Pick a template and adjust the consent sentence with placeholders.",
+    "placeholderTemplate.dialog.legalDescription": "Here you set the sentence the help seeker confirms with a checkbox when registering. It belongs to the data protection policy — publishing it creates a new version, even when the rest of the text stays the same.",
     "placeholderTemplate.preview.failed": "Preview could not be rendered.",
     "placeholderTemplate.preview.retry": "Retry",
     "placeholderTemplate.token.inviteLink": "Invitation link",


### PR DESCRIPTION
## Problem

The consent-text dialog opened with a bare title and a sub-line that named the **controls** ("Pick a template and adjust the consent sentence with placeholders") rather than the **subject**. An admin who has never published a policy could not tell from it that ticking this sentence is what the help seeker agrees to, nor that editing it produces a new policy version.

## Root cause

The dialog head was inherited from a frame shared with the invitation e-mail, which has no domain symbol and a control-oriented description. Nothing in the consent variant overrode it.

## Fix

- **`PlaceholderTemplateEditor`** takes an optional decorative `icon` and renders it before the heading. The prop is **optional on purpose**: the frame is shared with the invitation e-mail, so the symbol is the variant's call, not the frame's. It is `aria-hidden` — the `<section aria-label>` stays the accessible name.
- **`PlaceholderTemplateDialog`** forwards an `icon` to the `Modal`, which already centres a 32px hero icon above the title (M3 basic-dialog anatomy). Inside a dialog the editor's own head icon is hidden, the same way its `<h3>` is, so the head is not stamped twice.
- **`LegalConsentTemplateEditor`** supplies **`FactCheckOutlined`** — a document with a tick, i.e. the policy the sentence belongs to plus the checkbox that confirms it. Exported as `LegalConsentHeadIcon` so the full-page head and the dialog hero icon cannot drift apart.
- `placeholderTemplate.dialog.legalDescription` rewritten in **DE and EN** to name the subject and the consequence, matching the tone of the field-level `legal.consent.description`.

Colour and size come from `--m3-secondary` and the existing hero-icon sizing rule; **no hardcoded colours**.

## Tests

- `PlaceholderTemplateDialog.test.tsx` and `PlaceholderTemplateEditor.test.tsx` extended (icon rendered, `aria-hidden`, not stamped twice).
- **axe** (wcag2a / 2aa / 21a / 21aa / 22aa) on **both** the in-dialog and the full-page consent story: **0 violations**, run live against the real story.

## Reviewer test plan

- [ ] Storybook → `PlaceholderTemplateDialog` consent story: a `FactCheckOutlined` icon is centred above the title in `--m3-secondary`.
- [ ] Read the DE description — it should say what the sentence *is* and that editing it makes a new version, not which controls exist. Same in EN.
- [ ] Open the **full-page** consent editor: the same icon appears before the heading, and the head is **not** stamped twice when the editor is inside the dialog.
- [ ] Confirm the **invitation e-mail** variant of the same frame still has **no** icon (the prop is optional by design).
- [ ] Screen reader / a11y tree: the icon is `aria-hidden`; the accessible name still comes from the `<section aria-label>`.
- [ ] **Mobile 390x844**: the hero icon and the longer description do not overflow or crowd the title.
