### PR TITLE
feat(dpa-forward): frame the forwarded mail as itself and pin its footer in Storybook

### DIFF
--- a/src/components/DpaForwardDialog/DpaForwardDialog.stories.tsx
+++ b/src/components/DpaForwardDialog/DpaForwardDialog.stories.tsx
@@ -2,8 +2,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 // eslint-disable-next-line import/no-unresolved -- SB10 subpath export, invisible to the eslint import resolver
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { ThemeProvider } from '@mui/material/styles';
+import { http, HttpResponse } from 'msw';
 import { orisoMuiTheme } from '../../theme/orisoMuiTheme';
 import { PHONE_390 } from '../DpaLegalForm/dpaStoryText';
+import {
+    INVITE_EMAIL_PREVIEW_ENDPOINT,
+    renderBrandedEmailStoryPreview,
+} from '../EmailPreview/brandedEmailStoryPreview';
 import { DpaForwardDialog } from './DpaForwardDialog';
 import { DpaForwardError, DpaForwardLink, DpaForwardOutcome } from '../../api/tenantOnboarding/dpaForward';
 
@@ -18,6 +23,17 @@ const wait = (ms: number) =>
     });
 
 /**
+ * The backend's mail renderer, offline: it echoes the subject and body the dialog
+ * composed back inside the checked-in house frame. Without it the preview request
+ * falls through MSW's `bypass` to the Storybook origin and every story here shows
+ * the preview's error state instead of a mail.
+ */
+const mailPreview = http.post(INVITE_EMAIL_PREVIEW_ENDPOINT, async ({ request }) => {
+    const { body = '', subject = '' } = (await request.json()) as { body?: string; subject?: string };
+    return HttpResponse.json(renderBrandedEmailStoryPreview(subject, body));
+});
+
+/**
  * Shared forward-to-authorised-signer dialog (#723, epic #722): copyable
  * single-use sign link, optional e-mail send with the actual DPA_FORWARD mail
  * rendered through the e-mail kit preview, and the note that the link stays
@@ -28,7 +44,15 @@ const wait = (ms: number) =>
 const meta = {
     title: 'Organisms/DpaForwardDialog',
     component: DpaForwardDialog,
-    parameters: { layout: 'fullscreen' },
+    parameters: {
+        layout: 'fullscreen',
+        msw: { handlers: [mailPreview] },
+        // axe stops at the frame: it holds the backend's mail document (table
+        // layout, inline styles), not app UI. Same rule and reason as
+        // `Organisms/EmailPreview/BrandedEmailPreview`; the dialog's own
+        // chrome around it is still audited.
+        a11y: { options: { iframes: false } },
+    },
     decorators: [
         (Story) => (
             <ThemeProvider theme={orisoMuiTheme}>
@@ -59,6 +83,42 @@ type Story = StoryObj<typeof meta>;
  * shown to a person.
  */
 export const Default: Story = {};
+
+/**
+ * **The forwarded mail as it is framed and sent** (JOB11, owner note 2026-08-19:
+ * „Add Footer to the forwarded email as well").
+ *
+ * The variant this modal is linked to: the same dialog, with the mail preview
+ * showing the finished document rather than the two paragraphs the dialog
+ * composes. The frame around them — brand header, call-to-action, and the
+ * FOOTER with the brand name, `Impressum · Datenschutz` and the automated-send
+ * note — is the house layout every transactional mail carries
+ * (ORISO-UserService `email/layout/branded-email.html`), applied by the backend
+ * renderer that the send path itself runs. The forward mail was not opting out
+ * of it; it simply never told the renderer which mail it was, so the sample
+ * call-to-action pointed at the admin console instead of the app host.
+ *
+ * The document here is a checked-in verbatim backend response with this mail's
+ * subject and body substituted into it, so the footer on screen is the real one
+ * and not a drawing of it.
+ */
+export const ForwardedMailWithFooter: Story = {
+    play: async ({ canvasElement }) => {
+        const body = within(canvasElement.ownerDocument.body);
+        await userEvent.type(await body.findByLabelText(/Name der Person|Name of the person/), 'Dr. Ruth Recht');
+
+        const frame = (await body.findByTitle(/Vorschau der E-Mail|Preview of the e-mail/)) as HTMLIFrameElement;
+        await waitFor(() => {
+            const mail = frame.contentDocument?.body?.innerText ?? '';
+            // The composed content …
+            expect(mail).toContain('Dr. Ruth Recht');
+            // … inside the house frame, footer and all.
+            expect(mail).toContain('Impressum');
+            expect(mail).toContain('Datenschutz');
+            expect(mail).toContain('Diese E-Mail wurde automatisch versendet');
+        });
+    },
+};
 
 /** The whole dialog at 390×844 — link, fields and preview stay usable. */
 export const Mobile: Story = {

--- a/src/components/DpaForwardDialog/DpaForwardDialog.test.tsx
+++ b/src/components/DpaForwardDialog/DpaForwardDialog.test.tsx
@@ -13,6 +13,17 @@ vi.mock('react-i18next', () => ({
     }),
 }));
 
+/**
+ * The mail preview renders through the BACKEND's renderer. jsdom has no server,
+ * so the call is stubbed here — which also makes the request itself assertable.
+ */
+const renderPreview = vi.hoisted(() => vi.fn().mockResolvedValue({ html: '<p>mail</p>', subject: 'Betreff' }));
+
+vi.mock('../../api/accountInvites/accountInvites', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../../api/accountInvites/accountInvites')>()),
+    previewInviteEmailTemplateContent: renderPreview,
+}));
+
 const LINK: DpaForwardLink = {
     signUrl: 'https://app.example.org/dpa-sign/token-1',
     expiresAt: '2026-08-29T14:31:07',
@@ -173,6 +184,26 @@ describe('DpaForwardDialog', () => {
 
         expect(onClose).toHaveBeenCalledTimes(1);
         expect(onForwarded).not.toHaveBeenCalled();
+    });
+
+    /**
+     * JOB11. The mail frame — header, call-to-action and the house FOOTER (brand
+     * name, Impressum · Datenschutz, "Diese E-Mail wurde automatisch versendet …")
+     * — is applied by the backend renderer, the same one the send path runs; this
+     * dialog only composes the salutation and the body that go inside it. What the
+     * dialog owes the renderer is the identity of the mail, and it was not sending
+     * it: with no `kind`, `InviteEmailPreviewService` falls back to TENANT_INVITE
+     * and renders the sample call-to-action against the ADMIN console, while a DPA
+     * signer belongs on the app host. Nothing else in the render branches on kind,
+     * so this is the whole of the fix — and the reason the preview may not be
+     * hand-framed in Admin instead.
+     */
+    it('tells the backend renderer which mail this is, so the forward mail is framed as itself', async () => {
+        renderDialog();
+        await screen.findByLabelText('dpaForward.dialog.linkLabel');
+
+        await waitFor(() => expect(renderPreview).toHaveBeenCalled());
+        expect(renderPreview.mock.calls[0][0]).toMatchObject({ kind: 'DPA_FORWARD' });
     });
 });
 

--- a/src/components/DpaForwardDialog/DpaForwardDialog.tsx
+++ b/src/components/DpaForwardDialog/DpaForwardDialog.tsx
@@ -219,7 +219,18 @@ export const DpaForwardDialog = ({
                     </Form>
 
                     <div className={styles.preview}>
+                        {/* The kind is what makes this the FORWARD mail rather than a
+                            generic invite. Without it the backend renderer defaults to
+                            TENANT_INVITE (`InviteEmailPreviewService`: a null kind falls
+                            back to TENANT_INVITE), so the sample call-to-action pointed
+                            at the admin console — `admin.oriso.org/admin/tenant-onboarding/…`
+                            — while a DPA signer is sent to the app host instead. The
+                            house frame around the mail, and with it the footer (brand
+                            name, Impressum · Datenschutz, automated-send note), is
+                            applied by the backend for every kind; it is not something
+                            this dialog composes. */}
                         <EmailKitPreview
+                            kind="DPA_FORWARD"
                             subject={preview.subject}
                             body={preview.body}
                             previewLabel={t('dpaForward.dialog.previewLabel')}

--- a/src/components/DpaLegalForm/DpaLegalReader.stories.tsx
+++ b/src/components/DpaLegalForm/DpaLegalReader.stories.tsx
@@ -11,14 +11,17 @@ import { LONG_DPA_CHAPTER_COUNT, LONG_DPA_HTML, PHONE_390, PLAIN_DPA_HTML } from
  * step and the DPA blocker). It has NO navigation of its own: the canonical
  * read-only rich-text card provides the "Chapter Navbar" chip row
  * (`AnchorChips`, Figma 1299-81676), the fullscreen reading mode and the
- * in-text cross references. Picking a chapter scrolls the host surface to that
- * heading and moves keyboard focus to it.
+ * in-text cross references. Picking a chapter scrolls the reader's own viewport
+ * to that heading and moves keyboard focus to it.
  *
- * The card brings NO scroll container of its own (#594.3): its host scrolls —
- * the viewport-bounded sheet on the desktop, the page on a phone — so the
- * screen never stacks two scrollbars (#572) and a step containing a 60-page
- * agreement can still be bounded and centred. The chapter chips stay usable by
- * sticking to the bottom of whichever scrollport is active.
+ * Scrolling (owner demo 2026-08-19, REVERSING #594.3's "the card brings no
+ * scroll container of its own"): the agreement scrolls inside its own bounded
+ * viewport and the chapter bar stands still BELOW that box. With the host as
+ * the only scroller the bar was sticky against the page, so it travelled with
+ * it and a chip click re-scrolled it out from under the cursor — two clicks to
+ * pick one chapter. The contract for this layout is
+ * `FormPluginEditor/legalReader.styles.test.ts`; this comment must not drift
+ * from it again.
  */
 const meta = {
     title: 'Molecules/DpaLegalReader',

--- a/src/components/EmailPreview/brandedEmailStoryPreview.test.ts
+++ b/src/components/EmailPreview/brandedEmailStoryPreview.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { renderBrandedEmailStoryPreview } from './brandedEmailStoryPreview';
+
+const SUBJECT = 'Auftragsverarbeitungsvertrag: Ihre Unterschrift wird benötigt';
+const BODY =
+    'Guten Tag Dr. Ruth Recht,\n\nfür Ihre Organisation soll die Plattform eingerichtet werden.\n' +
+    'Bitte prüfen und unterzeichnen Sie den Vertrag:\n\nhttps://app.example.org/dpa-sign/token-1\n\n' +
+    'Der Link bleibt gültig, bis der Vertrag unterzeichnet ist.';
+
+/*
+ * JOB11 — "Add Footer to the forwarded email as well".
+ *
+ * The forwarded mail must carry the SAME footer the other transactional mails
+ * carry, and that footer is owned by ORISO-UserService, not by this repo. These
+ * assertions pin that the Storybook stand-in keeps showing the real one: it
+ * substitutes only the per-mail cells into a verbatim backend response, so a
+ * regression that starts inventing markup (or drops the footer) fails here
+ * rather than being noticed on a screenshot.
+ */
+describe('branded e-mail story preview — the house footer survives verbatim', () => {
+    const { html } = renderBrandedEmailStoryPreview(SUBJECT, BODY);
+
+    it('keeps the brand name, the legal pointers and the automated-send note', () => {
+        expect(html).toContain('>ORISO</strong>');
+        expect(html).toContain('>Impressum</a>');
+        expect(html).toContain('>Datenschutz</a>');
+        expect(html).toContain('Diese E-Mail wurde automatisch versendet. Bitte antworten Sie nicht darauf.');
+    });
+
+    it('keeps the footer bar itself — surface, top rule and rounded bottom corners', () => {
+        expect(html).toMatch(/bgcolor="#f0edee"[^>]*border-top:1px solid #c4c7c8;/);
+    });
+
+    /**
+     * The sample call-to-action of a DPA_FORWARD render points at the APP host,
+     * not the admin console: `targetRoleFor` sends every kind except
+     * TENANT_INVITE down the counsellor/app branch. A frame whose CTA suddenly
+     * reads `admin.oriso.org` is the wrong fixture.
+     */
+    it('keeps the app-host call-to-action shape a DPA_FORWARD preview renders with', () => {
+        expect(html).toContain('https://app.oriso.org/account-invite/SAMPLE-PREVIEW-TOKEN');
+        expect(html).not.toContain('admin.oriso.org');
+    });
+});
+
+describe('branded e-mail story preview — per-mail cells', () => {
+    const { html, subject, kind } = renderBrandedEmailStoryPreview(SUBJECT, BODY);
+
+    it('puts this mail’s subject and content into the frame', () => {
+        expect(subject).toBe(SUBJECT);
+        expect(kind).toBe('DPA_FORWARD');
+        expect(html).toContain(`font-weight:bold;">${SUBJECT}</td>`);
+        expect(html).toContain('<p>Guten Tag Dr. Ruth Recht,</p>');
+        // A single newline stays a line break inside one paragraph.
+        expect(html).toContain('eingerichtet werden.<br>Bitte prüfen');
+    });
+
+    it('drops the fixture’s own sample content — no counsellor invite left behind', () => {
+        expect(html).not.toContain('Willkommen im Beratungsteam');
+        expect(html).not.toContain('Erika');
+    });
+
+    it('links the sign link the way the backend does', () => {
+        expect(html).toContain(
+            '<a href="https://app.example.org/dpa-sign/token-1" target="_blank" rel="noopener noreferrer"',
+        );
+    });
+
+    it('escapes mail content instead of letting it reach the document as markup', () => {
+        const { html: escaped } = renderBrandedEmailStoryPreview('<b>x</b>', 'a & b <script>alert(1)</script>');
+        expect(escaped).not.toContain('<script>');
+        expect(escaped).toContain('&lt;script&gt;');
+        expect(escaped).toContain('a &amp; b');
+    });
+});

--- a/src/components/EmailPreview/brandedEmailStoryPreview.ts
+++ b/src/components/EmailPreview/brandedEmailStoryPreview.ts
@@ -1,0 +1,91 @@
+import type { InviteEmailPreviewDTO } from '../../api/accountInvites/accountInvites';
+
+// Verbatim backend output (see scripts/email-fixtures/README.md). This particular
+// fixture is the one whose sample accept URL has the APP-host shape
+// (`https://app.oriso.org/account-invite/SAMPLE-PREVIEW-TOKEN`), which is exactly
+// the shape `DPA_FORWARD` renders with: `InviteEmailPreviewService.targetRoleFor`
+// maps TENANT_INVITE to the admin console and *everything else* — COUNSELLOR_INVITE
+// and DPA_FORWARD alike — to the app host.
+import brandedFrameDe from './fixtures/invite-long-content-de.html?raw';
+
+/**
+ * Offline stand-in for the backend's mail renderer, for Storybook only.
+ *
+ * Stories must not talk to `POST /service/useradmin/invite-email-templates/preview`:
+ * without a handler the request falls through MSW's `onUnhandledRequest: 'bypass'`,
+ * hits the Storybook origin, and `EmailKitPreview` renders its "preview could not be
+ * rendered" state — so every story that wants to *show* a mail shows an error box
+ * instead.
+ *
+ * The rule from `scripts/email-fixtures/README.md` still holds: the mail frame is
+ * owned by ORISO-UserService (`BrandedEmailLayoutRenderer` + `email/layout/*`) and is
+ * never authored in this repository. This helper therefore does not build a frame —
+ * it takes a checked-in verbatim response and substitutes only the three cells the
+ * backend itself substitutes per mail: preheader, subject and content. Header,
+ * call-to-action, link hint and **footer** come through untouched, which is what makes
+ * the footer in these stories the real house footer (brand name, Impressum ·
+ * Datenschutz, "Diese E-Mail wurde automatisch versendet …") rather than a drawing of
+ * one.
+ *
+ * It is not a second renderer and must not grow into one: if a story needs a frame
+ * this fixture cannot show, refresh the fixtures against a running UserService using
+ * the recipe in that README instead of extending the substitution here.
+ */
+
+/*
+ * Unique markers of the per-mail slots inside the checked-in document. The
+ * subject appears TWICE in the backend's own layout — `<title>{{SUBJECT}}</title>`
+ * in the head as well as the heading cell — so both are substituted; leaving the
+ * head behind would keep the fixture's sample subject in the document title.
+ */
+const DOCUMENT_TITLE = /(<title>)[\s\S]*?(<\/title>)/;
+const PREHEADER = /(mso-hide:all;">)[\s\S]*?(<\/div>)/;
+const SUBJECT_CELL = /(font-size:22px;line-height:30px;font-weight:bold;">)[\s\S]*?(<\/td>)/;
+const CONTENT_CELL = /(font-size:16px;line-height:24px;">)[\s\S]*?(<\/td>)/;
+
+const escapeHtml = (value: string): string =>
+    value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+/** Mirrors the backend's own link treatment in the content cell. */
+const linkify = (escaped: string): string =>
+    escaped.replace(
+        /https?:\/\/[^\s<]+/g,
+        (url) =>
+            `<a href="${url}" target="_blank" rel="noopener noreferrer" ` +
+            `style="color:#a5000a;text-decoration:underline;word-break:break-word;">${url}</a>`,
+    );
+
+/** Plain-text mail body -> the paragraph markup the backend puts in the content cell. */
+const bodyToHtml = (body: string): string =>
+    body
+        .split(/\n{2,}/)
+        .map((paragraph) => `<p>${linkify(escapeHtml(paragraph)).replace(/\n/g, '<br>')}</p>`)
+        .join('');
+
+/** First ~120 characters of the body, the way the backend fills the hidden preheader. */
+const preheader = (body: string): string => {
+    const flat = body.replace(/\s+/g, ' ').trim();
+    return escapeHtml(flat.length > 120 ? `${flat.slice(0, 120)} …` : flat);
+};
+
+/**
+ * The rendered document a story shows: the checked-in branded frame with this mail's
+ * preheader, subject and content in it.
+ */
+export const renderBrandedEmailStoryPreview = (subject: string, body: string): InviteEmailPreviewDTO => ({
+    templateId: null,
+    templateName: null,
+    kind: 'DPA_FORWARD',
+    language: 'de',
+    subject,
+    html: brandedFrameDe
+        .replace(DOCUMENT_TITLE, (_match, open: string, close: string) => `${open}${escapeHtml(subject)}${close}`)
+        .replace(PREHEADER, (_match, open: string, close: string) => `${open}${preheader(body)}${close}`)
+        .replace(SUBJECT_CELL, (_match, open: string, close: string) => `${open}${escapeHtml(subject)}${close}`)
+        .replace(CONTENT_CELL, (_match, open: string, close: string) => `${open}${bodyToHtml(body)}${close}`),
+    plainText: `${subject}\n\n${body}`,
+    sampleAcceptUrl: 'https://app.oriso.org/account-invite/SAMPLE-PREVIEW-TOKEN',
+});
+
+/** The endpoint a story has to intercept to use the renderer above. */
+export const INVITE_EMAIL_PREVIEW_ENDPOINT = '*/service/useradmin/invite-email-templates/preview';


### PR DESCRIPTION
## Problem

The forward dialog previewed its mail **without saying which mail it is**. With no `kind`, `InviteEmailPreviewService` falls back to `TENANT_INVITE`, so the sample call-to-action rendered against the **admin console** — while a DPA signer belongs on the **app host**.

## Root cause

The preview request simply omitted `kind`. The house frame — and with it the footer (brand name, Impressum / Datenschutz, automated-send note) — is applied by the **backend renderer** for every kind; it is not composed here, **and must not be**.

## Second, pre-existing bug found while doing this

The story file **declared no MSW handler** for the preview endpoint. Without one, the request bypassed to the Storybook origin and **every preview-bearing story silently rendered the error state** instead of a mail. That was not caused by this work — it was already true, and nothing failed loudly enough to notice.

## Fix

- Pass **`kind="DPA_FORWARD"`** to the mail preview, with a test on the request.
- Add **`ForwardedMailWithFooter`** as a variant story of the existing `Organisms/DpaForwardDialog`, asserting the footer in the rendered mail.
- Give the story file an **MSW handler** for the preview endpoint (fixes the bug above).
- Add **`brandedEmailStoryPreview`**: substitutes only the per-mail slots (title, preheader, subject, content) into a **checked-in verbatim backend response**, so the footer shown in Storybook is the **real** one rather than markup authored in this repo.
- Correct the `DpaLegalReader` story doc, which still described the sticky chapter bar **reversed** by the 2026-08-19 owner demo.

## Tests

Node 22.12.0:

- vitest **310 passed / 32 files** across `DpaForwardDialog`, `DpaLegalForm`, `DpaBlocker`, `EmailPreview`, `FormPluginEditor` and `TenantOnboarding`
- `eslint` and `prettier` clean on the changed files

## Reviewer test plan

- [ ] Storybook → `Organisms/DpaForwardDialog` → **`ForwardedMailWithFooter`**: the preview shows a real mail with the branded footer (brand name, Impressum / Datenschutz, automated-send note).
- [ ] Confirm the other preview-bearing stories in that file now render a **mail** and not the **error state** — this is the pre-existing MSW bug.
- [ ] Inspect the outgoing preview request: it carries `kind=DPA_FORWARD`.
- [ ] Confirm the sample call-to-action now points at the **app host**, not the admin console.
- [ ] Sanity-check that the footer markup comes from the **checked-in backend fixture** and is not hand-authored in this repo — that is the whole point of `brandedEmailStoryPreview`.
- [ ] Read the corrected `DpaLegalReader` story doc against the actual sticky chapter bar behaviour.
- [ ] **Mobile 390x844**: the mail preview scales and the footer does not overflow the dialog.
