### PR TITLE
fix(a11y): take the grey scroll track off the reader and signup surfaces

### DIFF
--- a/src/components/DpaBlocker/styles.module.scss
+++ b/src/components/DpaBlocker/styles.module.scss
@@ -1,4 +1,5 @@
 @use '../../styles/breakpoints' as bp;
+@use '../../styles/scrollbars' as scrollbars;
 
 /* Global DPA blocker (TEN-INV-U10, #572).
  *
@@ -30,6 +31,12 @@
     background: var(--m3-surface-container-low, #f6f3f3);
     inset: 0;
     overflow-y: auto;
+
+    /* JOB10: the blocker covers the whole viewport, so its classic scrollbar
+       read as the window's own — a full-height grey track beside the contract
+       the admin is being asked to sign. */
+
+    @include scrollbars.quiet;
 }
 
 .card {
@@ -76,7 +83,12 @@
         padding: 0 4px;
         margin: 0 -4px;
         overflow-y: auto;
+
+        /* Gutter stays so the sign form does not jump sideways as it grows;
+           JOB10 only takes the track away. */
         scrollbar-gutter: stable;
+
+        @include scrollbars.quiet;
     }
 }
 

--- a/src/components/DpaForwardDialog/styles.module.scss
+++ b/src/components/DpaForwardDialog/styles.module.scss
@@ -1,3 +1,5 @@
+@use '../../styles/scrollbars' as scrollbars;
+
 /* House rule (owner, 2026-08-18): a dialog never touches the top or bottom edge
    of the viewport. The sheet is therefore bounded and its BODY is the scroller,
    so the hero icon, the title and the action row stay put while only the content
@@ -22,6 +24,8 @@
             /* A long preview must not chain its scroll to the page behind the mask. */
             overscroll-behavior: contain;
             scrollbar-gutter: stable;
+
+            @include scrollbars.quiet;
         }
     }
 }

--- a/src/components/FormPluginEditor/M3RichTextEditor.module.scss
+++ b/src/components/FormPluginEditor/M3RichTextEditor.module.scss
@@ -2,6 +2,8 @@
 // node 1:34903). Mirrors the M3 sys tokens; brand primary #273270, M3 seed
 // primary #a5000a (publish accent).
 
+@use '../../styles/scrollbars' as scrollbars;
+
 $m3-surface: #eae7e8;
 $m3-on-surface: #1b1b1c;
 $m3-on-surface-variant: #444748;
@@ -11,6 +13,22 @@ $m3-primary: #273270;
 $m3-publish: #a5000a;
 $m3-state-hover: rgb(68 71 72 / 8%);
 $m3-state-active: rgb(39 50 112 / 12%);
+
+/* The reading viewport of the legal reader — the box in the owner's JOB10
+   screenshot with a permanent grey scroll track down its right edge. It turns
+   into a scroller in three places (the 800x740 deck card at >=600px, the
+   fullscreen dialog, and the bounded fluid READ card), so the treatment is
+   declared once here for all of them; on the non-scrolling variants these two
+   declarations are inert.
+
+   Trackless-thin rather than hidden: a DPA runs to several screens and the
+   thumb is the only thing telling the reader that the contract continues
+   below the fold. The chapter bar underneath navigates BETWEEN chapters, it
+   does not signal WITHIN one. See src/styles/_scrollbars.scss. */
+
+.editorContentScroll {
+    @include scrollbars.quiet;
+}
 
 .module {
     display: flex;

--- a/src/pages/TenantOnboarding/styles.module.scss
+++ b/src/pages/TenantOnboarding/styles.module.scss
@@ -1,4 +1,5 @@
 @use '../../styles/breakpoints' as bp;
+@use '../../styles/scrollbars' as scrollbars;
 
 /* Public tenant-admin onboarding (#571).
  *
@@ -64,7 +65,17 @@
         padding: 0 4px;
         margin: 0 -4px;
         overflow-y: auto;
+
+        /* JOB10: this is the "main signup module" whose scrollbars the owner
+           called "even more visible" — `scrollbar-gutter: stable` reserves the
+           channel permanently, so a full-width classic scrollbar sat next to
+           the wizard on every step whether it was scrolling or not. The gutter
+           stays (it is what stops the step content jumping sideways when a
+           step grows past the fold); a thin, trackless thumb is what makes it
+           unobtrusive. */
         scrollbar-gutter: stable;
+
+        @include scrollbars.quiet;
     }
 }
 

--- a/src/styles/_scrollbars.scss
+++ b/src/styles/_scrollbars.scss
@@ -1,0 +1,55 @@
+// Shared scrollbar treatment for the CSS modules.
+//
+// Silent `//` comments on purpose: this partial is `@use`d by four modules,
+// and Sass copies a loud `/* */` block into the compiled output of every one
+// of them.
+//
+// Owner report (JOB10, 2026-08-19): "Remove the scrollbars in firefox, edge,
+// safari browsers, or that you only see them when scrolling. Also in the main
+// signup module they are even more visible." The screenshot shows a permanent
+// grey scroll TRACK down the right edge of the contract document box.
+//
+// The defect is the track, not the thumb. Firefox and Chromium/Edge on Windows
+// paint a classic scrollbar: an always-on grey channel plus a thumb, both
+// occupying layout width. macOS paints overlay scrollbars that already fade
+// out when idle, which is why this only ever looked broken on the browsers the
+// owner named.
+//
+// `quiet` therefore takes the track away and keeps the thumb: the surface
+// reads as "only visible while scrolling" on macOS (native overlay behaviour
+// is left untouched) and as a thin, trackless thumb everywhere else.
+//
+// Why NOT the full-hide pattern that this repo already uses in ~10 places:
+// every one of those is a HORIZONTAL control row — the chapter chips
+// (FormPluginEditor.styles.scss), the editor toolbar, the function bar,
+// CardDeck, the segmented tabs. Each carries its own affordance (a 32px edge
+// fade, prev/next arrows, an active chip). The surfaces this mixin is for are
+// VERTICAL readers and form scrollers — the contract box the owner
+// screenshotted, the onboarding sheet body, the public page itself. Hiding the
+// scrollbar there would delete the only signal that more text exists below, on
+// a page whose whole purpose is reading a contract before signing it. That is
+// a WCAG 2.2 regression, so the thumb stays.
+//
+// Standard properties only, deliberately. The webkit pseudo-element is not
+// paired with them because Chromium ignores it as soon as `scrollbar-width` is
+// set — the finding is already written down in
+// GlobalSearch/globalSearchBar.module.scss. Safari below 18.2 supports neither
+// property and keeps its native overlay scrollbar, which is the behaviour this
+// mixin is imitating anyway.
+//
+// Not a new idiom: the admin sidebar (protectedLayout.less `.upperSidebar`)
+// and the mobile editor toolbar (M3RichTextEditor.module.scss) have both
+// scrolled this way since they were built. This mixin names that treatment and
+// brings the public and reader surfaces in line with it.
+//
+// LESS-pipeline files (src/styles/components/*.less) cannot `@use` this
+// partial; publicLayout.less repeats the two declarations inline and points
+// here.
+
+@mixin quiet {
+    scrollbar-width: thin;
+
+    // Thumb tonal with the surface, track fully transparent — the same thumb
+    // colour GlobalSearch already uses for a styled scrollbar.
+    scrollbar-color: var(--m3-outline-variant, #c4c7c8) transparent;
+}

--- a/src/styles/components/publicLayout.less
+++ b/src/styles/components/publicLayout.less
@@ -21,6 +21,23 @@
     overflow-y: auto;
 
     /*
+     * JOB10. Because this element is the scroll container the app shell took
+     * away from the document, its scrollbar is what a visitor reads as "the
+     * browser scrollbar" on every public page — and below 1200px it is the
+     * ONLY scroller on the signup wizard, full viewport height. On Firefox and
+     * Edge that is a permanent grey track running the whole side of the
+     * screen; that is the "even more visible" half of the owner's report.
+     *
+     * Trackless-thin, not hidden: this scrolls the page, and a page whose
+     * scrollbar is gone gives no clue how much of a long form is left.
+     * Mirrors the `quiet` mixin in src/styles/_scrollbars.scss — repeated
+     * literally because LESS cannot @use an SCSS partial. Keep the two in
+     * step.
+     */
+    scrollbar-width: thin;
+    scrollbar-color: var(--m3-outline-variant, #c4c7c8) transparent;
+
+    /*
      * antd gives the content `flex: auto; min-height: 0`. Inside a
      * viewport-bounded layout that lets a tall page shrink back to the
      * viewport and spill its content over the footer instead of scrolling —

--- a/src/styles/quietScrollbar.styles.test.ts
+++ b/src/styles/quietScrollbar.styles.test.ts
@@ -1,0 +1,142 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/*
+ * JOB10 (owner report, 2026-08-19): "Remove the scrollbars in firefox, edge,
+ * safari browsers, or that you only see them when scrolling. Also in the main
+ * signup module they are even more visible."
+ *
+ * The screenshot shows a permanent grey scroll TRACK down the right edge of
+ * the contract document box. macOS paints overlay scrollbars that already fade
+ * when idle; Firefox and Edge paint a classic always-on track, which is why
+ * only those browsers were named.
+ *
+ * The chosen treatment is trackless-thin ("quiet"), NOT hidden — see
+ * src/styles/_scrollbars.scss for the full reasoning. The short version: every
+ * surface below is a VERTICAL reader or form scroller, and the thumb is the
+ * only thing that tells a reader a contract continues past the fold. Deleting
+ * it would trade a cosmetic complaint for a WCAG 2.2 regression. The full-hide
+ * pattern stays where it already lives: horizontal control rows that carry
+ * their own edge-fade and arrow affordances.
+ *
+ * These assertions read the stylesheets as text (the convention established by
+ * legalReader.styles.test.ts). If one goes red, either a scroll surface lost
+ * its treatment or someone swapped it for the full-hide pattern. Do not
+ * "fix" a failure by deleting the assertion — read _scrollbars.scss first.
+ */
+
+const read = (relativePath: string) => readFileSync(resolve(__dirname, '..', relativePath), 'utf8');
+
+const scrollbarsPartial = readFileSync(resolve(__dirname, './_scrollbars.scss'), 'utf8');
+
+// The prose above the mixin names both `scrollbar-width: none` and the webkit
+// pseudo-element while explaining why they are NOT used here, so the negative
+// assertions below have to read the mixin BODY rather than the whole file.
+const quietMixinBody = scrollbarsPartial.match(/@mixin quiet\s*{[\s\S]*?\n}/)?.[0] ?? '';
+
+describe('quiet scrollbar mixin', () => {
+    it('thins the scrollbar and makes the track transparent', () => {
+        // Two declarations, both standard properties. `transparent` as the
+        // second `scrollbar-color` value IS the fix: it removes the grey
+        // channel while leaving the thumb to do its job.
+        expect(quietMixinBody).toMatch(/scrollbar-width:\s*thin;/);
+        expect(quietMixinBody).toMatch(/scrollbar-color:\s*var\(--m3-outline-variant, #c4c7c8\) transparent;/);
+    });
+
+    it('never pairs the standard properties with the webkit pseudo-element', () => {
+        // Chromium drops that styling the moment `scrollbar-width` is set
+        // (documented in globalSearchBar.module.scss). A webkit block here
+        // would be dead code that reads as a live fallback.
+        expect(quietMixinBody).not.toMatch(/-webkit-scrollbar/);
+    });
+
+    it('does not hide the scrollbar outright', () => {
+        // `scrollbar-width: none` here would silently strip the affordance
+        // from every surface that includes the mixin.
+        expect(quietMixinBody).not.toMatch(/scrollbar-width:\s*none/);
+    });
+
+    it('stays silent in the compiled bundle', () => {
+        // Four modules `@use` this partial, and Sass copies a loud comment
+        // block into the compiled output of every one of them. Matches a
+        // comment OPENING a line, so the partial's own prose can still quote
+        // the syntax it is warning about.
+        expect(scrollbarsPartial).not.toMatch(/^\s*\/\*/m);
+    });
+});
+
+describe('the legal/contract reader — surface 1 of the owner report', () => {
+    const editorStyles = read('components/FormPluginEditor/M3RichTextEditor.module.scss');
+
+    it('treats the reading viewport once, for all three scrolling variants', () => {
+        // `.editorContentScroll` becomes a scroller in three separate blocks
+        // (the 800x740 deck card >=600px, the fullscreen dialog, and the
+        // bounded fluid READ card). A single top-level rule covers all of
+        // them; on the non-scrolling fluid WRITE variant it is inert.
+        expect(editorStyles).toMatch(/\n\.editorContentScroll\s*{\s*@include scrollbars\.quiet;\s*\n}/);
+    });
+
+    it('keeps the reading viewport scrollable rather than hiding its scrollbar', () => {
+        // A DPA runs to several screens. The chapter bar under the box
+        // navigates BETWEEN chapters; it says nothing about how much of the
+        // current chapter is left, so the thumb has to stay.
+        expect(editorStyles).not.toMatch(/\.editorContentScroll\s*{[^}]*scrollbar-width:\s*none/);
+    });
+});
+
+describe('the signup surfaces — surface 2 of the owner report ("even more visible")', () => {
+    it('quiets the public page shell, the scroller the app gave back to the page', () => {
+        // publicLayout.less is in the LESS pipeline and cannot @use the SCSS
+        // partial, so it repeats the two declarations literally. This test is
+        // what keeps that copy honest.
+        const publicLayout = read('styles/components/publicLayout.less');
+        expect(publicLayout).toMatch(/\.publicLayout\s*{[\s\S]*scrollbar-width:\s*thin;/);
+        expect(publicLayout).toMatch(
+            /\.publicLayout\s*{[\s\S]*scrollbar-color:\s*var\(--m3-outline-variant, #c4c7c8\) transparent;/,
+        );
+    });
+
+    it('quiets the onboarding sheet body without giving up its stable gutter', () => {
+        // The gutter is what stops the step content shifting sideways when a
+        // step grows past the fold — it is a layout fix, not the defect. Only
+        // the track had to go.
+        const onboarding = read('pages/TenantOnboarding/styles.module.scss');
+        expect(onboarding).toMatch(/\.sheetBody\s*{[\s\S]*scrollbar-gutter:\s*stable;/);
+        expect(onboarding).toMatch(/\.sheetBody\s*{[\s\S]*@include scrollbars\.quiet;/);
+    });
+
+    it('quiets the DPA forward dialog body', () => {
+        const forwardDialog = read('components/DpaForwardDialog/styles.module.scss');
+        expect(forwardDialog).toMatch(/\.ant-modal-body\s*{[\s\S]*@include scrollbars\.quiet;/);
+    });
+});
+
+describe('the DPA blocker — the reader surface inside the admin', () => {
+    const blockerStyles = read('components/DpaBlocker/styles.module.scss');
+
+    it('quiets the full-viewport overlay, which reads as the window scrollbar', () => {
+        expect(blockerStyles).toMatch(/\.overlay\s*{[\s\S]*@include scrollbars\.quiet;/);
+    });
+
+    it('quiets the card body that scrolls the sign form', () => {
+        expect(blockerStyles).toMatch(/\.cardBody\s*{[\s\S]*@include scrollbars\.quiet;/);
+    });
+});
+
+describe('the horizontal control rows keep the full-hide pattern', () => {
+    /*
+     * Guard against an over-eager future sweep that "unifies" every scrollbar
+     * onto the quiet mixin. These rows are hidden on purpose and each already
+     * carries a REPLACEMENT affordance — the chapter row has a 32px edge fade
+     * plus prev/next arrows (pinned by legalReader.styles.test.ts). Giving
+     * them a visible thumb back would put a scrollbar under the chips the fade
+     * exists to dissolve.
+     */
+    it('keeps the chapter-chip row hidden behind its edge fade', () => {
+        const editorGlobals = read('components/FormPluginEditor/FormPluginEditor.styles.scss');
+        const row = editorGlobals.match(/&-anchorNavRow\s*{[\s\S]*?\n {4}}/)?.[0] ?? '';
+        expect(row).toMatch(/scrollbar-width:\s*none;/);
+        expect(row).toMatch(/&::-webkit-scrollbar\s*{[\s\S]*display:\s*none;/);
+    });
+});


### PR DESCRIPTION
## Problem

The contract document box, the signup wizard and the public page shell all showed a **permanent grey scroll channel** down their right edge on **Firefox and Edge**. macOS paints overlay scrollbars that fade when idle, which is why the report named those two browsers specifically — and why the **signup module**, whose page shell is a full-viewport scroller, looked worst.

## Root cause

The **track**, not the thumb, was the defect: these surfaces had no `scrollbar-width`/track treatment, so browsers that paint classic (non-overlay) scrollbars drew a full-height grey channel whether or not the user was scrolling.

## Fix

- Add a **`quiet` mixin** (`src/styles/_scrollbars.scss`): `scrollbar-width: thin` plus a **transparent track**. It is the idiom the admin sidebar and the mobile editor toolbar already use — now **named and shared** rather than copy-pasted.
- Apply it to the legal reader's viewport (one rule covering the deck card, the fullscreen dialog and the bounded fluid read card), the onboarding sheet body, the DPA blocker overlay and card body, and the forward dialog body.
- `publicLayout.less` repeats the declarations **inline** — LESS cannot use an SCSS partial.

### Two judgement calls carried over from the commit

1. **The thumb is kept, deliberately.** This is **not** the repo's full-hide pattern. These are **vertical readers**: the thumb is the only signal that a contract continues past the fold, and the chapter bar below navigates *between* chapters, not *within* one. The full-hide pattern stays on the **horizontal** control rows, which carry their own edge-fade and arrow affordances.
2. **`scrollbar-gutter: stable` is kept where it was.** It prevents a sideways jump as a step grows, and only the track was ever the defect.

No webkit pseudo-element: **Chromium ignores it once `scrollbar-width` is set**, as already documented in `globalSearchBar.module.scss`.

## Tests

Node 22.12.0:

- vitest on the new `quietScrollbar.styles.test.ts` plus the existing `legalReader` / `DepartmentDataProtectionCard` style tests: **23 passed**
- `DpaBlocker`, `DpaForwardDialog` and `TenantOnboarding` suites: **122 passed**
- reader-related `FormPluginEditor` suites: **44 passed**
- `prettier` and `eslint` clean

## Reviewer test plan

- [ ] **In Firefox or Edge** (this is the point — macOS Chrome/Safari overlay scrollbars hide the defect): open the contract document box. The grey channel is gone; a thin thumb remains.
- [ ] Same in the **signup wizard** — this surface looked worst before.
- [ ] Same on the **public page shell**, the **DPA blocker** and the **forward dialog** body.
- [ ] Confirm the **thumb is still visible** on the legal reader. It must not be fully hidden — it is the only cue the contract continues.
- [ ] Grow a signup step (e.g. trigger a validation error) and confirm there is still **no sideways jump** — `scrollbar-gutter: stable` was kept for this.
- [ ] Check the **horizontal** control rows still use the full-hide pattern; this PR must not have changed them.
- [ ] **Mobile 390x844**: reader and signup scroll normally, no stray track.
