### PR TITLE
fix(legal): stop "Save draft" from publishing the agency-wide legal text

### DIFF
--- a/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.consent.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.consent.test.tsx
@@ -30,6 +30,12 @@ vi.mock('../../../../../hooks/useTranslateLegalContent.hook', () => ({
 vi.mock('../../../../../hooks/useUserPermission', () => ({
     useUserPermissions: () => ({ can: () => true, permissions: {} }),
 }));
+vi.mock('../../../../../hooks/useUserData.hook', () => ({
+    // The container reads the opaque user id to scope its device-local draft; without
+    // this mock the real react-query hook runs and the render dies on "No QueryClient".
+    useUserData: () => ({ data: { id: 'user-7' }, isLoading: false }),
+    USER_DATA_KEY: 'user-data',
+}));
 vi.mock('../../../../../hooks/useLegalTextVersions.hook', () => ({
     useLegalTextVersions: () => ({ data: [], isError: false }),
 }));

--- a/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.draft.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.draft.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+    card: vi.fn(),
+    saveAgencyWide: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'de' } }),
+}));
+vi.mock('../../../../../hooks/useDepartmentDpp.hook', () => ({
+    useDepartmentDpp: () => ({ data: undefined, isLoading: false, isError: false, isSuccess: true }),
+}));
+vi.mock('../../../../../hooks/useDepartmentImprint.hook', () => ({
+    useDepartmentImprint: () => ({ data: undefined, isLoading: false, isError: false, isSuccess: true }),
+}));
+vi.mock('../../../../../hooks/usePublishDepartmentDpp.hook', () => ({
+    usePublishDepartmentDpp: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('../../../../../hooks/usePublishDepartmentImprint.hook', () => ({
+    usePublishDepartmentImprint: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('../../../../../hooks/useSingleTenantData', () => ({
+    useSingleTenantData: () => ({ data: undefined, isLoading: false }),
+}));
+vi.mock('../../../../../hooks/useTenantAdminData.hook', () => ({ useTenantAdminData: () => ({ data: undefined }) }));
+vi.mock('../../../../../hooks/useTranslateLegalContent.hook', () => ({
+    useTranslateLegalContent: () => ({ translate: vi.fn() }),
+}));
+vi.mock('../../../../../hooks/useUserPermission', () => ({
+    useUserPermissions: () => ({ can: () => true, permissions: {} }),
+}));
+vi.mock('../../../../../hooks/useLegalTextVersions.hook', () => ({
+    useLegalTextVersions: () => ({ data: [], isError: false }),
+}));
+vi.mock('../../../../../hooks/useUserData.hook', () => ({
+    useUserData: () => ({ data: { id: 'user-7' }, isLoading: false }),
+}));
+vi.mock('../DepartmentDataProtectionCard', () => ({
+    DepartmentDataProtectionCard: (props: any) => {
+        h.card(props);
+        return <div data-testid="legal-editor">{props.departmentSlot}</div>;
+    },
+}));
+
+import { AgencyLegalTextContainer } from '.';
+
+const agencyData: any = {
+    id: '55',
+    tenantId: '1',
+    topics: [{ id: 3, name: 'U25 Suizidprävention' }],
+    content: { privacy: { de: '<p>agency wide</p>' } },
+};
+
+const renderContainer = (props: Record<string, unknown> = {}) =>
+    render(
+        <AgencyLegalTextContainer
+            agencyData={agencyData}
+            field="privacy"
+            onSaveAgencyWide={h.saveAgencyWide}
+            {...(props as any)}
+        />,
+    );
+
+const cardProps = () => h.card.mock.calls.at(-1)?.[0];
+
+/*
+ * jsdom's Storage does NOT enumerate through `Object.keys` — it returns [] even when
+ * `length` is 1. Read it through the Storage API instead, or this helper silently
+ * reports "nothing was saved" for a draft that was saved perfectly well.
+ */
+const draftKeys = () =>
+    Array.from({ length: window.localStorage.length }, (_, index) => window.localStorage.key(index))
+        .filter((key): key is string => !!key)
+        .filter((key) => key.startsWith('oriso-admin.legal.draft.'));
+
+beforeEach(() => {
+    window.localStorage.clear();
+    h.card.mockClear();
+    h.saveAgencyWide.mockClear();
+});
+afterEach(() => window.localStorage.clear());
+
+/*
+ * "Alle Fachbereiche" used to hand `onSave(content, publish=false)` — the editor's
+ * "Save draft" action — straight to `onSaveAgencyWide`, which writes the agency
+ * record. The `publish` argument was dropped on the floor, so the button published
+ * the live legal text with no confirmation and a label promising the opposite.
+ *
+ * The fix follows the house answer to the identical problem one level up
+ * (`LegalText` + `useLegalDraft`): the agency record has no draft state, so the
+ * draft is device-local, and only Publish touches the record.
+ */
+describe('agency-wide draft — "Save draft" must not publish', () => {
+    it('does not write the agency record when the editor saves a draft', async () => {
+        renderContainer();
+        await waitFor(() => expect(screen.getByTestId('legal-editor')).toBeInTheDocument());
+
+        cardProps().onSave({ de: '<p>work in progress</p>' }, false);
+
+        expect(h.saveAgencyWide).not.toHaveBeenCalled();
+    });
+
+    it('parks the draft on the device instead', async () => {
+        renderContainer();
+        await waitFor(() => expect(screen.getByTestId('legal-editor')).toBeInTheDocument());
+
+        cardProps().onSave({ de: '<p>work in progress</p>' }, false, { de: 'consent {{legal_links}}' });
+
+        await waitFor(() => expect(draftKeys()).toHaveLength(1));
+        const stored = JSON.parse(window.localStorage.getItem(draftKeys()[0]) as string);
+        expect(stored.content).toEqual({ de: '<p>work in progress</p>' });
+        expect(stored.consent).toEqual({ de: 'consent {{legal_links}}' });
+    });
+
+    it('scopes the draft to the agency so it cannot collide with the tenant-level draft', async () => {
+        // Both are `privacy` for the same user; only the agency id separates them.
+        // Without it, editing a Beratungsstelle would silently overwrite the
+        // Träger's parked wording, or vice versa.
+        renderContainer();
+        await waitFor(() => expect(screen.getByTestId('legal-editor')).toBeInTheDocument());
+
+        cardProps().onSave({ de: '<p>x</p>' }, false);
+
+        await waitFor(() => expect(draftKeys()).toHaveLength(1));
+        expect(draftKeys()[0]).toContain('55');
+        expect(draftKeys()[0]).not.toBe('oriso-admin.legal.draft.privacy.1:user-7');
+    });
+
+    it('still writes the agency record when the editor publishes', async () => {
+        renderContainer();
+        await waitFor(() => expect(screen.getByTestId('legal-editor')).toBeInTheDocument());
+
+        cardProps().onSave({ de: '<p>final</p>' }, true);
+
+        expect(h.saveAgencyWide).toHaveBeenCalledTimes(1);
+        expect(h.saveAgencyWide.mock.calls[0][0]).toEqual({ content: { privacy: { de: '<p>final</p>' } } });
+    });
+
+    it('clears the parked draft once the text is published', async () => {
+        renderContainer();
+        await waitFor(() => expect(screen.getByTestId('legal-editor')).toBeInTheDocument());
+
+        cardProps().onSave({ de: '<p>draft</p>' }, false);
+        await waitFor(() => expect(draftKeys()).toHaveLength(1));
+
+        cardProps().onSave({ de: '<p>final</p>' }, true);
+
+        await waitFor(() => expect(draftKeys()).toHaveLength(0));
+    });
+
+    it('seeds the editor from a parked draft on the next mount', async () => {
+        renderContainer();
+        await waitFor(() => expect(screen.getByTestId('legal-editor')).toBeInTheDocument());
+        cardProps().onSave({ de: '<p>parked wording</p>' }, false);
+        await waitFor(() => expect(draftKeys()).toHaveLength(1));
+
+        h.card.mockClear();
+        renderContainer();
+        await waitFor(() => expect(h.card).toHaveBeenCalled());
+
+        expect(cardProps().initialContentByLanguage).toMatchObject({ de: '<p>parked wording</p>' });
+    });
+});

--- a/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.test.tsx
@@ -31,6 +31,12 @@ vi.mock('../../../../../hooks/useUserPermission', () => ({
     useUserPermissions: () => ({ can: h.canEditLegalText, permissions: {} }),
 }));
 // The department-scoped history has its own suite (AgencyLegalTextContainer.versions.test.tsx).
+vi.mock('../../../../../hooks/useUserData.hook', () => ({
+    // The container reads the opaque user id to scope its device-local draft; without
+    // this mock the real react-query hook runs and the render dies on "No QueryClient".
+    useUserData: () => ({ data: { id: 'user-7' }, isLoading: false }),
+    USER_DATA_KEY: 'user-data',
+}));
 vi.mock('../../../../../hooks/useLegalTextVersions.hook', () => ({
     useLegalTextVersions: () => ({ data: [], isError: false }),
 }));

--- a/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.versions.test.tsx
+++ b/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/AgencyLegalTextContainer.versions.test.tsx
@@ -31,6 +31,12 @@ vi.mock('../../../../../hooks/useTranslateLegalContent.hook', () => ({
 vi.mock('../../../../../hooks/useUserPermission', () => ({
     useUserPermissions: () => ({ can: () => true, permissions: {} }),
 }));
+vi.mock('../../../../../hooks/useUserData.hook', () => ({
+    // The container reads the opaque user id to scope its device-local draft; without
+    // this mock the real react-query hook runs and the render dies on "No QueryClient".
+    useUserData: () => ({ data: { id: 'user-7' }, isLoading: false }),
+    USER_DATA_KEY: 'user-data',
+}));
 vi.mock('../../../../../hooks/useLegalTextVersions.hook', () => ({
     useLegalTextVersions: h.useLegalTextVersions,
 }));

--- a/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/index.tsx
+++ b/src/components/Tenants/LegalSettings/components/AgencyLegalTextContainer/index.tsx
@@ -10,6 +10,8 @@ import { useTenantAdminData } from '../../../../../hooks/useTenantAdminData.hook
 import { useLegalTextVersions } from '../../../../../hooks/useLegalTextVersions.hook';
 import { useTranslateLegalContent } from '../../../../../hooks/useTranslateLegalContent.hook';
 import { useUserPermissions } from '../../../../../hooks/useUserPermission';
+import { useUserData } from '../../../../../hooks/useUserData.hook';
+import { useLegalDraft } from '../../hooks/useLegalDraft';
 import { PermissionAction } from '../../../../../enums/PermissionAction';
 import { Resource } from '../../../../../enums/Resource';
 import { AgencyData } from '../../../../../types/agency';
@@ -131,6 +133,24 @@ export const AgencyLegalTextContainer = ({
         [tenantData, agencyData, agencyContentKey],
     );
 
+    const { data: userData } = useUserData();
+    /*
+     * The agency record has no draft state, exactly like the Träger record one level up —
+     * so the parked wording lives on the device (`LegalText` + `useLegalDraft` set this
+     * precedent, and its LegalDraftNotice is what tells the admin the draft is local).
+     *
+     * The agency id has to be in the scope. Both levels store the same `privacy` document
+     * for the same user, so without it a Beratungsstelle's parked wording and the Träger's
+     * would share one key and silently overwrite each other.
+     */
+    const agencyDraftScope =
+        userData?.id && agencyData?.id ? `${agencyData.tenantId}:${userData.id}:agency:${agencyData.id}` : undefined;
+    const {
+        draft: agencyDraft,
+        saveDraft: saveAgencyDraft,
+        discardDraft: discardAgencyDraft,
+    } = useLegalDraft(field, agencyDraftScope);
+
     const departmentContent = useMemo(
         () => parseLegalContentMap(departmentQuery.data?.content),
         [departmentQuery.data?.content],
@@ -187,7 +207,10 @@ export const AgencyLegalTextContainer = ({
     // That is the same silent-overwrite class this whole epic exists to remove, so a failed read
     // blocks the editor instead (see the isError branch below).
     const hasOwnText = isDepartment && departmentQuery.isSuccess && Object.keys(departmentContent).length > 0;
-    const contentByLanguage = hasOwnText ? departmentContent : agencyWideContent;
+    // A parked draft is the admin's unfinished wording; it wins over the stored agency text
+    // until it is published or discarded. Departments keep their own seeding rules above.
+    const agencyWideSeed = agencyDraft?.content ?? agencyWideContent;
+    const contentByLanguage = hasOwnText ? departmentContent : agencyWideSeed;
 
     const languages = useMemo(
         () => getEditableLanguages(tenantAdminData?.settings?.activeLanguages, contentByLanguage),
@@ -206,13 +229,22 @@ export const AgencyLegalTextContainer = ({
             }
             return;
         }
-        // The agency-wide text has no draft state of its own — it is stored on the agency record.
+        // `publish === false` is the editor's "Save draft" action. Writing the agency record
+        // here would publish the live legal text under a label promising the opposite — so the
+        // draft goes to device-local storage and the record is left alone.
+        if (!publish) {
+            saveAgencyDraft(content, consent);
+            return;
+        }
         // NOTE: unlike the department publishes above, this path cannot invalidate the agency
         // version history — it goes through the shared agency-card mutation, which has no legal
         // hook. The look-back catches up on its own `staleTime` (60s).
         onSaveAgencyWide({
             content: { [agencyContentKey]: content, ...(consent ? { privacyConsent: consent } : {}) },
         });
+        // The parked wording has become the published text; keeping it would re-seed the editor
+        // with a stale copy on the next mount.
+        discardAgencyDraft();
     };
 
     const selectedDepartment = departments.find(({ id }) => id === topicId);


### PR DESCRIPTION
## Problem

**This is the most serious of the batch.** On the **"Alle Fachbereiche"** selection, the editor's **"Entwurf speichern"** ("Save draft") button **published the live legal text**.

No confirmation, no version note, and the exact opposite of what the label promises. On a legal-text surface that is the worst kind of bug: **it succeeds quietly.**

## Root cause

The draft action reached `onSaveAgencyWide`, which writes the agency record — and the **`publish` argument was dropped on the floor**. So "save a draft" and "publish this to the world" took the same path.

## Fix

Give the agency-wide text the **same device-local draft the Träger level already has**. That is the house answer to this exact situation: the tenant record has no backend draft state either, which is why `useLegalDraft` exists — and its own comment says so.

- `publish === false` now parks the wording in local storage and **leaves the record alone**.
- `publish === true` writes the record **and discards the parked copy**, so a stale draft cannot re-seed the editor afterwards.
- A parked draft **wins over the stored text** when seeding.

### Why not the alternatives (carried over from the commit)

Both alternatives were worse. **Hiding the action** removes a real capability and makes this level the odd one out. **Confirming before the write** keeps a mislabelled button and merely apologises for it.

### The collision this avoids

The draft scope carries the agency id — `<tenantId>:<userId>:agency:<agencyId>`. Both levels store a `privacy` document for the same user, so **without the agency id a Beratungsstelle's parked wording and the Träger's would share one key and silently overwrite each other**.

## Tests

- **4 files / 31 passing.**
- **Reverting only the production file fails 5 of the 6 new assertions** — the tests genuinely pin the fix.
- Consumers (`DepartmentDataProtectionCard`, `LegalText`): **5 files / 62 passing**.
- The three existing container suites gained a `useUserData` mock: the container now reads the opaque user id, and those suites mock every other hook, so without it the real react-query hook runs and the render dies on *"No QueryClient set"*.

### Note for future test authors (from the commit — worth keeping)

**jsdom's `Storage` does not enumerate through `Object.keys`** — it returns `[]` while `length` is `1`. The draft helper reads it through the Storage API instead, or it would report "nothing was saved" for a draft that saved perfectly well.

## Reviewer test plan

- [ ] Select **"Alle Fachbereiche"**, edit the legal text, click **"Entwurf speichern"**. Confirm the **live** text is unchanged — check the public-facing text, not just the editor.
- [ ] Reload the page. The parked draft **re-seeds the editor** and wins over the stored text.
- [ ] Now click **publish**. The record is written **and** the parked draft is discarded — reload again and confirm a stale draft does not come back.
- [ ] As the **same user**, park a draft at **Träger** level and a different one on a **Beratungsstelle**, both for `privacy`. Confirm they do **not** overwrite each other (this is what the agency id in the scope is for).
- [ ] Park drafts on **two different agencies** as the same user; confirm they stay separate.
- [ ] Confirm the Träger level behaves exactly as before — this reuses `useLegalDraft`, it should not have changed.
- [ ] **Mobile 390x844**: the draft/publish actions are both reachable and still distinctly labelled.
